### PR TITLE
Rewrite introduction-preflight copy for the 18-status API

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/connections/ConnectionIntroductionProvider.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/connections/ConnectionIntroductionProvider.kt
@@ -119,8 +119,12 @@ class ConnectionIntroductionProvider(
         body.recipients.forEach { entry ->
             Logger.i(tag = TAG) {
                 "preflightIntroductions: ${entry.recipient.domainName} → status=${entry.status} " +
+                    "remedy=${entry.effectiveRemedyActor} canRetry=${entry.canRetry} " +
                     "isConfigured=${entry.isConfigured} requiresUpgrade=${entry.requiresUpgrade} " +
-                    "allowsIntroductions=${entry.allowsIntroductions} detail=${entry.detail}"
+                    "allowsIntroductions=${entry.allowsIntroductions} " +
+                    "callerConnected=${entry.isCallerConnected} callerConfirmed=${entry.isCallerConfirmed} " +
+                    "callerAutoConnected=${entry.isCallerAutoConnected} " +
+                    "callerConnectionState=${entry.callerConnectionState} detail=${entry.detail}"
             }
         }
         Logger.i(tag = TAG) {

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/connections/IntroductionPreflightResult.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/connections/IntroductionPreflightResult.kt
@@ -7,24 +7,59 @@ import kotlinx.serialization.Serializable
  * Per-recipient outcome of an introduction-preflight call.
  *
  * Sender's own identity is filtered out server-side, so the response may contain
- * fewer entries than the original request.
+ * fewer entries than the original request — always match rows back to your input
+ * by [recipient], never by array position or count.
  */
 @Serializable
 data class RecipientPreflightStatus(
     val recipient: OdinId,
     val status: IntroductionPreflightStatus,
-    /** Free-form server detail. Typically populated only when [status] is
-     *  [IntroductionPreflightStatus.UnknownError]; UI may surface this when
-     *  a generic per-status string is too vague. */
+    /** Free-form server detail: exception text, transport specifics, internal
+     *  identifiers. **Diagnostics only — never render this.** It exists for logs
+     *  and support threads. User-facing wording comes from the per-status
+     *  `chat_introduce_preflight_reason_*` strings. */
     val detail: String? = null,
     /** Convenience flag: false when [status] is [IntroductionPreflightStatus.RecipientNotConfigured]. */
     val isConfigured: Boolean = true,
     /** Convenience flag: true when [status] is [IntroductionPreflightStatus.RecipientRequiresUpgrade]. */
     val requiresUpgrade: Boolean = false,
-    /** Convenience flag: false when [status] is
-     *  [IntroductionPreflightStatus.IntroductionsNotPermitted]. */
+    /** Convenience flag. **Do not build copy from this** — it is false for
+     *  [IntroductionPreflightStatus.IntroductionsNotPermitted],
+     *  [IntroductionPreflightStatus.RecipientConnectionNotConfirmed],
+     *  [IntroductionPreflightStatus.RecipientDoesNotRecognizeConnection] and
+     *  [IntroductionPreflightStatus.RecipientConnectionNeedsRepair] alike, which
+     *  is exactly the conflation that produced the wrong "doesn't allow
+     *  introductions" message. Switch on [status]. */
     val allowsIntroductions: Boolean = true,
-)
+    /** Diagnostic detail behind statuses 5 vs 8: does the recipient hold a
+     *  connection record for us at all. Null when the server didn't say. */
+    val isCallerConnected: Boolean? = null,
+    /** Diagnostic detail behind statuses 5 vs 8: has the recipient confirmed
+     *  that connection. Null when the server didn't say. */
+    val isCallerConfirmed: Boolean? = null,
+    /** Diagnostic detail: was the connection established by auto-connect rather
+     *  than an explicit accept. Null when the server didn't say. */
+    val isCallerAutoConnected: Boolean? = null,
+    /** Diagnostic detail: the recipient's view of our connection record. */
+    val callerConnectionState: CallerConnectionState? = null,
+    /** Server's view of who can resolve this. Null on servers that predate the
+     *  field — read [effectiveRemedyActor] instead of this. */
+    val remedyActor: PreflightRemedyActor? = null,
+    /** Server's view of whether a retry is worthwhile. Null on servers that
+     *  predate the field — read [canRetry] instead of this. */
+    val isTransient: Boolean? = null,
+) {
+    /** Who can act, falling back to the client-side table when the server
+     *  omitted [remedyActor]. Drive fix-it affordances off this, not [status]. */
+    val effectiveRemedyActor: PreflightRemedyActor
+        get() = remedyActor ?: status.defaultRemedyActor
+
+    /** Whether re-running preflight unchanged could plausibly succeed, falling
+     *  back to the client-side table when the server omitted [isTransient].
+     *  Drive the retry affordance off this, not [status]. */
+    val canRetry: Boolean
+        get() = isTransient ?: status.defaultIsTransient
+}
 
 /**
  * Aggregate response from `POST /connections/introductions/preflight`.
@@ -48,4 +83,9 @@ data class IntroductionPreflightResult(
         get() = recipients
             .filter { it.status == IntroductionPreflightStatus.Ready }
             .map { it.recipient }
+
+    /** True when at least one blocked recipient might come back on a plain
+     *  retry — gates the dialog's "Check again" affordance. */
+    val hasRetryableRecipient: Boolean
+        get() = nonReady.any { it.canRetry }
 }

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/connections/IntroductionPreflightStatus.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/connections/IntroductionPreflightStatus.kt
@@ -13,10 +13,15 @@ import kotlinx.serialization.json.intOrNull
 
 /**
  * Status of an introduction-preflight check for a single recipient. The server
- * uses sparse integer values (1..7, 99) AND emits the lowercase enum name —
+ * uses sparse integer values (1..17, 99) AND emits the lowercase enum name —
  * production responses currently look like `"status": "ready"`. The serializer
  * accepts either form (int OR string-by-name, case-insensitive) and falls back
  * to [UnknownError] so client code never has to handle nulls or schema drift.
+ *
+ * Only [IntroductionsNotPermitted] represents a *decision* by the recipient.
+ * Every other non-Ready value is a setup gap, a broken connection record, or a
+ * transport failure — the UI copy must not present them as a refusal. See
+ * `chat_introduce_preflight_reason_*` in strings.xml.
  */
 @Serializable(with = IntroductionPreflightStatusSerializer::class)
 enum class IntroductionPreflightStatus(val value: Int) {
@@ -27,25 +32,112 @@ enum class IntroductionPreflightStatus(val value: Int) {
      *  invalid; we never even tried the peer call. */
     NotConnected(2),
 
-    /** Recipient's identity server hasn't completed initial setup. */
+    /** Recipient's identity server hasn't completed initial setup — they
+     *  registered but never logged in to finish provisioning. */
     RecipientNotConfigured(3),
 
     /** Recipient's identity server needs a version upgrade before it will
-     *  accept introductions. */
+     *  accept introductions, and is not currently running. */
     RecipientRequiresUpgrade(4),
 
-    /** Recipient hasn't granted us the AllowIntroductions permission (revoked
-     *  the system circle that carries it). */
+    /** Recipient is connected, has confirmed us, and has deliberately not
+     *  granted the AllowIntroductions permission. THE ONLY status that reflects
+     *  a decision by the recipient — the only one that may render as
+     *  "<name> doesn't allow introductions from you". */
     IntroductionsNotPermitted(5),
 
     /** Peer call returned 403. */
     RecipientRejected(6),
 
-    /** DNS / socket / timeout / non-success status from the recipient. */
+    /** Transport failure that could not be classified any further. */
     Unreachable(7),
 
-    /** Unexpected error; [RecipientPreflightStatus.detail] is populated. */
+    /** Recipient has a connection to us that they have never confirmed.
+     *  Nothing is broken and nothing was denied — confirming is a step they
+     *  take in their owner console. Historically the biggest contributor to the
+     *  bogus "does not allow introductions" message. */
+    RecipientConnectionNotConfirmed(8),
+
+    /** Recipient has no usable connection record for us; the connection is
+     *  one-sided. Also covers the blocked case — deliberately indistinguishable
+     *  from a stale record, since disclosing a block would leak it to its
+     *  target. Remedy is to reconnect. */
+    RecipientDoesNotRecognizeConnection(9),
+
+    /** Recipient has a connection record for us but it is damaged and unusable.
+     *  Repairable by reconnecting. */
+    RecipientConnectionNeedsRepair(10),
+
+    /** OUR OWN connection record is present but unusable. The fault is on our
+     *  side; copy must not blame the recipient. */
+    SenderConnectionInvalid(11),
+
+    /** Recipient runs a server too old to answer preflight, so nothing can be
+     *  determined. "Send anyway" is the meaningful offer. */
+    PreflightNotSupported(12),
+
+    /** Recipient's server is mid-upgrade. Retry shortly. */
+    RecipientUpgradeInProgress(13),
+
+    /** Recipient's domain could not be resolved. Probably permanent. */
+    RecipientUnresolvable(14),
+
+    /** TLS/certificate failure — the recipient's server is misconfigured. */
+    RecipientCertificateInvalid(15),
+
+    /** Recipient did not respond in time. */
+    RecipientTimedOut(16),
+
+    /** Recipient's host refused the socket; their server is down. */
+    RecipientConnectionRefused(17),
+
+    /** Unexpected error; [RecipientPreflightStatus.detail] is populated (logs only). */
     UnknownError(99);
+
+    /**
+     * Who can actually do something about this status, used when the server
+     * omits `remedyActor` (older server, or a value we don't recognize). The
+     * UI switches its *affordances* on this — never on the status itself.
+     */
+    val defaultRemedyActor: PreflightRemedyActor
+        get() = when (this) {
+            NotConnected,
+            RecipientDoesNotRecognizeConnection,
+            RecipientConnectionNeedsRepair,
+            SenderConnectionInvalid -> PreflightRemedyActor.Caller
+
+            RecipientNotConfigured,
+            RecipientRequiresUpgrade,
+            IntroductionsNotPermitted,
+            RecipientRejected,
+            RecipientConnectionNotConfirmed,
+            RecipientUnresolvable,
+            RecipientCertificateInvalid -> PreflightRemedyActor.Recipient
+
+            Ready,
+            Unreachable,
+            PreflightNotSupported,
+            RecipientUpgradeInProgress,
+            RecipientTimedOut,
+            RecipientConnectionRefused,
+            UnknownError -> PreflightRemedyActor.None
+        }
+
+    /**
+     * Whether re-running preflight unchanged is worth doing, used when the
+     * server omits `isTransient`. Only genuine "the network/server was busy"
+     * failures qualify — a missing permission or an unconfirmed connection
+     * needs a human to act first, so offering retry there is a lie.
+     */
+    val defaultIsTransient: Boolean
+        get() = when (this) {
+            Unreachable,
+            RecipientUpgradeInProgress,
+            RecipientTimedOut,
+            RecipientConnectionRefused -> true
+
+            else -> false
+        }
 
     companion object {
         fun fromValue(value: Int): IntroductionPreflightStatus =

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/connections/PreflightDiagnostics.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/connections/PreflightDiagnostics.kt
@@ -1,0 +1,102 @@
+package id.homebase.api.client.connections
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.descriptors.buildClassSerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.JsonDecoder
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.intOrNull
+
+/**
+ * Who can resolve a non-Ready [IntroductionPreflightStatus].
+ *
+ * The UI picks its *affordances* from this (and from
+ * [RecipientPreflightStatus.canRetry]) rather than from the status value, so a
+ * new server-side status lands with sane buttons even before we have bespoke
+ * copy for it.
+ */
+@Serializable(with = PreflightRemedyActorSerializer::class)
+enum class PreflightRemedyActor(val value: Int) {
+    /** Nobody can act — it either resolves itself or it doesn't. */
+    None(0),
+
+    /** We can act: connect, reconnect, or repair our own connection record. */
+    Caller(1),
+
+    /** Only the recipient can act. The copy tells the user what to ask for. */
+    Recipient(2);
+
+    companion object {
+        fun fromValue(value: Int): PreflightRemedyActor =
+            entries.firstOrNull { it.value == value } ?: None
+
+        fun fromName(name: String): PreflightRemedyActor =
+            entries.firstOrNull { it.name.equals(name, ignoreCase = true) } ?: None
+    }
+}
+
+/**
+ * State of the *caller's* connection as the recipient's server sees it. Pure
+ * diagnostics — it disambiguates statuses 5 / 8 / 9 / 10 in logs and support
+ * threads. Never drive user-facing copy off this; use the status.
+ */
+@Serializable(with = CallerConnectionStateSerializer::class)
+enum class CallerConnectionState(val value: Int) {
+    Unknown(0),
+    Connected(1),
+    NotRecognized(2),
+    NeedsRepair(3);
+
+    companion object {
+        fun fromValue(value: Int): CallerConnectionState =
+            entries.firstOrNull { it.value == value } ?: Unknown
+
+        fun fromName(name: String): CallerConnectionState =
+            entries.firstOrNull { it.name.equals(name, ignoreCase = true) } ?: Unknown
+    }
+}
+
+/**
+ * Shared int-or-name tolerant decoding, mirroring
+ * [IntroductionPreflightStatusSerializer]: the server may emit either the
+ * integer or the (case-insensitive) enum name, and we never want a schema
+ * change to fail the whole preflight response.
+ */
+internal abstract class IntOrNameSerializer<T : Enum<T>>(
+    serialName: String,
+    private val fallback: T,
+    private val valueOf: (T) -> Int,
+    private val fromValue: (Int) -> T,
+    private val fromName: (String) -> T,
+) : KSerializer<T> {
+    override val descriptor: SerialDescriptor = buildClassSerialDescriptor(serialName)
+
+    override fun serialize(encoder: Encoder, value: T) = encoder.encodeInt(valueOf(value))
+
+    override fun deserialize(decoder: Decoder): T {
+        val jsonDecoder = decoder as? JsonDecoder
+            ?: error("$descriptor requires a JSON decoder")
+        val primitive = jsonDecoder.decodeJsonElement() as? JsonPrimitive ?: return fallback
+        primitive.intOrNull?.let { return fromValue(it) }
+        return fromName(primitive.content)
+    }
+}
+
+internal object PreflightRemedyActorSerializer : IntOrNameSerializer<PreflightRemedyActor>(
+    serialName = "PreflightRemedyActor",
+    fallback = PreflightRemedyActor.None,
+    valueOf = { it.value },
+    fromValue = PreflightRemedyActor::fromValue,
+    fromName = PreflightRemedyActor::fromName,
+)
+
+internal object CallerConnectionStateSerializer : IntOrNameSerializer<CallerConnectionState>(
+    serialName = "CallerConnectionState",
+    fallback = CallerConnectionState.Unknown,
+    valueOf = { it.value },
+    fromValue = CallerConnectionState::fromValue,
+    fromName = CallerConnectionState::fromName,
+)

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationLifecycleHandler.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationLifecycleHandler.kt
@@ -220,6 +220,37 @@ internal class ConversationLifecycleHandler(
         }
     }
 
+    /**
+     * Re-run preflight from the dialog's "Check again" affordance and swap in
+     * the fresh result. Three outcomes:
+     *  - preflight itself failed (null): leave the dialog exactly as it was, so
+     *    a network blip doesn't erase what the user was reading.
+     *  - everything is Ready now: send, same as if the first check had passed.
+     *  - still mixed: replace the dialog's result so the list re-renders with
+     *    the new per-recipient reasons.
+     */
+    fun handleIntroduceRetryPreflight(action: ConversationListUiAction.IntroduceRetryPreflight) {
+        scope.launch {
+            uiState.update {
+                it.copy(inFlightOperationLabel = MR.string.chat_introduce_preflight_in_progress)
+            }
+            val preflight = conversationService.previewIntroduceEveryone(action.conversationId)
+            uiState.update { it.copy(inFlightOperationLabel = null) }
+            if (preflight == null) return@launch
+            if (preflight.allReady) {
+                uiState.update { it.copy(uiDialog = null) }
+                conversationService.introduceEveryone(action.conversationId, action.message)
+                sendEvent(ShowInfoMessage(MR.string.chat_group_introduce_everyone_status))
+                return@launch
+            }
+            uiState.update { state ->
+                val dialog = state.uiDialog as? ConversationListUiDialog.IntroducePreflight
+                    ?: return@update state
+                state.copy(uiDialog = dialog.copy(result = preflight))
+            }
+        }
+    }
+
     fun handleIntroduceCancel() {
         uiState.update { it.copy(uiDialog = null) }
     }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListScreen.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.VerticalDragHandle
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.input.pointer.pointerInput
@@ -85,14 +86,25 @@ import id.homebase.resources.chat_message_discard_draft
 import id.homebase.resources.chat_conversation_deleting_in_progress
 import id.homebase.resources.chat_introduce_preflight_body
 import id.homebase.resources.chat_introduce_preflight_bullet
+import id.homebase.resources.chat_introduce_preflight_check_again
+import id.homebase.resources.chat_introduce_preflight_reason_certificate_invalid
+import id.homebase.resources.chat_introduce_preflight_reason_connection_refused
+import id.homebase.resources.chat_introduce_preflight_reason_needs_repair
 import id.homebase.resources.chat_introduce_preflight_reason_not_configured
+import id.homebase.resources.chat_introduce_preflight_reason_not_confirmed
 import id.homebase.resources.chat_introduce_preflight_reason_not_connected
 import id.homebase.resources.chat_introduce_preflight_reason_not_permitted
+import id.homebase.resources.chat_introduce_preflight_reason_not_recognized
+import id.homebase.resources.chat_introduce_preflight_reason_not_supported
 import id.homebase.resources.chat_introduce_preflight_reason_ready
 import id.homebase.resources.chat_introduce_preflight_reason_rejected
 import id.homebase.resources.chat_introduce_preflight_reason_requires_upgrade
+import id.homebase.resources.chat_introduce_preflight_reason_sender_connection_invalid
+import id.homebase.resources.chat_introduce_preflight_reason_timed_out
 import id.homebase.resources.chat_introduce_preflight_reason_unknown
 import id.homebase.resources.chat_introduce_preflight_reason_unreachable
+import id.homebase.resources.chat_introduce_preflight_reason_unresolvable
+import id.homebase.resources.chat_introduce_preflight_reason_upgrade_in_progress
 import id.homebase.resources.chat_introduce_preflight_send_anyway
 import id.homebase.resources.chat_introduce_preflight_skip_and_send
 import id.homebase.resources.chat_introduce_preflight_title
@@ -489,6 +501,14 @@ fun ConversationListScreen(
                         )
                     )
                 },
+                onCheckAgain = {
+                    viewModel.onAction(
+                        ConversationListUiAction.IntroduceRetryPreflight(
+                            conversationId = dialog.conversationId,
+                            message = dialog.message,
+                        )
+                    )
+                },
                 onCancel = {
                     viewModel.onAction(ConversationListUiAction.IntroduceCancel)
                 },
@@ -567,6 +587,9 @@ private fun InFlightOperationOverlay(label: org.jetbrains.compose.resources.Stri
  * "Send anyway" still passes the FULL original recipient list to the server —
  * preflight is advisory; the server's outbox retries the actual failures in the
  * background.
+ *
+ * A fourth, conditional affordance ("Check again") appears inline under the list
+ * when any entry is retryable; it re-runs preflight rather than sending.
  */
 @Composable
 private fun IntroducePreflightDialog(
@@ -574,6 +597,7 @@ private fun IntroducePreflightDialog(
     nameFor: (id.homebase.api.common.OdinId) -> String,
     onSendAnyway: () -> Unit,
     onSendReadyOnly: () -> Unit,
+    onCheckAgain: () -> Unit,
     onCancel: () -> Unit,
 ) {
     val nonReady = dialog.result.nonReady
@@ -608,17 +632,10 @@ private fun IntroducePreflightDialog(
             Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
                 nonReady.forEach { entry ->
                     val name = nameFor(entry.recipient)
+                    // `entry.detail` is deliberately NOT rendered — it carries raw
+                    // server/exception text and is for logs and support only
+                    // (ConnectionIntroductionProvider already logs the full row).
                     val reason = stringResource(entry.status.reasonResource(), name)
-                    val text = if (entry.status ==
-                        id.homebase.api.client.connections.IntroductionPreflightStatus.UnknownError
-                        && !entry.detail.isNullOrBlank()
-                    ) {
-                        // Splice in server detail as a fallback when the per-status
-                        // string is too generic. Format: "<base> <detail>".
-                        "$reason ${entry.detail}"
-                    } else {
-                        reason
-                    }
                     // Build the bullet-prefixed line via stringResource so the
                     // bullet character itself is localized (and so the line we
                     // pass to Text below is an identifier, not a literal — the
@@ -626,7 +643,7 @@ private fun IntroducePreflightDialog(
                     // literals at the Text call site).
                     val bulletLine = stringResource(
                         MR.string.chat_introduce_preflight_bullet,
-                        text,
+                        reason,
                     )
                     Text(
                         text = bulletLine,
@@ -635,13 +652,37 @@ private fun IntroducePreflightDialog(
                         modifier = Modifier.padding(vertical = 4.dp),
                     )
                 }
+                // Retry is offered on the aggregate `canRetry` (server's IsTransient,
+                // falling back to the per-status default) — never on specific status
+                // values, so a status we don't know yet still gets the right
+                // affordance. Statuses that need a human to act first (permission not
+                // granted, connection unconfirmed, connection broken) are not
+                // retryable and deliberately show no button: the copy is the remedy.
+                if (dialog.result.hasRetryableRecipient) {
+                    TextButton(
+                        onClick = onCheckAgain,
+                        modifier = Modifier.align(Alignment.End),
+                    ) {
+                        Text(text = stringResource(MR.string.chat_introduce_preflight_check_again))
+                    }
+                }
             }
         }
     }
 }
 
 /** Maps a preflight status to its localized per-recipient reason string. The
- *  caller passes the recipient's display name as the format arg `%1$s`. */
+ *  caller passes the recipient's display name as the format arg `%1$s`.
+ *
+ *  Wording only — the dialog's *affordances* come from
+ *  [id.homebase.api.client.connections.RecipientPreflightStatus.canRetry] and
+ *  `effectiveRemedyActor`, so an unrecognized future status still behaves
+ *  sensibly. Shared with the group-settings inline label
+ *  (`introductionPreflightInlineLabel`) so both surfaces always say the same
+ *  thing about the same status.
+ *
+ *  ONLY [IntroductionsNotPermitted] may render as "doesn't allow introductions
+ *  from you" — it is the sole status that reflects a decision by the recipient. */
 private fun id.homebase.api.client.connections.IntroductionPreflightStatus.reasonResource():
     org.jetbrains.compose.resources.StringResource = when (this) {
     id.homebase.api.client.connections.IntroductionPreflightStatus.Ready ->
@@ -659,6 +700,30 @@ private fun id.homebase.api.client.connections.IntroductionPreflightStatus.reaso
         MR.string.chat_introduce_preflight_reason_rejected
     id.homebase.api.client.connections.IntroductionPreflightStatus.Unreachable ->
         MR.string.chat_introduce_preflight_reason_unreachable
+    id.homebase.api.client.connections.IntroductionPreflightStatus.RecipientConnectionNotConfirmed ->
+        // A pending step, not a refusal and not an error — see the string.
+        MR.string.chat_introduce_preflight_reason_not_confirmed
+    id.homebase.api.client.connections.IntroductionPreflightStatus.RecipientDoesNotRecognizeConnection ->
+        // Also the blocked case; worded identically to the other broken-connection
+        // states so a block stays indistinguishable from a stale record.
+        MR.string.chat_introduce_preflight_reason_not_recognized
+    id.homebase.api.client.connections.IntroductionPreflightStatus.RecipientConnectionNeedsRepair ->
+        MR.string.chat_introduce_preflight_reason_needs_repair
+    id.homebase.api.client.connections.IntroductionPreflightStatus.SenderConnectionInvalid ->
+        // Our fault, not theirs — the string says "your saved connection details".
+        MR.string.chat_introduce_preflight_reason_sender_connection_invalid
+    id.homebase.api.client.connections.IntroductionPreflightStatus.PreflightNotSupported ->
+        MR.string.chat_introduce_preflight_reason_not_supported
+    id.homebase.api.client.connections.IntroductionPreflightStatus.RecipientUpgradeInProgress ->
+        MR.string.chat_introduce_preflight_reason_upgrade_in_progress
+    id.homebase.api.client.connections.IntroductionPreflightStatus.RecipientUnresolvable ->
+        MR.string.chat_introduce_preflight_reason_unresolvable
+    id.homebase.api.client.connections.IntroductionPreflightStatus.RecipientCertificateInvalid ->
+        MR.string.chat_introduce_preflight_reason_certificate_invalid
+    id.homebase.api.client.connections.IntroductionPreflightStatus.RecipientTimedOut ->
+        MR.string.chat_introduce_preflight_reason_timed_out
+    id.homebase.api.client.connections.IntroductionPreflightStatus.RecipientConnectionRefused ->
+        MR.string.chat_introduce_preflight_reason_connection_refused
     id.homebase.api.client.connections.IntroductionPreflightStatus.UnknownError ->
         MR.string.chat_introduce_preflight_reason_unknown
 }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiAction.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiAction.kt
@@ -50,6 +50,23 @@ sealed interface ConversationListUiAction {
         val message: String,
     ) : ConversationListUiAction
 
+    /**
+     * "Check again" in the preflight dialog — re-runs the preflight call and
+     * replaces the dialog's result with the fresh one. Offered only when the
+     * result contains at least one retryable entry
+     * ([id.homebase.api.client.connections.IntroductionPreflightResult.hasRetryableRecipient]),
+     * i.e. a failure the recipient's server may recover from on its own; a
+     * missing permission or an unconfirmed connection needs a human first and
+     * gets no retry button.
+     *
+     * If the retry comes back all-Ready the introduction is sent, matching what
+     * would have happened had the first preflight succeeded.
+     */
+    data class IntroduceRetryPreflight(
+        val conversationId: Uuid,
+        val message: String,
+    ) : ConversationListUiAction
+
     /** Dismiss the preflight dialog without sending. Equivalent to closing the dialog. */
     data object IntroduceCancel : ConversationListUiAction
     data object FilterByUnreadClicked : ConversationListUiAction

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
@@ -1325,6 +1325,8 @@ class ConversationListViewModel(
 
             is ConversationListUiAction.IntroduceSendReadyOnly -> conversationLifecycleHandler.handleIntroduceSendReadyOnly(action)
 
+            is ConversationListUiAction.IntroduceRetryPreflight -> conversationLifecycleHandler.handleIntroduceRetryPreflight(action)
+
             is ConversationListUiAction.IntroduceCancel -> conversationLifecycleHandler.handleIntroduceCancel()
 
             is ConversationListUiAction.ArchiveConversation -> conversationLifecycleHandler.handleArchiveConversation(action)

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/groupsettings/GroupSettingsScreen.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/groupsettings/GroupSettingsScreen.kt
@@ -120,13 +120,23 @@ import id.homebase.resources.chat_group_choose_new_admin
 import id.homebase.api.client.connections.IntroductionPreflightStatus
 import id.homebase.resources.chat_group_heal
 import id.homebase.resources.chat_group_heal_admin_resent
+import id.homebase.resources.chat_introduce_preflight_reason_certificate_invalid
+import id.homebase.resources.chat_introduce_preflight_reason_connection_refused
+import id.homebase.resources.chat_introduce_preflight_reason_needs_repair
 import id.homebase.resources.chat_introduce_preflight_reason_not_configured
+import id.homebase.resources.chat_introduce_preflight_reason_not_confirmed
 import id.homebase.resources.chat_introduce_preflight_reason_not_connected
 import id.homebase.resources.chat_introduce_preflight_reason_not_permitted
+import id.homebase.resources.chat_introduce_preflight_reason_not_recognized
+import id.homebase.resources.chat_introduce_preflight_reason_not_supported
 import id.homebase.resources.chat_introduce_preflight_reason_rejected
 import id.homebase.resources.chat_introduce_preflight_reason_requires_upgrade
+import id.homebase.resources.chat_introduce_preflight_reason_sender_connection_invalid
+import id.homebase.resources.chat_introduce_preflight_reason_timed_out
 import id.homebase.resources.chat_introduce_preflight_reason_unknown
 import id.homebase.resources.chat_introduce_preflight_reason_unreachable
+import id.homebase.resources.chat_introduce_preflight_reason_unresolvable
+import id.homebase.resources.chat_introduce_preflight_reason_upgrade_in_progress
 import id.homebase.resources.chat_group_heal_already_in_sync
 import id.homebase.resources.chat_group_heal_checking_peers
 import id.homebase.resources.chat_group_heal_main_resent
@@ -1465,6 +1475,16 @@ internal fun introductionPreflightInlineLabel(
         IntroductionPreflightStatus.IntroductionsNotPermitted -> MR.string.chat_introduce_preflight_reason_not_permitted
         IntroductionPreflightStatus.RecipientRejected -> MR.string.chat_introduce_preflight_reason_rejected
         IntroductionPreflightStatus.Unreachable -> MR.string.chat_introduce_preflight_reason_unreachable
+        IntroductionPreflightStatus.RecipientConnectionNotConfirmed -> MR.string.chat_introduce_preflight_reason_not_confirmed
+        IntroductionPreflightStatus.RecipientDoesNotRecognizeConnection -> MR.string.chat_introduce_preflight_reason_not_recognized
+        IntroductionPreflightStatus.RecipientConnectionNeedsRepair -> MR.string.chat_introduce_preflight_reason_needs_repair
+        IntroductionPreflightStatus.SenderConnectionInvalid -> MR.string.chat_introduce_preflight_reason_sender_connection_invalid
+        IntroductionPreflightStatus.PreflightNotSupported -> MR.string.chat_introduce_preflight_reason_not_supported
+        IntroductionPreflightStatus.RecipientUpgradeInProgress -> MR.string.chat_introduce_preflight_reason_upgrade_in_progress
+        IntroductionPreflightStatus.RecipientUnresolvable -> MR.string.chat_introduce_preflight_reason_unresolvable
+        IntroductionPreflightStatus.RecipientCertificateInvalid -> MR.string.chat_introduce_preflight_reason_certificate_invalid
+        IntroductionPreflightStatus.RecipientTimedOut -> MR.string.chat_introduce_preflight_reason_timed_out
+        IntroductionPreflightStatus.RecipientConnectionRefused -> MR.string.chat_introduce_preflight_reason_connection_refused
         IntroductionPreflightStatus.UnknownError -> MR.string.chat_introduce_preflight_reason_unknown
     }
     return stringResource(key, peerName)

--- a/homebase-common/src/commonMain/composeResources/values-da/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values-da/strings.xml
@@ -569,10 +569,10 @@
     <!-- Per-status reasons. %1$s is the recipient's display name. -->
     <string name="chat_introduce_preflight_reason_ready">%1$s er klar.</string>
     <string name="chat_introduce_preflight_reason_not_connected">Du er ikke forbundet med %1$s.</string>
-    <string name="chat_introduce_preflight_reason_not_configured">%1$s's identitet er ikke konfigureret endnu.</string>
+    <string name="chat_introduce_preflight_reason_not_configured">%1$s har ikke færdiggjort opsætningen af sin identitet — bed dem logge ind og gøre det færdigt.</string>
     <string name="chat_introduce_preflight_reason_requires_upgrade">%1$s's server skal opdateres.</string>
     <string name="chat_introduce_preflight_reason_not_permitted">%1$s tillader ikke introduktioner fra dig.</string>
-    <string name="chat_introduce_preflight_reason_rejected">%1$s afviste anmodningen.</string>
+    <string name="chat_introduce_preflight_reason_rejected">%1$s's server accepterede ikke anmodningen.</string>
     <string name="chat_introduce_preflight_reason_unreachable">Kunne ikke nå %1$s's server lige nu.</string>
     <string name="chat_introduce_preflight_reason_unknown">Noget gik galt med %1$s.</string>
     <string name="chat_leave_and_delete">Forlad og slet</string>

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -567,16 +567,34 @@
     <string name="chat_introduce_preflight_body">Some recipients may not receive an introduction:</string>
     <string name="chat_introduce_preflight_send_anyway">Send anyway</string>
     <string name="chat_introduce_preflight_skip_and_send">Skip these and send to the rest</string>
+    <!-- Shown under the list when at least one recipient failed for a transient
+         reason (server busy, updating, timed out) — re-runs the preflight check. -->
+    <string name="chat_introduce_preflight_check_again">Check again</string>
     <!-- Bullet-prefixed line in the preflight dialog body. %1$s is a per-status reason. -->
     <string name="chat_introduce_preflight_bullet">• %1$s</string>
-    <!-- Per-status reasons. %1$s is the recipient's display name. -->
+    <!-- Per-status reasons. %1$s is the recipient's display name.
+         Exactly ONE of these may say the recipient doesn't allow introductions:
+         chat_introduce_preflight_reason_not_permitted (IntroductionsNotPermitted).
+         Every other status is a setup gap, a broken connection record or a
+         transport failure — never phrase those as a refusal. Nothing here may
+         reveal that a recipient has blocked the user. -->
     <string name="chat_introduce_preflight_reason_ready">%1$s is ready.</string>
     <string name="chat_introduce_preflight_reason_not_connected">You're not connected to %1$s.</string>
-    <string name="chat_introduce_preflight_reason_not_configured">%1$s's identity isn't set up yet.</string>
-    <string name="chat_introduce_preflight_reason_requires_upgrade">%1$s's server needs an update.</string>
+    <string name="chat_introduce_preflight_reason_not_configured">%1$s hasn't finished setting up their identity — ask them to sign in and complete it.</string>
+    <string name="chat_introduce_preflight_reason_requires_upgrade">%1$s's server needs an update before it can accept introductions.</string>
     <string name="chat_introduce_preflight_reason_not_permitted">%1$s doesn't allow introductions from you.</string>
-    <string name="chat_introduce_preflight_reason_rejected">%1$s declined the request.</string>
-    <string name="chat_introduce_preflight_reason_unreachable">Couldn't reach %1$s's server right now.</string>
+    <string name="chat_introduce_preflight_reason_rejected">%1$s's server didn't accept the request.</string>
+    <string name="chat_introduce_preflight_reason_unreachable">Couldn't reach %1$s right now.</string>
+    <string name="chat_introduce_preflight_reason_not_confirmed">%1$s hasn't confirmed your connection yet — introductions work once they do.</string>
+    <string name="chat_introduce_preflight_reason_not_recognized">Your connection with %1$s isn't active on their side.</string>
+    <string name="chat_introduce_preflight_reason_needs_repair">Your connection with %1$s is damaged and needs to be set up again.</string>
+    <string name="chat_introduce_preflight_reason_sender_connection_invalid">Your saved connection details for %1$s aren't usable.</string>
+    <string name="chat_introduce_preflight_reason_not_supported">%1$s's server is too old to check ahead of time — the introduction may still go through.</string>
+    <string name="chat_introduce_preflight_reason_upgrade_in_progress">%1$s's server is updating right now.</string>
+    <string name="chat_introduce_preflight_reason_unresolvable">%1$s's address couldn't be found — it may have changed or no longer exist.</string>
+    <string name="chat_introduce_preflight_reason_certificate_invalid">%1$s's server has a security certificate problem.</string>
+    <string name="chat_introduce_preflight_reason_timed_out">%1$s's server didn't respond in time.</string>
+    <string name="chat_introduce_preflight_reason_connection_refused">%1$s's server appears to be offline.</string>
     <string name="chat_introduce_preflight_reason_unknown">Something went wrong with %1$s.</string>
     <string name="chat_leave_and_delete">Leave &amp; delete</string>
     <string name="chat_leave_and_delete_conversation_title">Leave and delete this group?</string>


### PR DESCRIPTION
Preflight grew from 8 statuses to 18, and the UI rendered nearly every failure as "<name> doesn't allow introductions from you". That message was wrong in most cases: an unconfirmed connection, a one-sided or damaged connection record, our own invalid record and a plain transport failure all rendered as a deliberate refusal by the recipient.

Only IntroductionsNotPermitted reflects a decision by the recipient, so that string is now reserved for it. Each other status gets copy that points at what is actually wrong and who can fix it — statuses 9/10 name the connection rather than the person, 11 blames our own saved details rather than the recipient, 8 reads as a pending step instead of an error, and 9 is worded identically to the other broken-connection cases so a block stays indistinguishable from a stale record.

API:
- IntroductionPreflightStatus: add values 8..17, plus defaultRemedyActor and defaultIsTransient so servers that omit the new fields still get the right affordances.
- PreflightDiagnostics: PreflightRemedyActor and CallerConnectionState, sharing the status enum's int-or-name tolerant serializer.
- RecipientPreflightStatus: carry isCallerConnected/isCallerConfirmed/ isCallerAutoConnected/callerConnectionState/remedyActor/isTransient; expose effectiveRemedyActor, canRetry, hasRetryableRecipient.

UI:
- Per-status strings for all 18 statuses in both surfaces (create-group preflight dialog and the group-settings inline label).
- Affordances switch on IsTransient/RemedyActor, not on status: a "Check again" action re-runs preflight when any entry is retryable. Statuses needing a human first show no button — the copy is the remedy.
- Stop rendering RecipientPreflightStatus.detail in the dialog; it is raw server/exception text and belongs in logs only. The provider now logs the full diagnostic row instead.

Danish: two lines whose meaning changed are updated; the 10 new keys fall back to English pending translation.