### PR TITLE
Raise video playback errors above the moments thumbnail overlay (#959)

### DIFF
--- a/homebase-chat/src/androidMain/kotlin/id/homebase/chat/widget/video/VideoPlayerSurface.android.kt
+++ b/homebase-chat/src/androidMain/kotlin/id/homebase/chat/widget/video/VideoPlayerSurface.android.kt
@@ -97,6 +97,7 @@ actual fun VideoPlayerSurface(
     onEnded: () -> Unit,
     replayToken: Int,
     paused: Boolean,
+    onError: (String) -> Unit,
 ) {
     // useInlineOptimizations is a no-op on Android — the player pool, audio
     // track disable, and first-frame paint already apply unconditionally to
@@ -155,9 +156,12 @@ actual fun VideoPlayerSurface(
                 // this device can't decode (e.g. a 10-bit HLG capture from a sender that shipped it
                 // un-downconverted) gets a specific message; everything else a generic one.
                 val format = (error as? ExoPlaybackException)?.rendererFormat
-                state = VpsState.Error(
+                val message =
                     if (isTenBitFormat(format)) tenBitPlaybackError else genericPlaybackError
-                )
+                state = VpsState.Error(message)
+                // Callers that cover this surface with a thumbnail render the
+                // message themselves — ours is invisible under it (#959).
+                onError(message)
             }
             override fun onPlayerErrorChanged(error: PlaybackException?) {
                 if (error == null) {
@@ -429,7 +433,10 @@ actual fun VideoPlayerSurface(
                 Logger.e(tag = "VideoIO", throwable = e) {
                     "playback setup error: fileId=${data.fileId} key=${data.payloadKey} message=${e.message}"
                 }
-                state = VpsState.Error(e.message ?: "Playback error")
+                // The raw exception text is logged above; the UI gets the
+                // localized generic message (and so does the caller, #959).
+                state = VpsState.Error(genericPlaybackError)
+                onError(genericPlaybackError)
             }
         }
     }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/video/VideoPlayerSurface.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/video/VideoPlayerSurface.kt
@@ -97,4 +97,17 @@ expect fun VideoPlayerSurface(
      * unaffected.
      */
     paused: Boolean = false,
+    /**
+     * Fires with a localized, user-facing message when playback fails (decode
+     * error, unsupported codec, content-resolution failure). The surface also
+     * renders that message centred in its own bounds — but a caller that draws
+     * a thumbnail *over* the surface (the moments inline tile keeps its poster
+     * up until [onFirstFrame], which a failed playback never reaches) would
+     * hide it completely, so the error has to be re-raised above that overlay
+     * by the caller (#959).
+     *
+     * May fire more than once for a single mount if the player reports
+     * successive errors; the latest message wins.
+     */
+    onError: (String) -> Unit = {},
 )

--- a/homebase-chat/src/jvmMain/kotlin/id/homebase/chat/widget/video/VideoPlayerSurface.jvm.kt
+++ b/homebase-chat/src/jvmMain/kotlin/id/homebase/chat/widget/video/VideoPlayerSurface.jvm.kt
@@ -51,6 +51,7 @@ import id.homebase.api.video.resolveVideoContent
 import id.homebase.chat.conversationlist.FullScreenOverlay
 import id.homebase.resources.MR
 import id.homebase.resources.cd_video_frame
+import id.homebase.resources.video_error_generic
 import id.homebase.resources.vlc_required
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
@@ -101,6 +102,7 @@ actual fun VideoPlayerSurface(
     // which the desktop never shows (it uses the wide split layout), so the
     // flag is accepted to satisfy the expect signature but not wired here.
     @Suppress("UNUSED_PARAMETER") paused: Boolean,
+    onError: (String) -> Unit,
 ) {
     // VLC-J's CallbackMediaPlayerComponent paints to a Swing canvas with no
     // built-in transport UI of its own (host renders controls). Param is
@@ -121,6 +123,10 @@ actual fun VideoPlayerSurface(
     // startup sweep is the backstop.
     var tempFile by remember(data) { mutableStateOf<File?>(null) }
     var httpServer by remember(data) { mutableStateOf<HttpServer?>(null) }
+
+    // Resolved in composable scope — stringResource can't run inside the
+    // LaunchedEffect's catch block below (#959).
+    val genericPlaybackError = stringResource(MR.string.video_error_generic)
 
     DisposableEffect(data) {
         onDispose {
@@ -230,7 +236,14 @@ actual fun VideoPlayerSurface(
                     }
                 }
             } catch (e: Exception) {
-                state = VpsState.Error(e.message ?: "Playback error")
+                Logger.e(tag = "VideoIO", throwable = e) {
+                    "playback setup error: fileId=${data.fileId} key=${data.payloadKey} message=${e.message}"
+                }
+                // Localized message for the UI; the raw exception text stays in
+                // the log. Also raised to the caller, whose thumbnail overlay
+                // would otherwise hide our own centred Text (#959).
+                state = VpsState.Error(genericPlaybackError)
+                onError(genericPlaybackError)
             }
         }
     }

--- a/homebase-chat/src/nativeMain/kotlin/id/homebase/chat/widget/video/VideoPlayerSurface.native.kt
+++ b/homebase-chat/src/nativeMain/kotlin/id/homebase/chat/widget/video/VideoPlayerSurface.native.kt
@@ -24,6 +24,9 @@ import id.homebase.api.video.VideoPlayerData
 import id.homebase.api.video.VideoPreloader
 import id.homebase.api.video.resolveVideoContent
 import id.homebase.chat.conversationlist.FullScreenOverlay
+import id.homebase.resources.MR
+import id.homebase.resources.video_error_generic
+import org.jetbrains.compose.resources.stringResource
 import kotlinx.cinterop.BetaInteropApi
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.addressOf
@@ -130,6 +133,7 @@ actual fun VideoPlayerSurface(
     onEnded: () -> Unit,
     replayToken: Int,
     paused: Boolean,
+    onError: (String) -> Unit,
 ) {
     val driveFileProvider = koinInject<DriveFileProvider>()
     val fileOperationsProvider = koinInject<id.homebase.api.file.FileOperationsProvider>()
@@ -145,6 +149,10 @@ actual fun VideoPlayerSurface(
     // Natural end-of-clip flag: at end AVPlayer stays state=Playing with
     // paused=false, so the keep-awake below needs this to release on finish.
     var ended by remember(data) { mutableStateOf(false) }
+
+    // Resolved in composable scope — stringResource can't run inside the
+    // LaunchedEffect's catch block below (#959).
+    val genericPlaybackError = stringResource(MR.string.video_error_generic)
 
     DisposableEffect(data) {
         onDispose {
@@ -361,7 +369,14 @@ actual fun VideoPlayerSurface(
                     }
                 }
             } catch (e: Exception) {
-                state = VpsState.Error(e.message ?: "Playback error")
+                Logger.e(tag = "VideoIO", throwable = e) {
+                    "playback setup error: fileId=${data.fileId} key=${data.payloadKey} message=${e.message}"
+                }
+                // Localized message for the UI; the raw exception text stays in
+                // the log. Also raised to the caller, whose thumbnail overlay
+                // would otherwise hide our own centred Text (#959).
+                state = VpsState.Error(genericPlaybackError)
+                onError(genericPlaybackError)
             }
         }
     }

--- a/homebase-chat/src/wasmJsMain/kotlin/id/homebase/chat/widget/video/VideoPlayerSurface.web.kt
+++ b/homebase-chat/src/wasmJsMain/kotlin/id/homebase/chat/widget/video/VideoPlayerSurface.web.kt
@@ -27,6 +27,7 @@ import id.homebase.api.video.VideoPlayerData
 import id.homebase.api.video.resolveVideoContent
 import id.homebase.chat.conversationlist.FullScreenOverlay
 import id.homebase.resources.MR
+import id.homebase.resources.video_error_generic
 import id.homebase.resources.video_web_large_playback_unsupported
 import kotlin.io.encoding.Base64
 import org.jetbrains.compose.resources.stringResource
@@ -63,6 +64,7 @@ actual fun VideoPlayerSurface(
     // web playback is partial, so the flag is accepted to satisfy the expect
     // signature but not wired here.
     @Suppress("UNUSED_PARAMETER") paused: Boolean,
+    onError: (String) -> Unit,
 ) {
     val driveFileProvider = koinInject<DriveFileProvider>()
     val density = LocalDensity.current.density
@@ -76,6 +78,11 @@ actual fun VideoPlayerSurface(
     var objectUrl by remember(data) { mutableStateOf<String?>(null) }
     var bounds by remember(data) { mutableStateOf<Rect?>(null) }
     var started by remember(data) { mutableStateOf(false) }
+
+    // Resolved in composable scope — stringResource can't run inside the
+    // LaunchedEffect below (#959).
+    val genericPlaybackError = stringResource(MR.string.video_error_generic)
+    val hlsUnsupportedError = stringResource(MR.string.video_web_large_playback_unsupported)
 
     LaunchedEffect(data) {
         onProgress(0f)
@@ -119,11 +126,15 @@ actual fun VideoPlayerSurface(
                     // .m3u8 blob and we don't remux on web yet. Show a message instead of a dark
                     // stuck player.
                     state = WebVps.HlsUnsupported
+                    onError(hlsUnsupportedError)
                     onProgress(1f)
                 }
             }
         } catch (e: Exception) {
-            state = WebVps.Error(e.message ?: "Playback error")
+            // Localized message for the UI; also raised to the caller, whose
+            // thumbnail overlay would hide our own centred Text (#959).
+            state = WebVps.Error(genericPlaybackError)
+            onError(genericPlaybackError)
             onProgress(1f)
         }
     }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/widget/MomentInlineVideoTile.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/widget/MomentInlineVideoTile.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.VolumeOff
 import androidx.compose.material.icons.automirrored.filled.VolumeUp
+import androidx.compose.material.icons.filled.ErrorOutline
 import androidx.compose.material.icons.filled.Fullscreen
 import androidx.compose.material.icons.filled.FullscreenExit
 import androidx.compose.material.icons.filled.PauseCircle
@@ -45,6 +46,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import id.homebase.api.client.KeyHeader
@@ -302,6 +304,15 @@ fun MomentInlineVideoTile(
     // every isPlaying flip so a fresh play / swipe-back never starts paused.
     var heldPaused by remember(payload.key, isPlaying) { mutableStateOf(false) }
 
+    // Playback failure reported by [VideoPlayerSurface] (decode error,
+    // unsupported codec, content-resolution failure). The surface renders the
+    // same message centred in its own bounds, but it sits at the BOTTOM of this
+    // Box — under the thumbnail, which never drops because a failed playback
+    // never reaches onFirstFrame — so the message is invisible unless we raise
+    // it above the thumbnail ourselves (#959). Cleared on every isPlaying flip
+    // so a retry starts from a clean state.
+    var playbackError by remember(payload.key, isPlaying) { mutableStateOf<String?>(null) }
+
     // Auto-hide the centred pause affordance ~2.5 s into playback so it doesn't
     // sit over the video the whole time — long-press still pauses (see the
     // surface's pointerInput below). Re-shown briefly on each fresh play and on
@@ -434,6 +445,12 @@ fun MomentInlineVideoTile(
                 },
                 replayToken = replayToken,
                 paused = heldPaused,
+                onError = { message ->
+                    playbackError = message
+                    Logger.w(tag = "MomentVideo") {
+                        "tile playback error: fileId=$fileId key=${payload.key} message=$message"
+                    }
+                },
             )
         }
 
@@ -477,7 +494,38 @@ fun MomentInlineVideoTile(
 
         // Layer 3: state-specific overlays.
         if (isPlaying) {
-            if (ended) {
+            val error = playbackError
+            if (error != null) {
+                // Playback failed. The thumbnail above the surface stays put
+                // (there's no video frame to reveal), so the message goes here
+                // — over the poster, dimmed so it stays legible on a bright
+                // frame (#959).
+                Box(
+                    modifier = Modifier
+                        .matchParentSize()
+                        .background(Color.Black.copy(alpha = 0.55f)),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Row(
+                        modifier = Modifier.padding(horizontal = 24.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.ErrorOutline,
+                            contentDescription = null,
+                            modifier = Modifier.size(20.dp),
+                            tint = Color.White,
+                        )
+                        Text(
+                            text = error,
+                            color = Color.White,
+                            style = MaterialTheme.typography.bodyMedium,
+                            textAlign = TextAlign.Center,
+                        )
+                    }
+                }
+            } else if (ended) {
                 // End-of-clip: the player is paused on its last frame. Offer a
                 // centred "Watch again" pill (both feed and reels) that seeks
                 // back to 0 and resumes in place via [replayToken]. We do not


### PR DESCRIPTION
Refs #959 (part 2 UI — leaves part 3, the descriptor codec hevc-vs-avc mismatch, open).

Follow-up to #1137. That PR added a visible playback-error message to `VideoPlayerSurface`, but in the moments feed you still can't see it — the thumbnail sits on top of it.

## Cause

`MomentInlineVideoTile` deliberately layers the poster **above** the player surface (layer 1 = surface, layer 2 = thumbnail) and drops it to `alpha 0` only when `onFirstFrame` fires. A failed playback never renders a first frame, so the poster stays fully opaque and buries the error `Text` the surface draws in its own bounds. The tile just looks like a dead player.

The surface can't fix this from inside itself — it's below the overlay — so the error has to be re-raised by the host.

## Changes

- `VideoPlayerSurface` (expect + Android/JVM/iOS/web actuals) gains `onError: (String) -> Unit = {}`, fired with the same localized message the surface displays. Android reports both the decode-failure path (`onPlayerError`, including the 10-bit-specific message) and the setup-exception path.
- `MomentInlineVideoTile` keeps the message in state (reset on every `isPlaying` flip) and renders it as layer 3: a 55%-black scrim over the poster with a centred `ErrorOutline` + text, taking priority over the "Watch again" and pause affordances.
- Desktop/iOS/web actuals stop putting raw, untranslated exception text on screen (`e.message ?: "Playback error"`) — they now show `video_error_generic` and log the exception detail instead. Web's "HLS too large" state also notifies the host, since it was hidden by the same overlay.

Chat's `FullScreenVideoPlayer` was never affected — its thumbnail only draws when `!isPlaying`, which starts `true`.

## Testing

Compile-checked on JVM, Android, iOS simulator and wasmJs; `homebase-common:jvmTest` (Konsist) passes.

**Not verified on device** — this still needs hardware that actually fails to decode 10-bit (the Pixel 8 gap already noted on #959) to confirm the message renders end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
