### PR TITLE
refactor: one PlatformFile.contentType() instead of 21 hand-rolled MIME resolutions

### DIFF
--- a/androidApp/src/main/kotlin/id/homebase/feed/share/ShareReceiverActivity.kt
+++ b/androidApp/src/main/kotlin/id/homebase/feed/share/ShareReceiverActivity.kt
@@ -73,12 +73,12 @@ import id.homebase.core.moments.services.MomentCreateFlowState
 import id.homebase.core.settings.ThemeState
 import id.homebase.core.settings.UserPreferences
 import id.homebase.core.ui.theme.HomebaseTheme
+import id.homebase.core.util.contentType
 import id.homebase.feed.MainActivity
 import id.homebase.feed.R
 import io.github.vinceglb.filekit.PlatformFile
 import io.github.vinceglb.filekit.dialogs.FileKitType
 import io.github.vinceglb.filekit.dialogs.compose.rememberFilePickerLauncher
-import io.github.vinceglb.filekit.mimeType
 import io.github.vinceglb.filekit.name
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -239,8 +239,7 @@ class ShareReceiverActivity : ComponentActivity(), KoinComponent {
                 type = FileKitType.ImageAndVideo
             ) { file ->
                 file?.let {
-                    val mimeType = it.mimeType()?.toString() ?: ""
-                    val pending = if (mimeType.startsWith("video/")) {
+                    val pending = if (it.contentType().startsWith("video/")) {
                         AttachmentPendingFile.FileVideo(Uuid.random(), it)
                     } else {
                         AttachmentPendingFile.FileImage(Uuid.random(), it)
@@ -755,17 +754,19 @@ class ShareReceiverActivity : ComponentActivity(), KoinComponent {
                         when (attachment) {
                             is AttachmentPendingFile.FileImage -> AttachmentInput(
                                 filePath = attachment.file.toString(),
-                                contentType = attachment.file.mimeType()?.toString() ?: "image/jpeg",
+                                contentType = attachment.file.contentType()
+                                    .takeUnless { it == "application/octet-stream" } ?: "image/jpeg",
                                 displayName = attachment.file.name,
                             )
                             is AttachmentPendingFile.FileVideo -> AttachmentInput(
                                 filePath = attachment.file.toString(),
-                                contentType = attachment.file.mimeType()?.toString() ?: "video/mp4",
+                                contentType = attachment.file.contentType()
+                                    .takeUnless { it == "application/octet-stream" } ?: "video/mp4",
                                 displayName = attachment.file.name,
                             )
                             is AttachmentPendingFile.File -> AttachmentInput(
                                 filePath = attachment.file.toString(),
-                                contentType = attachment.file.mimeType()?.toString() ?: "application/octet-stream",
+                                contentType = attachment.file.contentType(),
                                 displayName = attachment.file.name,
                             )
                             is AttachmentPendingFile.Gallery -> AttachmentInput(

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/AttachmentHandler.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/AttachmentHandler.kt
@@ -11,6 +11,7 @@ import id.homebase.core.audio.AudioRecorder
 import id.homebase.core.audio.AudioWaveFormGenerator
 import id.homebase.core.clipboard.platformFileFromPath
 import id.homebase.core.localization.TranslationUtil
+import id.homebase.core.util.contentType
 import id.homebase.chat.services.image.StickerImageProcessor
 import id.homebase.chat.services.image.removeBackground
 import id.homebase.chat.services.image.warmUpBackgroundRemoval
@@ -123,7 +124,7 @@ internal class AttachmentHandler(
                 val newFiles = action.files.map { picked ->
                     // Read the type off the PICKED handle first — the copy below is a plain file
                     // whose extension-less photo-picker name resolves to octet-stream (#1149).
-                    val ct = picked.pickedContentType()
+                    val ct = picked.contentType()
                     // Copy the picked file into the sandbox NOW, while the picker's iOS
                     // security scope is still live. The send path later reads the file by
                     // path from a separate coroutine, where a path-rebuilt NSURL has no

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/AttachmentUploadResolve.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/AttachmentUploadResolve.kt
@@ -1,11 +1,10 @@
 package id.homebase.chat.conversationlist
 
 import id.homebase.api.file.FileOperationsProvider
+import id.homebase.core.util.contentType
 import id.homebase.core.util.extensionForMimeType
-import id.homebase.core.util.resolveContentType
 import io.github.vinceglb.filekit.PlatformFile
 import io.github.vinceglb.filekit.mimeType
-import io.github.vinceglb.filekit.name
 import kotlin.uuid.Uuid
 
 /**
@@ -49,22 +48,10 @@ expect suspend fun PlatformFile.toUploadPath(fileOps: FileOperationsProvider): S
 expect suspend fun PlatformFile.materializeForUpload(fileOps: FileOperationsProvider): PlatformFile
 
 /**
- * Content type of a **freshly picked** [PlatformFile], resolved before [materializeForUpload]
- * throws the evidence away.
- *
- * Only the picked handle knows the real type: on Android it is a `content://` URI whose
- * `ContentResolver.getType()` answers `image/jpeg`, while the sandbox copy is a plain file that can
- * only be typed from its name — and the system photo picker's display names (`photopicker-1000022602`)
- * carry no extension, so the copy resolves to `application/octet-stream` and the message ships as a
- * generic file chip with no thumbnail (#1149). Carry this to `AttachmentInput.contentType`.
- */
-internal fun PlatformFile.pickedContentType(): String =
-    resolveContentType(fileName = name, platformMimeType = mimeType()?.toString())
-
-/**
  * Name for the pick-time sandbox copy: the original name behind a collision-proof prefix, plus an
- * extension derived from [mimeType] when the picker's name has none. Belt to [pickedContentType]'s
- * braces — it keeps the copy self-describing for anything that only sees the file (#1149).
+ * extension derived from [mimeType] when the picker's name has none. Belt to
+ * [PlatformFile.contentType]'s braces — it keeps the copy self-describing for anything that only
+ * sees the file (#1149).
  */
 internal fun sandboxCopyName(name: String, mimeType: String?): String {
     val hasExtension = name.substringAfterLast('.', "").isNotEmpty()

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiState.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiState.kt
@@ -404,7 +404,7 @@ sealed class AttachmentPendingFile(val attachmentId: Uuid) {
     data class File(
         val id: Uuid,
         val file: PlatformFile,
-        // Content type read from the ORIGINAL picked handle (see PlatformFile.pickedContentType),
+        // Content type read from the ORIGINAL picked handle (see PlatformFile.contentType),
         // before the pick-time sandbox copy dropped it. [file] here is that copy: a plain file whose
         // type can only come from its name, and Android's photo picker vends extension-less names
         // ("photopicker-1000022602") that resolve to application/octet-stream — which ships the

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/MessageActionsHandler.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/MessageActionsHandler.kt
@@ -45,6 +45,7 @@ import id.homebase.core.share.ShareContentProcessor
 import id.homebase.core.share.hasSendableContent
 import id.homebase.core.share.resolveMessageBody
 import id.homebase.core.util.ScrollPosition
+import id.homebase.core.util.contentType
 import id.homebase.core.util.resolveContentType
 import id.homebase.core.util.toMessageMarkdown
 import id.homebase.core.widget.ReactionDisplayItem
@@ -689,10 +690,8 @@ internal class MessageActionsHandler(
                         attachments.add(
                             AttachmentInput(
                                 filePath = attachment.file.toUploadPath(fileOperationsProvider),
-                                contentType = attachment.sourceContentType ?: resolveContentType(
-                                    fileName = attachment.file.name,
-                                    platformMimeType = attachment.file.mimeType()?.toString(),
-                                ),
+                                contentType = attachment.sourceContentType
+                                    ?: attachment.file.contentType(),
                                 displayName = attachment.file.name,
                             )
                         )
@@ -757,10 +756,7 @@ internal class MessageActionsHandler(
                         attachments.add(
                             AttachmentInput(
                                 filePath = attachment.audioFile.toUploadPath(fileOperationsProvider),
-                                contentType = resolveContentType(
-                                    fileName = attachment.audioFile.name,
-                                    platformMimeType = attachment.audioFile.mimeType()?.toString(),
-                                ),
+                                contentType = attachment.audioFile.contentType(),
                                 displayName = attachment.audioFile.name,
                                 waveformFile = attachment.waveformFile?.toUploadPath(fileOperationsProvider),
                                 audioLengthSeconds = attachment.lengthSeconds,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/event/EventComposerSheet.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/event/EventComposerSheet.kt
@@ -71,7 +71,6 @@ import id.homebase.chat.composer.ComposerEditableField
 import id.homebase.chat.composer.ComposerRow
 import id.homebase.chat.composer.ComposerTitleField
 import id.homebase.chat.conversationlist.materializeForUpload
-import id.homebase.chat.conversationlist.pickedContentType
 import id.homebase.core.location.rememberCurrentGps
 import id.homebase.core.location.tracking.GpsFixResult
 import id.homebase.chat.services.ChatMessageSenderService
@@ -82,6 +81,7 @@ import id.homebase.chat.services.builder.toImageAttachmentInput
 import id.homebase.chat.services.content.MessageContent
 import id.homebase.chat.widget.GuardedComposerSheet
 import id.homebase.core.ui.theme.HomebaseTheme
+import id.homebase.core.util.contentType
 import id.homebase.core.util.rememberCameraManager
 import id.homebase.resources.MR
 import id.homebase.resources.cancel
@@ -179,13 +179,13 @@ private fun EventComposerContent(
     val coverGalleryPicker = rememberFilePickerLauncher(type = FileKitType.Image) { file ->
         if (file != null) scope.launch {
             coverInput = file.materializeForUpload(fileOperationsProvider)
-                .toImageAttachmentInput(fileOperationsProvider, file.pickedContentType())
+                .toImageAttachmentInput(fileOperationsProvider, file.contentType())
         }
     }
     val coverCameraLauncher = rememberCameraManager { file ->
         if (file != null) scope.launch {
             coverInput = file.materializeForUpload(fileOperationsProvider)
-                .toImageAttachmentInput(fileOperationsProvider, file.pickedContentType())
+                .toImageAttachmentInput(fileOperationsProvider, file.contentType())
         }
     }
     // Deferred picker launch — presenting the picker synchronously from the

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/builder/ImageAttachmentResolve.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/builder/ImageAttachmentResolve.kt
@@ -3,9 +3,8 @@ package id.homebase.chat.services.builder
 import id.homebase.api.file.FileOperationsProvider
 import id.homebase.api.image.convertHeicToJpeg
 import id.homebase.chat.conversationlist.toUploadPath
-import id.homebase.core.util.resolveContentType
+import id.homebase.core.util.contentType
 import io.github.vinceglb.filekit.PlatformFile
-import io.github.vinceglb.filekit.mimeType
 import io.github.vinceglb.filekit.name
 
 /**
@@ -16,7 +15,7 @@ import io.github.vinceglb.filekit.name
  * forceSticker via copy() if needed.
  *
  * [sourceContentType] is the type read off the ORIGINAL picked handle (see
- * `PlatformFile.pickedContentType`). Pass it whenever the receiver is a pick-time sandbox
+ * [PlatformFile.contentType]). Pass it whenever the receiver is a pick-time sandbox
  * copy: the copy's name may carry no extension, and this receiver can otherwise only be
  * typed from that name (#1149).
  */
@@ -25,8 +24,7 @@ suspend fun PlatformFile.toImageAttachmentInput(
     sourceContentType: String? = null,
 ): AttachmentInput {
     var filePath = toUploadPath(fileOps)
-    var contentType = sourceContentType
-        ?: resolveContentType(fileName = name, platformMimeType = mimeType()?.toString())
+    var contentType = sourceContentType ?: contentType()
     if (contentType == "image/heic" || contentType == "image/heif") {
         val heicBytes = fileOps.readFileBytes(filePath)
         val jpegBytes = convertHeicToJpeg(heicBytes)

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/image/HomebaseImageLoader.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/image/HomebaseImageLoader.kt
@@ -9,8 +9,7 @@ import id.homebase.api.client.withRetry
 import id.homebase.api.coroutines.supervisedScope
 import id.homebase.api.file.FileOperationsProvider
 import id.homebase.core.clipboard.platformFileFromPath
-import io.github.vinceglb.filekit.extension
-import io.github.vinceglb.filekit.mimeType
+import id.homebase.core.util.contentType
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
 import kotlin.uuid.Uuid
@@ -278,7 +277,7 @@ suspend fun FileOperationsProvider.loadPendingFile(data: HomebaseImageData): Cac
     return try {
         val file = platformFileFromPath(fileUri)
         val bytes = this.readFileBytes(fileUri)
-        val contentType = file.mimeType()?.toString() ?: file.extension
+        val contentType = file.contentType()
         CachedImage(bytes = bytes, contentType = contentType, size = null)
     } catch (e: Exception) {
         Logger.e(tag = "HomebaseImageLoader") { "Failed to load pending file: ${e.message}" }

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/util/ContentTypeUtil.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/util/ContentTypeUtil.kt
@@ -1,5 +1,9 @@
 package id.homebase.core.util
 
+import io.github.vinceglb.filekit.PlatformFile
+import io.github.vinceglb.filekit.mimeType
+import io.github.vinceglb.filekit.name
+
 const val CONTENT_TYPE_MARKDOWN = "text/markdown"
 
 fun detectContentTypeFromExtensionOrHint(nameOrPath: String?): String {
@@ -30,6 +34,19 @@ fun resolveContentType(
     // 2. Extension-based lookup
     return detectContentTypeFromExtensionOrHint(fileName)
 }
+
+/**
+ * [resolveContentType] over a [PlatformFile]'s own name and platform MIME. Use this instead of
+ * spelling the pair out, and never `mimeType()` alone — the raw MIME has no extension fallback.
+ *
+ * Call it on the **originally picked** handle, before any sandbox copy. Only that handle knows the
+ * real type: on Android it is a `content://` URI whose `ContentResolver.getType()` answers
+ * `image/jpeg`, while a copy is a plain file that can only be typed from its name — and the system
+ * photo picker's names (`photopicker-1000022602`) carry no extension, so a copy resolves to
+ * `application/octet-stream` and the message ships as a generic file chip with no thumbnail (#1149).
+ */
+fun PlatformFile.contentType(): String =
+    resolveContentType(fileName = name, platformMimeType = mimeType()?.toString())
 
 private val commonExtToMime: Map<String, String> = mapOf(
     // Images

--- a/homebase-common/src/jvmTest/kotlin/id/homebase/core/util/PlatformFileContentTypeTest.kt
+++ b/homebase-common/src/jvmTest/kotlin/id/homebase/core/util/PlatformFileContentTypeTest.kt
@@ -1,0 +1,26 @@
+package id.homebase.core.util
+
+import io.github.vinceglb.filekit.PlatformFile
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * `PlatformFile.contentType()` is what ~20 call sites now use instead of spelling out
+ * `resolveContentType(f.name, f.mimeType()?.toString())` or — worse — reading `mimeType()` raw.
+ * Both parameters are `String?`, so a swapped argument order would compile and silently drop the
+ * extension fallback. These pin the delegation.
+ */
+class PlatformFileContentTypeTest {
+
+    @Test
+    fun resolvesFromTheExtensionWhenThePlatformHasNoMime() {
+        assertEquals("image/png", PlatformFile("/tmp/does-not-exist.png").contentType())
+    }
+
+    @Test
+    fun neverReturnsEmpty_soStartsWithChecksAreSafe() {
+        // The raw-mime call sites this replaced used `mimeType()?.toString().orEmpty()` and then
+        // `startsWith("video/")`; an extension-less photo-picker name gave them "" (#1149).
+        assertEquals("application/octet-stream", PlatformFile("/tmp/photopicker-1000022602").contentType())
+    }
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/ContactSaveHelper.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/ContactSaveHelper.kt
@@ -14,10 +14,8 @@ import id.homebase.core.contactbook.ContactOverrideStore
 import id.homebase.core.ui.screens.contactbook.model.ContactBookEntry
 import id.homebase.core.ui.screens.contactbook.model.ContactBookSource
 import id.homebase.core.ui.screens.contactbook.model.ContactFieldOverlay
-import id.homebase.core.util.resolveContentType
+import id.homebase.core.util.contentType
 import io.github.vinceglb.filekit.PlatformFile
-import io.github.vinceglb.filekit.mimeType
-import io.github.vinceglb.filekit.name
 import io.github.vinceglb.filekit.readBytes
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
@@ -217,7 +215,7 @@ private suspend fun uploadContactPhoto(
         return false
     }
     if (bytes.isEmpty()) return false
-    val contentType = resolveContentType(photo.name, photo.mimeType()?.toString())
+    val contentType = photo.contentType()
     return repo.setImage(
         uniqueId = uniqueId,
         bytes = bytes,

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentComposeScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentComposeScreen.kt
@@ -51,6 +51,7 @@ import id.homebase.chat.widget.MediaAttachmentEditor
 import id.homebase.core.ui.screens.moments.widget.MomentDateChip
 import id.homebase.core.ui.screens.moments.widget.MomentDescriptionField
 import id.homebase.core.ui.screens.moments.widget.MomentImageInfoChip
+import id.homebase.core.util.contentType
 import id.homebase.core.util.rememberCameraManager
 import id.homebase.resources.MR
 import id.homebase.resources.chat_message_add_gallery_image
@@ -61,7 +62,6 @@ import id.homebase.resources.moments_compose_title
 import io.github.vinceglb.filekit.dialogs.FileKitMode
 import io.github.vinceglb.filekit.dialogs.FileKitType
 import io.github.vinceglb.filekit.dialogs.compose.rememberFilePickerLauncher
-import io.github.vinceglb.filekit.mimeType
 import org.jetbrains.compose.resources.stringResource
 import kotlin.uuid.Uuid
 
@@ -119,7 +119,7 @@ fun MomentComposeScreen(
     ) { files ->
         if (files.isNullOrEmpty()) return@rememberFilePickerLauncher
         val pending = files.map { f ->
-            val ct = f.mimeType()?.toString().orEmpty()
+            val ct = f.contentType()
             if (ct.startsWith("video/")) {
                 AttachmentPendingFile.FileVideo(Uuid.generateV7(), f, thumbnailBytes = null)
             } else {
@@ -141,7 +141,7 @@ fun MomentComposeScreen(
 
     val cameraLauncher = rememberCameraManager { file ->
         file?.let {
-            val ct = it.mimeType()?.toString().orEmpty()
+            val ct = it.contentType()
             val pending = if (ct.startsWith("video/")) {
                 AttachmentPendingFile.FileVideo(Uuid.generateV7(), it, thumbnailBytes = null)
             } else {

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentComposeViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentComposeViewModel.kt
@@ -12,10 +12,10 @@ import id.homebase.chat.services.builder.AttachmentInput
 import id.homebase.core.clipboard.platformFileFromPath
 import id.homebase.core.moments.services.MediaInfo
 import id.homebase.core.moments.services.MomentCreateFlowState
+import id.homebase.core.util.contentType
 import id.homebase.core.util.resolveContentType
 import id.homebase.imageeditor.ui.CropResultBus
 import id.homebase.imageeditor.ui.DrawResultBus
-import io.github.vinceglb.filekit.mimeType
 import io.github.vinceglb.filekit.name
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -405,19 +405,19 @@ internal fun deriveMomentInstant(attachments: List<AttachmentPendingFile>): Inst
 internal fun AttachmentPendingFile.toAttachmentInput(): AttachmentInput = when (this) {
     is AttachmentPendingFile.File -> AttachmentInput(
         filePath = file.toString(),
-        contentType = resolveContentType(file.name, file.mimeType()?.toString()),
+        contentType = file.contentType(),
         displayName = file.name,
     )
 
     is AttachmentPendingFile.FileImage -> AttachmentInput(
         filePath = file.toString(),
-        contentType = resolveContentType(file.name, file.mimeType()?.toString()),
+        contentType = file.contentType(),
         displayName = file.name,
     )
 
     is AttachmentPendingFile.FileVideo -> AttachmentInput(
         filePath = file.toString(),
-        contentType = resolveContentType(file.name, file.mimeType()?.toString()),
+        contentType = file.contentType(),
         displayName = file.name,
         trimStartMs = trimStartMs,
         trimEndMs = trimEndMs,
@@ -431,7 +431,7 @@ internal fun AttachmentPendingFile.toAttachmentInput(): AttachmentInput = when (
 
     is AttachmentPendingFile.Audio -> AttachmentInput(
         filePath = audioFile.toString(),
-        contentType = resolveContentType(audioFile.name, audioFile.mimeType()?.toString()),
+        contentType = audioFile.contentType(),
         displayName = audioFile.name,
         waveformFile = waveformFile?.toString(),
         audioLengthSeconds = lengthSeconds,

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultViewModel.kt
@@ -24,12 +24,11 @@ import id.homebase.core.sync.OptionalDriveActivation
 import id.homebase.core.ui.screens.vault.model.VaultEntry
 import id.homebase.core.ui.screens.vault.model.VaultSection
 import id.homebase.core.ui.screens.vault.model.VaultSectionContent
-import id.homebase.core.util.resolveContentType
+import id.homebase.core.util.contentType
 import id.homebase.core.vault.VaultPreferences
 import id.homebase.api.client.KeyHeader
 import id.homebase.api.file.FileOperationsProvider
 import id.homebase.api.sync.DriveState
-import io.github.vinceglb.filekit.mimeType
 import io.github.vinceglb.filekit.name
 import io.github.vinceglb.filekit.PlatformFile
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -448,11 +447,11 @@ class VaultViewModel(
         val firstName = files.first().name
         // The user-typed value is the entry's editable label, NOT its file name.
         val label = action.entryName?.ifBlank { null }
-        val firstContentType = resolveContentType(firstName, files.first().mimeType()?.toString())
+        val firstContentType = files.first().contentType()
         val pendingId = Uuid.random()
 
         val fileContentTypes = files.map { file ->
-            resolveContentType(file.name, file.mimeType()?.toString())
+            file.contentType()
         }
 
         val placeholderDescriptors = fileContentTypes.mapIndexed { index, contentType ->
@@ -617,7 +616,7 @@ class VaultViewModel(
 
     private fun handleAppendPages(action: VaultUiAction.AppendPages) {
         val fileData = action.newFiles.map { file ->
-            val ct = resolveContentType(file.name, file.mimeType()?.toString())
+            val ct = file.contentType()
             file.pathCompat to ct
         }
 
@@ -673,7 +672,7 @@ class VaultViewModel(
     // region Add-pictures editor (reuses image-editor-ui's crop/draw seam)
 
     private fun stageAttachment(file: PlatformFile): AttachmentPendingFile {
-        val ct = resolveContentType(file.name, file.mimeType()?.toString())
+        val ct = file.contentType()
         return if (ct.startsWith("image/")) {
             AttachmentPendingFile.FileImage(id = Uuid.random(), file = file)
         } else {


### PR DESCRIPTION
Follow-up to #1152, acting on [Michael's review comment](https://github.com/homebase-id/chat-kmp/pull/1152#issuecomment-5099616013):

> I'm wondering if the code would be cleaner if PlatformFile contains a filetype() function which can infer the filetype so that we don't need to scatter logic like checking for an empty mime string and then calling a function to detect.

He's right, and the scatter was wider than #1152 touched.

## What was scattered

| Shape | Sites | Problem |
|---|---|---|
| `resolveContentType(f.name, f.mimeType()?.toString())` | 14 | Pure duplication |
| `f.mimeType()?.toString().orEmpty()` / `?: "image/jpeg"` | 7 | **No extension fallback at all** |

`PlatformFile` is FileKit's type so it can't gain a member function — the Kotlin equivalent is an extension, which #1152 already had as `pickedContentType()`, chat-local and named for one use case. This promotes it to `homebase-common`'s `ContentTypeUtil.kt` as `PlatformFile.contentType()` and sweeps every site onto it.

## This also fixes live bugs

The 7 raw-MIME sites are the same defect #1149 fixed for chat, still present elsewhere. With an extension-less picker name the raw MIME comes back empty or generic, so:

- **`MomentComposeScreen.kt:122` and `:144`** — `val ct = f.mimeType()?.toString().orEmpty()` then `ct.startsWith("video/")`. A picked **video** fell to the else branch and became `AttachmentPendingFile.FileImage`.
- **`ShareReceiverActivity.kt:242`** — same shape on the Android share sheet's gallery route.
- **`HomebaseImageLoader.kt:281`** — `?: file.extension` handed `CachedImage.contentType` a bare `"jpg"` where every other producer passes a real MIME.

The ShareReceiver *send* sites keep their per-branch safety defaults (`image/jpeg`, `video/mp4`) as a last resort, so they can only improve:

```kotlin
contentType = attachment.file.contentType()
    .takeUnless { it == "application/octet-stream" } ?: "image/jpeg",
```

## What this does NOT change

#1149's actual cause is **temporal**, not structural: the picked `content://` handle must be read *before* `materializeForUpload` copies it into the sandbox and discards it. A tidier `contentType()` called at send time still reads the copy and still returns octet-stream. The `sourceContentType` carry-through from #1152 is untouched.

## Verification

| Check | Result |
|---|---|
| `:homebase-{common,chat,core}:compileKotlinJvm` | BUILD SUCCESSFUL |
| `compileAndroidMain` ×3 + `:androidApp:compileDebugKotlin` | BUILD SUCCESSFUL |
| `compileKotlinWasmJs` ×3 | BUILD SUCCESSFUL |
| `compileKotlinIosSimulatorArm64` ×3 | BUILD SUCCESSFUL |
| `:homebase-{common,chat,core}:jvmTest --rerun-tasks` | BUILD SUCCESSFUL |
| `./gradlew lint` | BUILD SUCCESSFUL |

New: `homebase-common/src/jvmTest/.../PlatformFileContentTypeTest.kt` (2 tests). Both `resolveContentType` params are `String?`, so a swapped argument order would compile and silently drop the extension fallback — these pin the delegation and pin that the result is never empty (the `startsWith` call sites depend on that).

### On device — Redmi Note 5 Pro (whyred, AOSP 11), debug build 1.4.1505

Planted a deterministic test file (`argent-clip.mp4`, MediaStore mime `video/mp4`) and exercised both changed branches. Nothing was sent or posted; all drafts discarded.

- **Moments composer** (`MomentComposeScreen:122`, the changed line) → rendered with pause control, `0:02 / 0:02` duration readout, and a **trim scrubber**. All three are `FileVideo`-only affordances; the old code's failure mode (`FileImage`) has none of them.
- **Moments composer, image** (`f_1.png`) → static preview with **crop + draw** tools, no transport, no trim. Opposite branch, also correct.
- **Chat gallery route** (`argent-clip.mp4`) → opened the video editor with playback.
- No crashes in logcat, no attachment errors in `homebase.log`.

**Not reproducible on this hardware:** #1149's precise input shape — correct provider MIME plus an extension-less `photopicker-NNNNNNNNNN` display name — needs Android's **system photo picker**. This device has no updatable MediaProvider, so `ACTION_PICK_IMAGES` is unresolved and the gallery route falls back to DocumentsUI. I planted extension-less media to approximate it, but MediaStore types such files `application/octet-stream`, which makes them **unselectable** in an ImageAndVideo picker — and MediaProvider on A11 rejects `content update` on `mime_type`, so the MIME can't be forged. The device run above is therefore a regression check of the sweep, not a reproduction of #1149; the resolution logic itself is covered by the unit tests here and in #1152.

Refs #1149.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
