### PR TITLE
fix(chat): a status message no longer sets the conversation-list preview

### DIFF
--- a/homebase-api/src/commonMain/sqldelight/id/homebase/api/sync/database/ChatReadCount.sq
+++ b/homebase-api/src/commonMain/sqldelight/id/homebase/api/sync/database/ChatReadCount.sq
@@ -35,20 +35,11 @@ WHERE identityId = ? AND fileType = 8888;
 -- This is needed at boot-time to efficiently load the full list of conversations
 -- and their corresponding last message.
 -- Only fetches the 1 latest message per conversation via index seek.
---
--- `m2.dataType != 202` skips status messages (group rename, photo update, member
--- add/remove): they are rendered as system chips inside the thread, never as the
--- list preview. Its twin is the `if (m.isStatusMessage) return null` gate at the
--- top of `applyIncomingMessageBump` (the live-arrival path) — the two own the
--- row's last-message fields between them and must stay in step, or the same
--- conversation renders differently before and after a restart (#1153).
---
--- Don't "fix" this by dropping the exclusion: status visibility is decided in
--- Kotlin from decrypted content this query cannot read (`mapToMessageData` drops
--- a peer-authored GroupHealLocalCleanup, an emergency-locate notice inside its
--- embargo window, and any soft-deleted status message), so a row returned here
--- can fail to map and leave the conversation on its "No messages yet"
--- placeholder — the blank #1148 fixed.
+-- `dataType != 202` skips status messages; its twin is the `isStatusMessage`
+-- gate in applyIncomingMessageBump — both own the row's last-message fields and
+-- must stay in step (#1153). Don't drop it: status visibility depends on
+-- decrypted content SQL can't read, so a row returned here can fail to map and
+-- blank the preview (#1148).
 selectAllConversationPlusLastMessage:
 SELECT
   d.jsonHeader AS convJsonHeader,

--- a/homebase-api/src/commonMain/sqldelight/id/homebase/api/sync/database/ChatReadCount.sq
+++ b/homebase-api/src/commonMain/sqldelight/id/homebase/api/sync/database/ChatReadCount.sq
@@ -35,6 +35,20 @@ WHERE identityId = ? AND fileType = 8888;
 -- This is needed at boot-time to efficiently load the full list of conversations
 -- and their corresponding last message.
 -- Only fetches the 1 latest message per conversation via index seek.
+--
+-- `m2.dataType != 202` skips status messages (group rename, photo update, member
+-- add/remove): they are rendered as system chips inside the thread, never as the
+-- list preview. Its twin is the `if (m.isStatusMessage) return null` gate at the
+-- top of `applyIncomingMessageBump` (the live-arrival path) — the two own the
+-- row's last-message fields between them and must stay in step, or the same
+-- conversation renders differently before and after a restart (#1153).
+--
+-- Don't "fix" this by dropping the exclusion: status visibility is decided in
+-- Kotlin from decrypted content this query cannot read (`mapToMessageData` drops
+-- a peer-authored GroupHealLocalCleanup, an emergency-locate notice inside its
+-- embargo window, and any soft-deleted status message), so a row returned here
+-- can fail to map and leave the conversation on its "No messages yet"
+-- placeholder — the blank #1148 fixed.
 selectAllConversationPlusLastMessage:
 SELECT
   d.jsonHeader AS convJsonHeader,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/data/ConversationUiModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/data/ConversationUiModel.kt
@@ -160,14 +160,22 @@ data class ConversationUiModel(
          * on the cold-load / post-sync enrichment path, where the
          * `selectAllConversationPlusLastMessage` row IS the authority for "what
          * is the last message" and the row being patched always still carries
-         * `mapToBasic`'s `" "` placeholder. That query excludes status messages
-         * (`dataType = 202`) while `applyIncomingMessageBump` advances the sort
-         * key for them, so the persisted `localAppData.latestMessageTimestamp`
-         * seed can legitimately be *newer* than the newest real message — under
+         * `mapToBasic`'s `" "` placeholder. The persisted
+         * `localAppData.latestMessageTimestamp` seed can legitimately be
+         * *newer* than the newest real message that query can return — under
          * the old `candidate >= latestMessageTimestamp` guard the preview lost
          * that comparison and the row rendered "No messages yet" next to a
          * correct timestamp (#1148). Live arrivals keep their own recency guard
          * in [id.homebase.chat.services.convo.applyIncomingMessageBump].
+         *
+         * A newer-than-the-message seed used to be routine: that query excludes
+         * status messages (`dataType = 202`) while `applyIncomingMessageBump`
+         * advanced the sort key for them. Since #1153 the live path leaves the
+         * row alone for a status message, so the two agree — but the seed is
+         * stamped monotonically (`UnixTimeUtc.later`) into owner-synced
+         * localAppData, so a status-derived value written by an older build, or
+         * by one of the owner's devices still running one, never goes away. The
+         * unconditional preview is what keeps those rows readable.
          *
          * The candidate timestamp is driven by [latestTimestampOverrideMs]
          * when the caller knows the SQL-side userDate (e.g. from

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/data/ConversationUiModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/data/ConversationUiModel.kt
@@ -168,14 +168,12 @@ data class ConversationUiModel(
          * correct timestamp (#1148). Live arrivals keep their own recency guard
          * in [id.homebase.chat.services.convo.applyIncomingMessageBump].
          *
-         * A newer-than-the-message seed used to be routine: that query excludes
-         * status messages (`dataType = 202`) while `applyIncomingMessageBump`
-         * advanced the sort key for them. Since #1153 the live path leaves the
-         * row alone for a status message, so the two agree — but the seed is
-         * stamped monotonically (`UnixTimeUtc.later`) into owner-synced
-         * localAppData, so a status-derived value written by an older build, or
-         * by one of the owner's devices still running one, never goes away. The
-         * unconditional preview is what keeps those rows readable.
+         * Such a seed used to be routine, before #1153 made the live path leave
+         * status messages alone. It can still occur: the seed is stamped
+         * monotonically (`UnixTimeUtc.later`) into owner-synced localAppData, so
+         * a status-derived value written by an older build — or by another of
+         * the owner's devices still on one — never goes away. Keep the preview
+         * unconditional.
          *
          * The candidate timestamp is driven by [latestTimestampOverrideMs]
          * when the caller knows the SQL-side userDate (e.g. from

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationMessageBump.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationMessageBump.kt
@@ -17,28 +17,13 @@ import kotlin.uuid.Uuid
  * last message left every denormalised field unchanged). Returns the
  * new list otherwise.
  *
- * A **status message** (`dataType = 202` — group rename, photo update,
- * member add/remove) is not a last message and returns null outright.
- * The cold-load / post-`DriveSync.Stopped` enrichment path
- * ([ConversationMapper.applyLastMessage]) is fed by
- * `selectAllConversationPlusLastMessage`, whose last-message subquery
- * excludes `dataType = 202`, so a status message contributes nothing to
- * the row there. Letting it drive the preview and the sort key here made
- * the same conversation render differently before and after a restart —
- * *"You updated the conversation photo"* at the top of the list live,
- * the newest real message further down after a cold start (#1153).
- * These two functions are the sole owners of the row's last-message
- * fields (see the "Message-preview ownership" note on
- * [mergeConversationFileUpdate]), so they have to agree.
- *
- * The exclusion can't move the other way — into the SQL — because status
- * visibility is decided in Kotlin from *decrypted* content that SQL
- * cannot read: `mapToMessageData` drops a peer-authored
- * `GroupHealLocalCleanup`, an emergency-locate notice still inside its
- * embargo window, and any soft-deleted status message. A JOIN that
- * returned those would hand `applyLastMessage` a null map and leave the
- * row on `mapToBasic`'s `" "` placeholder — the exact "No messages yet"
- * blank that #1148 fixed.
+ * A **status message** (`dataType = 202`) is not a last message and returns
+ * null outright, matching cold-load enrichment, whose query excludes
+ * `dataType = 202` — when the two disagree the row's preview *and* sort key
+ * change on restart (#1153). The exclusion has to be duplicated rather than
+ * moved into the SQL: status visibility depends on decrypted content the query
+ * can't read, so a row it returned could fail to map and blank the preview
+ * (#1148).
  *
  * Three cases on a non-status message's `userDate` vs the conversation's
  * current `latestMessageTimestamp`:
@@ -101,11 +86,6 @@ internal fun applyIncomingMessageBump(
     sqlUserDate: Instant,
     activeDomain: OdinId?,
 ): List<ConversationUiModel>? {
-    // A status message is not a last message. Cold-load enrichment can never
-    // surface one (`selectAllConversationPlusLastMessage` filters
-    // `dataType != 202`), so neither may we, or the row changes on restart
-    // (#1153). Covers both the strictly-newer branch and the same-userDate
-    // re-emit below.
     if (m.isStatusMessage) return null
 
     val increment = if (!m.isEdited && !m.isAuthoredBy(activeDomain)) 1 else 0

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationMessageBump.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationMessageBump.kt
@@ -17,12 +17,35 @@ import kotlin.uuid.Uuid
  * last message left every denormalised field unchanged). Returns the
  * new list otherwise.
  *
- * Three cases on the message's `userDate` vs the conversation's current
- * `latestMessageTimestamp`:
+ * A **status message** (`dataType = 202` — group rename, photo update,
+ * member add/remove) is not a last message and returns null outright.
+ * The cold-load / post-`DriveSync.Stopped` enrichment path
+ * ([ConversationMapper.applyLastMessage]) is fed by
+ * `selectAllConversationPlusLastMessage`, whose last-message subquery
+ * excludes `dataType = 202`, so a status message contributes nothing to
+ * the row there. Letting it drive the preview and the sort key here made
+ * the same conversation render differently before and after a restart —
+ * *"You updated the conversation photo"* at the top of the list live,
+ * the newest real message further down after a cold start (#1153).
+ * These two functions are the sole owners of the row's last-message
+ * fields (see the "Message-preview ownership" note on
+ * [mergeConversationFileUpdate]), so they have to agree.
+ *
+ * The exclusion can't move the other way — into the SQL — because status
+ * visibility is decided in Kotlin from *decrypted* content that SQL
+ * cannot read: `mapToMessageData` drops a peer-authored
+ * `GroupHealLocalCleanup`, an emergency-locate notice still inside its
+ * embargo window, and any soft-deleted status message. A JOIN that
+ * returned those would hand `applyLastMessage` a null map and leave the
+ * row on `mapToBasic`'s `" "` placeholder — the exact "No messages yet"
+ * blank that #1148 fixed.
+ *
+ * Three cases on a non-status message's `userDate` vs the conversation's
+ * current `latestMessageTimestamp`:
  *
  *  - **newer (`>`)** — a genuinely new last message. Advance the
  *    timestamp, refresh the preview, and bump unread (non-self,
- *    non-edit, non-status).
+ *    non-edit).
  *  - **equal (`==`)** — a re-emit of the *current* last message
  *    (soft-delete, delivery-status change, or reaction fan-out; a
  *    reaction re-emit carries the original `userDate` because reactions
@@ -78,8 +101,14 @@ internal fun applyIncomingMessageBump(
     sqlUserDate: Instant,
     activeDomain: OdinId?,
 ): List<ConversationUiModel>? {
-    val increment =
-        if (!m.isEdited && !m.isAuthoredBy(activeDomain) && !m.isStatusMessage) 1 else 0
+    // A status message is not a last message. Cold-load enrichment can never
+    // surface one (`selectAllConversationPlusLastMessage` filters
+    // `dataType != 202`), so neither may we, or the row changes on restart
+    // (#1153). Covers both the strictly-newer branch and the same-userDate
+    // re-emit below.
+    if (m.isStatusMessage) return null
+
+    val increment = if (!m.isEdited && !m.isAuthoredBy(activeDomain)) 1 else 0
 
     // Denormalised last-message preview fields, recomputed from `m`. Shared by
     // the "new message" and "same-userDate re-emit" branches so the preview is
@@ -104,7 +133,7 @@ internal fun applyIncomingMessageBump(
         when {
             // Strictly newer → a genuinely new last message. Advance the
             // timestamp, refresh the preview and bump unread (for non-self,
-            // non-edit, non-status arrivals).
+            // non-edit arrivals).
             sqlUserDate > existing.latestMessageTimestamp -> {
                 didChange = true
                 val next = existing
@@ -123,7 +152,7 @@ internal fun applyIncomingMessageBump(
                     "bump convo=$targetConversationId sqlUserDateMs=${sqlUserDate.toEpochMilliseconds()} " +
                         "originalAuthor=${m.originalAuthor?.domainName ?: "null"} " +
                         "isAuthoredBy(self)=${m.isAuthoredBy(activeDomain)} " +
-                        "isEdited=${m.isEdited} isStatusMessage=${m.isStatusMessage} " +
+                        "isEdited=${m.isEdited} " +
                         "increment=$increment unreadCount=${next.unreadCount}"
                 }
                 next

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/data/ConversationUiModelUpdateWithLatestMessageTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/data/ConversationUiModelUpdateWithLatestMessageTest.kt
@@ -122,13 +122,17 @@ class ConversationUiModelUpdateWithLatestMessageTest {
     }
 
     /**
-     * #1148 — a status message ("You updated the conversation photo") advances
-     * `latestMessageTimestamp` and gets that value persisted into `localAppData`,
+     * #1148 — a status message ("You updated the conversation photo") used to advance
+     * `latestMessageTimestamp` and get that value persisted into `localAppData`,
      * but `selectAllConversationPlusLastMessage` excludes `dataType = 202`. Cold-load
      * enrichment therefore arrives with a message OLDER than the seeded sort key; the
      * old `candidate >= latestMessageTimestamp` guard rejected it and the row kept
      * `mapToBasic`'s `" "` placeholder, rendering "No messages yet" beside a correct
      * timestamp. The preview must apply anyway; the sort key must not regress.
+     *
+     * #1153 stopped the live path advancing the sort key for status messages, but the
+     * seed is monotonic and owner-synced, so a value stamped by an older build (or by
+     * another of the owner's devices still on one) persists. This stays a live case.
      */
     @Test
     fun appliesPreview_whenSeedTimestampIsNewerThanEnrichmentMessage() {

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/ConversationMessageBumpTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/ConversationMessageBumpTest.kt
@@ -185,6 +185,12 @@ class ConversationMessageBumpTest {
         assertEquals(5, updated.first().unreadCount)
     }
 
+    /**
+     * A status message never bumps unread — and since #1153 it doesn't touch
+     * the row at all (no preview, no sort-key advance), because the cold-load
+     * enrichment path can't surface one either. Full parity coverage lives in
+     * [StatusMessagePreviewParityTest].
+     */
     @Test
     fun statusMessage_doesNotBumpUnread() {
         val items = listOf(convo(unread = 5))
@@ -198,8 +204,8 @@ class ConversationMessageBumpTest {
             activeDomain = me,
         )
 
-        assertNotNull(updated)
-        assertEquals(5, updated.first().unreadCount)
+        assertNull(updated)
+        assertEquals(5, items.first().unreadCount)
     }
 
     @Test

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/StatusMessagePreviewParityTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/StatusMessagePreviewParityTest.kt
@@ -1,0 +1,249 @@
+package id.homebase.chat.services.convo
+
+import id.homebase.api.client.KeyHeader
+import id.homebase.api.common.OdinId
+import id.homebase.api.common.time.UnixTimeUtc
+import id.homebase.chat.data.ConversationState
+import id.homebase.chat.data.ConversationUiModel
+import id.homebase.chat.data.ConversationUiModel.Companion.updateWithLatestMessage
+import id.homebase.chat.data.MessageUiModel
+import id.homebase.chat.services.MessageAppData
+import id.homebase.core.avatars.ConversationAvatarModel
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.time.Instant
+import kotlin.uuid.Uuid
+
+/**
+ * #1153 — the conversation-list row for a thread whose newest item is a
+ * **status message** (`dataType = 202`: group rename, photo update, member
+ * add/remove) must look the same however the row was populated.
+ *
+ * Two independent paths own the row's last-message fields (see the
+ * "Message-preview ownership" section of [mergeConversationFileUpdate]):
+ *
+ *  - **live arrival** — [applyIncomingMessageBump], driven by a WS push.
+ *  - **cold start / post-`DriveSync.Stopped` enrichment** —
+ *    [ConversationMapper.mapToBasic] + [ConversationMapper.applyLastMessage],
+ *    fed by `selectAllConversationPlusLastMessage`, which **excludes**
+ *    `dataType = 202`.
+ *
+ * Before the fix the live path called `withPreviewOf()` unconditionally on
+ * its strictly-newer branch and set `latestMessageTimestamp = sqlUserDate`,
+ * so a status message set the preview to *"You updated the conversation
+ * photo"* and floated the row to the top — while a restart re-derived the
+ * same row from SQL and showed the newest **real** message instead, at that
+ * message's timestamp. Same conversation, same data, two different rows.
+ *
+ * These tests exercise both paths as the pure functions they are (no DB, no
+ * Koin, no coroutines) and assert the resulting rows are identical.
+ */
+class StatusMessagePreviewParityTest {
+
+    private val me = OdinId("owner.test")
+    private val alice = OdinId("alice.test")
+    private val convoId = Uuid.parse("33333333-3333-3333-3333-333333333333")
+
+    /** `fileMetadata.created` of the conversation file — mapToBasic's sort-key fallback. */
+    private val conversationCreatedMs = 500L
+
+    /** Newest real (`dataType = 0`) message: the only thing the SQL JOIN can return. */
+    private val realMessageMs = 1_000L
+
+    /** Group-photo update, authored by us, arriving after the real message. */
+    private val statusMessageMs = 2_000L
+
+    /**
+     * What [ConversationMapper.mapToBasic] produces: identity + membership, the
+     * `" "` last-message placeholder, `unreadCount = 0`, and the sort key seeded
+     * from the persisted `localAppData.latestMessageTimestamp` — falling back to
+     * `metadata.created` when the lastRead writeback has never flushed for this
+     * thread (the common case for a thread the user hasn't opened).
+     */
+    private fun basicRow(sortKeyMs: Long = conversationCreatedMs) = ConversationUiModel(
+        id = convoId,
+        name = "the group",
+        lastMessage = " ",
+        latestMessageTimestamp = Instant.fromEpochMilliseconds(sortKeyMs),
+        unreadCount = 0,
+        avatarInitials = "",
+        avatarUrl = "",
+        avatarTiny = null,
+        participants = listOf(me, alice),
+        lastRead = Instant.fromEpochMilliseconds(0),
+        avatarModel = ConversationAvatarModel(type = ConversationAvatarModel.Type.GroupFallback),
+        admins = setOf(me),
+        conversationState = ConversationState.Active,
+        isGroup = true,
+        fileCreated = Instant.fromEpochMilliseconds(conversationCreatedMs),
+    )
+
+    private fun message(
+        author: OdinId,
+        userDateMs: Long,
+        content: String,
+        isStatusMessage: Boolean = false,
+    ) = MessageUiModel(
+        id = Uuid.random(),
+        globalTransitId = null,
+        fileId = Uuid.random(),
+        conversationId = convoId,
+        content = content,
+        userDate = Instant.fromEpochMilliseconds(userDateMs),
+        modified = null,
+        created = Instant.fromEpochMilliseconds(userDateMs),
+        originalAuthor = author,
+        sender = author,
+        displayName = author.domainName,
+        localReadTimestamp = null as UnixTimeUtc?,
+        isEdited = false,
+        isDeleted = false,
+        isPendingSend = false,
+        isStatusMessage = isStatusMessage,
+        versionTag = Uuid.NIL,
+        messageAppData = MessageAppData(),
+        reactionPreview = null,
+        previewThumbnail = null,
+        payloads = null,
+        keyHeader = KeyHeader.empty(),
+        hasMore = false,
+    )
+
+    private val realMessage =
+        message(author = alice, userDateMs = realMessageMs, content = "see you tomorrow")
+
+    private val statusMessage = message(
+        author = me,
+        userDateMs = statusMessageMs,
+        content = "You updated the conversation photo",
+        isStatusMessage = true,
+    )
+
+    private fun bump(
+        items: List<ConversationUiModel>,
+        m: MessageUiModel,
+        sqlUserDateMs: Long,
+    ) = applyIncomingMessageBump(
+        items = items,
+        targetConversationId = convoId,
+        m = m,
+        sqlUserDate = Instant.fromEpochMilliseconds(sqlUserDateMs),
+        activeDomain = me,
+    )
+
+    /**
+     * LIVE — app in the foreground: the real message arrives over the WS, then
+     * the group-photo status message arrives.
+     */
+    private fun liveRow(): ConversationUiModel {
+        val afterReal = bump(listOf(basicRow()), realMessage, realMessageMs)
+        assertNotNull(afterReal, "a real peer message must change the row")
+        val afterStatus = bump(afterReal, statusMessage, statusMessageMs)
+        return (afterStatus ?: afterReal).single()
+    }
+
+    /**
+     * COLD START — same thread, same two files on disk, app restarted.
+     *
+     * `mapToBasic` seeds the placeholder row, `enrichWithLastMessages` runs
+     * `selectAllConversationPlusLastMessage` (which can only ever hand back the
+     * real message — `dataType != 202`) and patches it via `applyLastMessage`,
+     * and `enrichAllConversationsWithUnreadCounts` recounts unread from
+     * `selectAllUnreadCount`.
+     *
+     * @param sortKeyMs the persisted `localAppData.latestMessageTimestamp`, or
+     *   `metadata.created` when the lastRead writeback never flushed.
+     * @param unreadCount what `selectAllUnreadCount` returns. That query filters
+     *   `dataType = 0`, so the status message contributes nothing — exactly
+     *   matching the live path's `!m.isStatusMessage` increment gate. Only
+     *   alice's real message counts.
+     */
+    private fun coldStartRow(
+        sortKeyMs: Long = conversationCreatedMs,
+        unreadCount: Int = 1,
+    ): ConversationUiModel = basicRow(sortKeyMs)
+        .updateWithLatestMessage(
+            msg = realMessage,
+            activeUserDomain = me,
+            latestTimestampOverrideMs = realMessageMs,
+        )
+        .copy(unreadCount = unreadCount)
+
+    /**
+     * THE parity guard. Every field of the row — preview text, sender,
+     * delivery/payload flags and the `latestMessageTimestamp` sort key — must
+     * match between a live status-message arrival and a cold start over the
+     * same two files.
+     */
+    @Test
+    fun liveArrival_andColdStart_produceIdenticalRow_whenNewestItemIsAStatusMessage() {
+        assertEquals(coldStartRow(), liveRow())
+    }
+
+    /**
+     * Same guard for the thread the user *has* opened, so the lastRead
+     * writeback has flushed `localAppData.latestMessageTimestamp` and
+     * `mapToBasic` seeds from it instead of `metadata.created`. The seed can
+     * only ever be the value the live path landed on, so pinning it here keeps
+     * the two seeds honest.
+     */
+    @Test
+    fun liveArrival_andColdStart_produceIdenticalRow_whenSortKeyWasPersisted() {
+        val live = liveRow()
+        val cold = coldStartRow(sortKeyMs = live.latestMessageTimestamp.toEpochMilliseconds())
+        assertEquals(cold, live)
+    }
+
+    /**
+     * The mechanism behind the parity: a status message is not a last message,
+     * so it must leave the conversation row completely alone — no preview, no
+     * sort-key advance (which would float the thread to the top of the list for
+     * no visible reason and then drop it back down on the next restart), no
+     * unread bump.
+     */
+    @Test
+    fun statusMessage_leavesTheRowUntouched() {
+        val withRealMessage = bump(listOf(basicRow()), realMessage, realMessageMs)
+        assertNotNull(withRealMessage)
+
+        assertNull(
+            bump(withRealMessage, statusMessage, statusMessageMs),
+            "a status message must not change the conversation row",
+        )
+    }
+
+    /**
+     * The `sqlUserDate == latestMessageTimestamp` re-emit branch has to be
+     * gated too: a delivery-status or soft-delete re-push of a status message
+     * carries the original `userDate`, and rewriting the preview from it would
+     * reopen the same disagreement through the back door.
+     */
+    @Test
+    fun statusMessageReEmit_atTheCurrentSortKey_leavesTheRowUntouched() {
+        val items = listOf(basicRow(sortKeyMs = statusMessageMs))
+
+        assertNull(
+            bump(items, statusMessage, statusMessageMs),
+            "a status-message re-emit must not change the conversation row",
+        )
+    }
+
+    /**
+     * Guard rail on the gate's scope: only `dataType = 202` is excluded. A
+     * normal message still drives the preview and the sort key on the live
+     * path, which is what `selectAllConversationPlusLastMessage` returns on the
+     * cold path.
+     */
+    @Test
+    fun realMessage_stillDrivesPreviewAndSortKey() {
+        val updated = bump(listOf(basicRow()), realMessage, realMessageMs)
+
+        assertNotNull(updated)
+        val row = updated.single()
+        assertEquals("see you tomorrow", row.lastMessage)
+        assertEquals(realMessageMs, row.latestMessageTimestamp.toEpochMilliseconds())
+        assertEquals(1, row.unreadCount)
+    }
+}


### PR DESCRIPTION
## What disagreed

The conversation-list row for a thread whose newest item is a **status message** (`dataType = 202` — group rename, photo update, member add/remove) was built by two independent paths that owned the same fields and disagreed:

| path | `lastMessage` | `latestMessageTimestamp` |
|---|---|---|
| **live arrival** — `applyIncomingMessageBump` | *"You updated the conversation photo"* | the status message's `userDate` (row floats to the top) |
| **cold start / post-`DriveSync.Stopped`** — `ConversationMapper.applyLastMessage` | the newest **real** message | that message's `userDate` |

`applyIncomingMessageBump` called `withPreviewOf()` on **every** strictly-newer arrival and set `latestMessageTimestamp = sqlUserDate`; only the unread `increment` was gated on `!m.isStatusMessage`. The enrichment path is fed by `selectAllConversationPlusLastMessage`, whose last-message subquery excludes `dataType = 202`.

So the same conversation, over the same two files on disk, rendered a different preview **and** sat in a different list position before and after a restart. Note the issue only called out the preview — the sort key diverges too, and it diverges non-deterministically: `localAppData.latestMessageTimestamp` is only stamped when the lastRead writeback flushes, so whether the cold row inherited the status timestamp depended on whether the user had opened the thread.

Pre-existing. #1151 (#1148) only made it visible by fixing the blank preview that used to mask it.

## Which option, and why not the other

**Option 2 — gate the live path** (`applyIncomingMessageBump` returns `null` for a status message). This covers the strictly-newer branch *and* the same-`userDate` re-emit branch, so preview, sort key and unread are all left alone — the full no-op the SQL already produces. The now-redundant `!m.isStatusMessage` term is dropped from the `increment` expression, leaving one gate rather than two.

**Option 1 — include status messages in the query — was rejected as not implementable correctly at the SQL layer.** Whether a status message is *visible* is decided in Kotlin from **decrypted** content that SQL cannot read. `mapToMessageData` returns `null` for:

- a peer-authored `GroupHealLocalCleanup` marker,
- an emergency-locate notice still inside its embargo window (`emergencyLocateEmbargoUntilMs`),
- any soft-deleted status message.

A JOIN that handed one of those to `applyLastMessage` would get a null map back, `applyLastMessage` returns its input unchanged, and the row stays on `mapToBasic`'s `" "` placeholder — reintroducing the exact *"No messages yet"* blank that #1148 fixed. Doing option 1 properly needs a candidate-list query plus a first-mappable-wins loop, which also gives up the single index seek per conversation that `idx_unread_cover` exists to provide. Not worth it for a preview line.

A comment now sits on the `.sq` query explaining that `m2.dataType != 202` and the Kotlin gate are twins, so the exclusion isn't "fixed" later on its own.

The orphan-placeholder branch in `ConversationStream` (`matchingConversation == null`) is deliberately untouched: it builds a row for a conversation whose header hasn't synced, which by definition has no cold-load counterpart, and gating it would hide the thread entirely.

## What the test pins

`StatusMessagePreviewParityTest` (new, `homebase-chat/src/jvmTest`) runs both paths as the pure functions they are — no DB, no Koin, no coroutines — over the same two message files, and asserts **full `ConversationUiModel` equality**, not just matching preview text:

- `liveArrival_andColdStart_produceIdenticalRow_whenNewestItemIsAStatusMessage` — cold seed from `metadata.created` (writeback never flushed). Failed on both `lastMessage` and `latestMessageTimestamp` before the fix.
- `liveArrival_andColdStart_produceIdenticalRow_whenSortKeyWasPersisted` — cold seed from the persisted `localAppData` sort key. Failed on `lastMessage`.
- `statusMessage_leavesTheRowUntouched` — the mechanism: no preview, no sort-key advance, no unread bump.
- `statusMessageReEmit_atTheCurrentSortKey_leavesTheRowUntouched` — the `sqlUserDate == latestMessageTimestamp` re-emit branch is gated too, so a delivery-status re-push can't reopen the disagreement.
- `realMessage_stillDrivesPreviewAndSortKey` — guard rail on the gate's scope; this one passed before and after.

Four of the five failed before the change. `ConversationMessageBumpTest.statusMessage_doesNotBumpUnread` was updated to the stronger contract (`assertNull`), and two kdocs that described the old behaviour as current were corrected — including the `updateWithLatestMessage` one, which explains why its preview stays unconditional: the seed is stamped monotonically (`UnixTimeUtc.later`) into owner-synced `localAppData`, so a status-derived value written by an older build, or by another of the owner's devices still on one, never goes away.

## Verification

```
./gradlew homebase-chat:jvmTest homebase-auth:jvmTest homebase-common:jvmTest homebase-api:jvmTest --rerun-tasks
BUILD SUCCESSFUL in 2m 3s
```

2648 tests, 0 failures (homebase-chat 1051 / homebase-api 1119 / homebase-common 464 / homebase-auth 14).

Per-module compile checks for both touched modules, all green:

```
./gradlew :homebase-api:compileKotlinJvm :homebase-api:compileAndroidMain \
          :homebase-api:compileKotlinWasmJs :homebase-api:compileKotlinIosSimulatorArm64 \
          :homebase-chat:compileAndroidMain :homebase-chat:compileKotlinWasmJs \
          :homebase-chat:compileKotlinIosSimulatorArm64
BUILD SUCCESSFUL in 59s
```

SQLDelight codegen + migration verification re-run from scratch on the edited `.sq` (comment-only edit; generated `ChatReadCountQueries.kt` still carries `AND m2.dataType != 202`):

```
./gradlew :homebase-api:generateSqlDelightInterface :homebase-api:verifySqlDelightMigration --rerun-tasks
BUILD SUCCESSFUL in 4s
```

## Device-verified (Redmi Note 5 Pro, whyred, AOSP A11 / SDK 30)

Same device, same conversation, same data, A/B across the two builds. Test group `Introz`
(members `frodo.baggins.demo.rocks`, `yes.web.demo.rocks`, `no.web.demo.rocks`), renamed while
the app was foregrounded to emit a title-change status message as the newest item, then
force-stopped and relaunched.

**Before (`origin/main`)**

| path | preview | timestamp | list position |
|---|---|---|---|
| live arrival | `You: You updated the conversation tit…` | Just now | 1 |
| cold start | `No messages yet` | Yesterday | 2 |

**After (this branch)**

| path | preview | timestamp | list position |
|---|---|---|---|
| baseline, pre-rename | `No messages yet` | Yesterday | 2 |
| live arrival | `No messages yet` | Yesterday | 2 |
| cold start | `No messages yet` | Yesterday | 2 |

The pre-fix row changed **position as well as text**, confirming the sort key had diverged too
and not just the preview — a `withPreviewOf()`-only gate would have left the row jumping to the
top with an unchanged preview.

The conversation itself still renders both status messages under Today, so the row is ignoring
them rather than failing to receive them.

Not verified on iOS.

Fixes #1153

🤖 Generated with [Claude Code](https://claude.com/claude-code)
