### PR TITLE
docs: when to use stacked PRs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -247,6 +247,29 @@ GitHub Actions workflows in `.github/workflows/`:
 
 Do NOT use slash (/) in Git branch names
 
+## Stacked PRs
+
+GitHub's native stacked pull requests: an ordered chain where each branch targets the branch
+below it instead of `main`, so each layer is reviewed on its own diff and the stack merges
+atomically. Driven by `gh extension install github/gh-stack` — run `gh stack --help`.
+
+Use a stack only when:
+
+- A single PR has grown too big to review in one sitting and splits cleanly into layers.
+- The work spans `homebase-api` → `homebase-chat`/`homebase-common` → `homebase-core` and the
+  upper layers can't compile without the lower ones.
+
+Otherwise open one normal PR. Two independent bugfixes are two PRs, not a stack.
+
+Rules:
+
+- Bottom layers first: API/schema/instrumentation below, the feature that consumes them above.
+- Every layer must be correct on its own — `main` stays green if the layers above never merge.
+- If two layers can only be reviewed together, they're one PR.
+- Work blocked on an undecided question is a separate issue, not a stack layer.
+- CI must be green on every layer before merging — the stack merge is all-or-nothing.
+- Branch names still must not contain `/`.
+
 ## UI & Design Quality
 
 All UI code must follow **Material 3** guidelines and the **kmp-compose-multiplatform** skill. Before


### PR DESCRIPTION
Adds a short CLAUDE.md section on GitHub's native stacked pull requests, which went to public preview on 2026-07-30.

The point of the section is the **scoping rule**, not the tooling. Stacks are easy to over-apply — the first thing I did with them was split a two-bugfix issue into a stack, which was wrong. So the rule names the two cases where they actually earn their overhead:

- a single PR has grown too big to review in one sitting and splits cleanly into layers;
- the work spans `homebase-api` → `homebase-chat`/`homebase-common` → `homebase-core` and the upper layers genuinely can't compile without the lower ones.

Everything else stays one normal PR. Two independent bugfixes are two PRs, not a stack.

Plus five rules: bottom layers first, every layer correct on its own so `main` stays green if the ones above never merge, layers that can only be reviewed together are one PR, work blocked on an undecided question is a separate issue rather than a stack layer, and CI green on every layer before merging because the stack merge is all-or-nothing.

Deliberately no command table — `gh stack --help` covers that and would only go stale here. The extension is `gh extension install github/gh-stack`; verified working on gh 2.72.0.

Docs only, no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)