### PR TITLE
fix(chat): a message that lands while a conversation is archived unarchives it (#1145)

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/data/ConversationUiModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/data/ConversationUiModel.kt
@@ -57,6 +57,8 @@ data class ConversationUiModel(
     val isGroup: Boolean = false,
     val isLegacyGroup: Boolean = false,
     val exitedAt: Instant? = null,
+    /** Null unless archived, and on threads archived before the stamp existed (#1145). */
+    val archivedAt: Instant? = null,
     /** Server-stamped last-modified time of the conversation file (fileMetadata.updated). */
     val fileUpdated: Instant = Instant.fromEpochMilliseconds(0),
     /**

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/data/ConversationUiModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/data/ConversationUiModel.kt
@@ -57,7 +57,7 @@ data class ConversationUiModel(
     val isGroup: Boolean = false,
     val isLegacyGroup: Boolean = false,
     val exitedAt: Instant? = null,
-    /** Null unless archived, and on threads archived before the stamp existed (#1145). */
+    /** Null unless archived, and on threads archived before the stamp existed. */
     val archivedAt: Instant? = null,
     /** Server-stamped last-modified time of the conversation file (fileMetadata.updated). */
     val fileUpdated: Instant = Instant.fromEpochMilliseconds(0),

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/AutoUnarchive.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/AutoUnarchive.kt
@@ -2,6 +2,7 @@ package id.homebase.chat.services.convo
 
 import id.homebase.chat.data.ConversationState
 import kotlin.time.Instant
+import kotlin.uuid.Uuid
 
 /**
  * Cold half of auto-unarchive: decides from persisted state alone, so it still
@@ -25,3 +26,17 @@ internal fun shouldAutoUnarchive(
         archivedAt != null &&
         !lastMessageIsFromActiveUser &&
         lastMessageUserDate > archivedAt
+
+/**
+ * Dedup for the cold half. It runs on every sync `Stopped` and on every cold
+ * start, so a tag removal that never reaches the local row would otherwise
+ * re-fire — and re-enqueue — on every pass. Keyed on the baseline rather than
+ * the id alone, so a later re-archive stamps a fresh [Instant] and re-opens the
+ * gate. Session-scoped, like `ConversationStream.recoveryAttemptedIds`.
+ */
+internal class AutoUnarchiveGate {
+    private val fired = mutableMapOf<Uuid, Instant>()
+
+    fun markFired(conversationId: Uuid, archivedAt: Instant): Boolean =
+        fired.put(conversationId, archivedAt) != archivedAt
+}

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/AutoUnarchive.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/AutoUnarchive.kt
@@ -4,9 +4,9 @@ import id.homebase.chat.data.ConversationState
 import kotlin.time.Instant
 
 /**
- * Cold half of auto-unarchive (#1145): decides from persisted state alone, so it
- * still fires after a restart or a silent DriveSync catch-up — neither of which
- * emits the `BatchReceived` the live half in
+ * Cold half of auto-unarchive: decides from persisted state alone, so it still
+ * fires after a restart or a silent DriveSync catch-up — neither of which emits
+ * the `BatchReceived` the live half in
  * `ConversationStream.processMessageBatchIncrementally` listens for.
  *
  * Callers must pass the last message from `selectAllConversationPlusLastMessage`,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/AutoUnarchive.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/AutoUnarchive.kt
@@ -1,0 +1,27 @@
+package id.homebase.chat.services.convo
+
+import id.homebase.chat.data.ConversationState
+import kotlin.time.Instant
+
+/**
+ * Cold half of auto-unarchive (#1145): decides from persisted state alone, so it
+ * still fires after a restart or a silent DriveSync catch-up — neither of which
+ * emits the `BatchReceived` the live half in
+ * `ConversationStream.processMessageBatchIncrementally` listens for.
+ *
+ * Callers must pass the last message from `selectAllConversationPlusLastMessage`,
+ * which excludes `dataType = 202`, so a group rename can't unarchive a thread.
+ *
+ * A null [archivedAt] means the thread was archived before the stamp existed;
+ * with no baseline every message looks new, so those are left alone.
+ */
+internal fun shouldAutoUnarchive(
+    state: ConversationState,
+    archivedAt: Instant?,
+    lastMessageUserDate: Instant,
+    lastMessageIsFromActiveUser: Boolean,
+): Boolean =
+    state == ConversationState.Archived &&
+        archivedAt != null &&
+        !lastMessageIsFromActiveUser &&
+        lastMessageUserDate > archivedAt

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationLocalAppDataJson.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationLocalAppDataJson.kt
@@ -17,6 +17,12 @@ data class ConversationLocalAppDataJson(
     val lastReadTime: UnixTimeUtc? = null,
     val lastExitedAt: UnixTimeUtc? = null,
     /**
+     * Baseline for auto-unarchive (#1145); null on threads archived before this
+     * field existed. `fileMetadata.updated` can't stand in — `updateLocalTags`
+     * stamps `updated + 1ms`, a version counter, not a wall clock.
+     */
+    val archivedAt: UnixTimeUtc? = null,
+    /**
      * Sort key for the conversation list: the userDate of the most recent
      * message known the last time this conversation was stamped. It rides
      * along with the [lastReadTime] writeback (no separate push), so it is

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationLocalAppDataJson.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationLocalAppDataJson.kt
@@ -17,9 +17,9 @@ data class ConversationLocalAppDataJson(
     val lastReadTime: UnixTimeUtc? = null,
     val lastExitedAt: UnixTimeUtc? = null,
     /**
-     * Baseline for auto-unarchive (#1145); null on threads archived before this
-     * field existed. `fileMetadata.updated` can't stand in — `updateLocalTags`
-     * stamps `updated + 1ms`, a version counter, not a wall clock.
+     * Baseline for auto-unarchive; null on threads archived before this field
+     * existed. `fileMetadata.updated` can't stand in — `updateLocalTags` stamps
+     * `updated + 1ms`, a version counter, not a wall clock.
      */
     val archivedAt: UnixTimeUtc? = null,
     /**

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationMapper.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationMapper.kt
@@ -236,6 +236,9 @@ class ConversationMapper(
                     isGroup = isGroup,
                     isLegacyGroup = isLegacyGroup,
                     exitedAt = exitedAt,
+                    archivedAt = if (conversationState == ConversationState.Archived) {
+                        localAppData?.archivedAt?.toInstant()
+                    } else null,
                     fileUpdated = metadata.updated.toInstant(),
                     fileCreated = metadata.created.toInstant(),
                 )

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationService.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationService.kt
@@ -1687,10 +1687,18 @@ class ConversationService(
         val audit = MethodAudit("archiveConversation")
         audit.start("conversationId=$conversationId")
         try {
+            stampArchivedAt(conversationId, UnixTimeUtc())
             updateConversationTags(conversationId) { it + ChatProtocol.ConversationArchivedTag }
             audit.finish()
         } catch (e: Throwable) { audit.threw("execution", e); audit.finish("threw"); throw e }
         // ---- end DEBUG ----
+    }
+
+    /** Cleared on unarchive so a re-archive whose stamp fails falls back to
+     *  "never auto-unarchive" instead of a stale timestamp. */
+    private suspend fun stampArchivedAt(conversationId: Uuid, at: UnixTimeUtc?) {
+        optimisticWriter.stampConversationArchivedAt(chatDrive, conversationId, at)
+            ?.let { outboxSync.tryEnqueue(it) }
     }
 
     suspend fun unarchiveConversation(conversationId: Uuid) {
@@ -1698,6 +1706,7 @@ class ConversationService(
         val audit = MethodAudit("unarchiveConversation")
         audit.start("conversationId=$conversationId")
         try {
+            stampArchivedAt(conversationId, null)
             updateConversationTags(conversationId) { it - ChatProtocol.ConversationArchivedTag }
             audit.finish()
         } catch (e: Throwable) { audit.threw("execution", e); audit.finish("threw"); throw e }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
@@ -503,8 +503,7 @@ class ConversationStream(
 
             // region Auto-unarchive: Signal-style unarchive on incoming message
             if (matchingConversation?.conversationState == ConversationState.Archived) {
-                // Only unarchive for messages from others, not our own synced messages.
-                // A status message (rename, join, leave) is not re-engagement (#1145).
+                // A status message (rename, join, leave) is not re-engagement.
                 if (!m.isStatusMessage && !m.isAuthoredBy(credentialsManager.getActiveDomain())) {
                     Logger.i("ConversationStream: unarchiving conversation ${m.conversationId} due to incoming message from ${m.originalAuthor}")
                     val unarchived = matchingConversation.copy(

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
@@ -503,10 +503,14 @@ class ConversationStream(
 
             // region Auto-unarchive: Signal-style unarchive on incoming message
             if (matchingConversation?.conversationState == ConversationState.Archived) {
-                // Only unarchive for messages from others, not our own synced messages
-                if (!m.isAuthoredBy(credentialsManager.getActiveDomain())) {
+                // Only unarchive for messages from others, not our own synced messages.
+                // A status message (rename, join, leave) is not re-engagement (#1145).
+                if (!m.isStatusMessage && !m.isAuthoredBy(credentialsManager.getActiveDomain())) {
                     Logger.i("ConversationStream: unarchiving conversation ${m.conversationId} due to incoming message from ${m.originalAuthor}")
-                    val unarchived = matchingConversation.copy(conversationState = ConversationState.Active)
+                    val unarchived = matchingConversation.copy(
+                        conversationState = ConversationState.Active,
+                        archivedAt = null,
+                    )
                     _conversations.value = _conversations.value.copy(
                         items = _conversations.value.items.map { if (it.id == unarchived.id) unarchived else it }
                     )
@@ -1151,15 +1155,39 @@ class ConversationStream(
         }
 
         val current = _conversations.value
+        val toUnarchive = ArrayList<Uuid>()
         val updated = current.items.map { ui ->
             val pair = msgByConversation[ui.id] ?: return@map ui
-            mapper.applyLastMessage(ui, pair.first, domain, sqlUserDateMs = pair.second)
+            val patched = mapper.applyLastMessage(ui, pair.first, domain, sqlUserDateMs = pair.second)
+            val shouldUnarchive = shouldAutoUnarchive(
+                state = patched.conversationState,
+                archivedAt = patched.archivedAt,
+                lastMessageUserDate = pair.second
+                    ?.let { Instant.fromEpochMilliseconds(it) }
+                    ?: patched.latestMessageTimestamp,
+                lastMessageIsFromActiveUser = patched.lastMessageIsFromActiveUser,
+            )
+            if (!shouldUnarchive) return@map patched
+            toUnarchive += ui.id
+            patched.copy(conversationState = ConversationState.Active, archivedAt = null)
         }
 
         _conversations.value = current.copy(
             items = updated,
             enrichment = current.enrichment.copy(hasLastMessages = true),
         )
+
+        for (id in toUnarchive) {
+            Logger.i("ConversationStream: auto-unarchiving $id — message arrived after it was archived")
+            try {
+                onUnarchiveConversation?.invoke(id)
+            } catch (e: kotlinx.coroutines.CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                // Never let one bad conversation file abort the enrichment pass.
+                Logger.e(e) { "ConversationStream: failed to auto-unarchive $id: ${e.message}" }
+            }
+        }
 
         Logger.i(tag = "ConvListPerf") {
             "enrichWithLastMessages end-to-end=${Clock.System.now().toEpochMilliseconds() - startedAt}ms " +

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
@@ -169,6 +169,8 @@ class ConversationStream(
     /** Called when a message arrives for an archived conversation.
      *  Wired in AppModule to ConversationService.unarchiveConversation(). */
     var onUnarchiveConversation: (suspend (conversationId: Uuid) -> Unit)? = null
+
+    private val autoUnarchiveGate = AutoUnarchiveGate()
     // endregion
 
     // region Unread-count dirty bits
@@ -1154,20 +1156,21 @@ class ConversationStream(
         }
 
         val current = _conversations.value
-        val toUnarchive = ArrayList<Uuid>()
+        val toUnarchive = ArrayList<Pair<Uuid, Instant>>()
         val updated = current.items.map { ui ->
             val pair = msgByConversation[ui.id] ?: return@map ui
             val patched = mapper.applyLastMessage(ui, pair.first, domain, sqlUserDateMs = pair.second)
-            val shouldUnarchive = shouldAutoUnarchive(
-                state = patched.conversationState,
-                archivedAt = patched.archivedAt,
-                lastMessageUserDate = pair.second
-                    ?.let { Instant.fromEpochMilliseconds(it) }
-                    ?: patched.latestMessageTimestamp,
-                lastMessageIsFromActiveUser = patched.lastMessageIsFromActiveUser,
-            )
-            if (!shouldUnarchive) return@map patched
-            toUnarchive += ui.id
+            val archivedAt = patched.archivedAt
+            if (archivedAt == null || !shouldAutoUnarchive(
+                    state = patched.conversationState,
+                    archivedAt = archivedAt,
+                    lastMessageUserDate = pair.second
+                        ?.let { Instant.fromEpochMilliseconds(it) }
+                        ?: patched.latestMessageTimestamp,
+                    lastMessageIsFromActiveUser = patched.lastMessageIsFromActiveUser,
+                )
+            ) return@map patched
+            toUnarchive += ui.id to archivedAt
             patched.copy(conversationState = ConversationState.Active, archivedAt = null)
         }
 
@@ -1176,7 +1179,8 @@ class ConversationStream(
             enrichment = current.enrichment.copy(hasLastMessages = true),
         )
 
-        for (id in toUnarchive) {
+        for ((id, baseline) in toUnarchive) {
+            if (!autoUnarchiveGate.markFired(id, baseline)) continue
             Logger.i("ConversationStream: auto-unarchiving $id — message arrived after it was archived")
             try {
                 onUnarchiveConversation?.invoke(id)

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/outbox/OptimisticWriter.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/outbox/OptimisticWriter.kt
@@ -700,6 +700,15 @@ class OptimisticWriter(
             it.copy(lastExitedAt = UnixTimeUtc())
         }
 
+    suspend fun stampConversationArchivedAt(
+        driveId: Uuid,
+        conversationId: Uuid,
+        archivedAt: UnixTimeUtc?,
+    ): UpdateLocalAppdataContentOutboxRequest? =
+        stampConversationLocalAppData(driveId, conversationId, "stampConversationArchivedAt") {
+            it.copy(archivedAt = archivedAt)
+        }
+
     suspend fun stampConversationLastReadTime(
         driveId: Uuid,
         conversationId: Uuid,

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/AutoUnarchiveTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/AutoUnarchiveTest.kt
@@ -7,9 +7,9 @@ import kotlin.test.assertTrue
 import kotlin.time.Instant
 
 /**
- * Locks the cold-path half of auto-unarchive (#1145). The live WS path was
- * already covered; the bug was that DriveSync — FCM cold-wake, reconnect
- * catch-up — writes message rows silently, so nothing re-evaluated the archive.
+ * Locks the cold-path half of auto-unarchive. The live WS path was already
+ * covered; the bug was that DriveSync — FCM cold-wake, reconnect catch-up —
+ * writes message rows silently, so nothing re-evaluated the archive.
  */
 class AutoUnarchiveTest {
 

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/AutoUnarchiveTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/AutoUnarchiveTest.kt
@@ -2,9 +2,11 @@ package id.homebase.chat.services.convo
 
 import id.homebase.chat.data.ConversationState
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import kotlin.time.Instant
+import kotlin.uuid.Uuid
 
 /**
  * Locks the cold-path half of auto-unarchive. The live WS path was already
@@ -52,5 +54,45 @@ class AutoUnarchiveTest {
             if (state == ConversationState.Archived) continue
             assertFalse(decide(state = state), "$state must not be flipped to Active")
         }
+    }
+}
+
+/**
+ * The cold half runs on every sync `Stopped` and on every cold start, re-reading
+ * conversation state from the DB each time. If the unarchive write never lands,
+ * the row still reads `Archived` on the next pass — ungated, that re-enqueues an
+ * outbox row every pass, indefinitely.
+ */
+class AutoUnarchiveGateTest {
+
+    private val convoId = Uuid.random()
+    private val archivedAt = Instant.fromEpochMilliseconds(1_000)
+
+    /** 1 = the pass reached `onUnarchiveConversation`, which is what enqueues. */
+    private fun AutoUnarchiveGate.coldPass(at: Instant = archivedAt): Int =
+        if (markFired(convoId, at)) 1 else 0
+
+    @Test
+    fun coldPassRepeatedWhileTheWriteNeverLands_enqueuesOnce() {
+        val gate = AutoUnarchiveGate()
+        val enqueued = (1..5).sumOf { gate.coldPass() }
+        assertEquals(1, enqueued, "a stuck unarchive must not re-enqueue on every sync")
+    }
+
+    @Test
+    fun reArchivingStampsANewBaseline_soTheGateReopens() {
+        val gate = AutoUnarchiveGate()
+        gate.coldPass()
+
+        val reArchivedAt = Instant.fromEpochMilliseconds(5_000)
+        assertEquals(1, gate.coldPass(reArchivedAt), "a thread archived again must still auto-unarchive")
+        assertEquals(0, gate.coldPass(reArchivedAt))
+    }
+
+    @Test
+    fun conversationsAreGatedIndependently() {
+        val gate = AutoUnarchiveGate()
+        assertTrue(gate.markFired(convoId, archivedAt))
+        assertTrue(gate.markFired(Uuid.random(), archivedAt))
     }
 }

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/AutoUnarchiveTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/AutoUnarchiveTest.kt
@@ -1,0 +1,56 @@
+package id.homebase.chat.services.convo
+
+import id.homebase.chat.data.ConversationState
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.time.Instant
+
+/**
+ * Locks the cold-path half of auto-unarchive (#1145). The live WS path was
+ * already covered; the bug was that DriveSync — FCM cold-wake, reconnect
+ * catch-up — writes message rows silently, so nothing re-evaluated the archive.
+ */
+class AutoUnarchiveTest {
+
+    private val archivedAt = Instant.fromEpochMilliseconds(1_000)
+
+    private fun decide(
+        state: ConversationState = ConversationState.Archived,
+        archivedAt: Instant? = this.archivedAt,
+        lastMessageMs: Long = 2_000,
+        fromActiveUser: Boolean = false,
+    ) = shouldAutoUnarchive(
+        state = state,
+        archivedAt = archivedAt,
+        lastMessageUserDate = Instant.fromEpochMilliseconds(lastMessageMs),
+        lastMessageIsFromActiveUser = fromActiveUser,
+    )
+
+    @Test
+    fun messageAfterTheArchive_unarchives() = assertTrue(decide())
+
+    @Test
+    fun messageFromBeforeTheArchive_staysArchived() =
+        assertFalse(decide(lastMessageMs = 999), "archiving a thread must stick")
+
+    @Test
+    fun messageAtExactlyTheArchiveInstant_staysArchived() =
+        assertFalse(decide(lastMessageMs = 1_000))
+
+    @Test
+    fun ourOwnMessage_doesNotUnarchive() =
+        assertFalse(decide(fromActiveUser = true), "the incoming path is a separate trigger from sending")
+
+    @Test
+    fun noBaseline_staysArchived() =
+        assertFalse(decide(archivedAt = null), "pre-stamp threads have no baseline to compare against")
+
+    @Test
+    fun nonArchivedStates_areNeverTouched() {
+        for (state in ConversationState.entries) {
+            if (state == ConversationState.Archived) continue
+            assertFalse(decide(state = state), "$state must not be flipped to Active")
+        }
+    }
+}

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/ConversationServiceLifecycleTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/ConversationServiceLifecycleTest.kt
@@ -344,7 +344,7 @@ class ConversationServiceLifecycleTest {
     //
     // All four route through updateConversationTags. We verify each writes an
     // outbox row via the tag-update path. Archive and unarchive write a second
-    // row for the `archivedAt` baseline in localAppData.content (#1145).
+    // row for the `archivedAt` baseline in localAppData.content.
 
     @Test
     fun archiveConversation_enqueuesTagUpdate() = runTest {

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/ConversationServiceLifecycleTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/ConversationServiceLifecycleTest.kt
@@ -343,7 +343,8 @@ class ConversationServiceLifecycleTest {
     // ---------- archive / unarchive / pin / unpin (tag flips) ----------
     //
     // All four route through updateConversationTags. We verify each writes an
-    // outbox row via the tag-update path.
+    // outbox row via the tag-update path. Archive and unarchive write a second
+    // row for the `archivedAt` baseline in localAppData.content (#1145).
 
     @Test
     fun archiveConversation_enqueuesTagUpdate() = runTest {
@@ -354,7 +355,7 @@ class ConversationServiceLifecycleTest {
 
             service.archiveConversation(convoId)
 
-            assertEquals(1L, fixture.outboxRowCount() - before)
+            assertEquals(2L, fixture.outboxRowCount() - before)
         }
     }
 
@@ -370,7 +371,7 @@ class ConversationServiceLifecycleTest {
 
             service.unarchiveConversation(convoId)
 
-            assertEquals(1L, fixture.outboxRowCount() - before)
+            assertEquals(2L, fixture.outboxRowCount() - before)
         }
     }
 


### PR DESCRIPTION
Closes #1145.

## Correcting the premise

The issue says nothing in the message-receive path touches the archive flag. That was not true when it was written. `ConversationStream.processMessageBatchIncrementally` has flipped an archived conversation back to Active on an incoming message since #299 (9d47235ef, 16 Apr 2026), wired in `AppModule` to `ConversationService.unarchiveConversation`. On the WebSocket push path, auto-unarchive already works on `main`.

So this PR is not "add auto-unarchive". It is two narrower things: cover the sync path, and stop a status message from counting as re-engagement.

## The window that is genuinely broken

That live branch runs on `DataEvent.BatchReceived`, which only the WebSocket push path emits. DriveSync is a silent batched DB write by design (`DriveSync.kt`: "DriveSync is a silent batched DB write") — it upserts headers into `DriveMainIndex` and signals `DriveEvent.Stopped`, with no per-row events. `Stopped` reloads the list from the DB, the `ConversationArchivedTag` is still on the file, and the thread renders Archived again.

The broken set is therefore: **rows that reach `DriveMainIndex` via QueryBatch without a corresponding WS push.** In practice that is a first sync after install or re-login, a cold-wake sync that drains before a socket is up, and any push the socket misses or drops while the sync cursor still picks the row up.

It is *not* "everything delivered by FCM cold-wake, reconnect catch-up, or background sync", which is what an earlier revision of this description claimed. A captured July 2026 log shows the opposite for reconnect: `syncAll` returns 0 records and the rows arrive moments later over WSPush — i.e. much of what looks like offline backlog comes down the path that already works. The fix is still worth making; the blast radius is smaller than the issue implies.

## The fix

**Cold half (new).** `archiveConversation` stamps `archivedAt` into the conversation's owner-synced `localAppData.content`, alongside the existing `lastReadTime` / `lastExitedAt` / `draft`. `enrichWithLastMessages` — which both `start()` and the `DriveEvent.Stopped` handler already run — unarchives any archived thread whose last message is newer than that stamp and isn't ours. Because it reads only persisted state, it also works on a cold start, where an in-memory before/after diff has nothing to compare against.

**Live half (gate only).** The existing WS-push branch now also requires `!m.isStatusMessage`. A group rename or a join/leave is not re-engagement — the issue calls this out explicitly. Nothing else about that branch changes.

**Re-fire gate (new).** The cold half runs on *every* sync `Stopped` and every cold start, re-reading state from the DB each pass. If the unarchive write never reaches the local row — the conversation is missing from `DriveMainIndex`, or `updateConversationTags` throws — the row still reads `Archived` next pass, and an ungated cold half would fire again and enqueue another pair of outbox rows, indefinitely. `AutoUnarchiveGate` dedups per session, the same shape as `ConversationStream.recoveryAttemptedIds`. It keys on the `archivedAt` baseline rather than the conversation id alone, so archiving a thread *again* stamps a fresh baseline and re-opens the gate — a second archive/unarchive cycle in one session still works.

## Why not reuse `fileMetadata.updated` as the baseline

It looks like a free archive timestamp and it isn't. `OptimisticWriter.updateLocalTags` stamps `updated = updated + 1ms` — a version counter, not a wall clock. On a thread untouched for weeks it reads weeks old, so every message already in the DB looks post-archive and **archiving would never stick**. Hence the explicit stamp.

`archivedAt` is cleared on unarchive, so a later re-archive whose stamp write fails degrades to "never auto-unarchive" rather than to a stale timestamp that unarchives on the next sync.

## Known limitation: no backfill for existing archives

There is deliberately no migration that stamps `archivedAt` onto conversations that are already archived when this ships.

`shouldAutoUnarchive` requires a non-null `archivedAt` — with no baseline every message in the DB looks newer than the archive, so a backfill-free `null` is the only safe reading. The consequence: **for a thread archived before this upgrade, the new cold-sync half never fires.** It is inert on those threads, not merely conservative, and it stays inert until the user archives that thread again, which writes the stamp.

Those threads are not left worse off than today: the live WS branch does not consult `archivedAt` at all, so they keep exactly the `main` behaviour — a push-delivered message still unarchives them. They just don't gain the sync-path coverage until they're re-archived.

This is a deliberate scope decision, not an oversight. Recording it here so it isn't later read as a bug.

## Status messages, both paths

Cold path: the last message comes from `selectAllConversationPlusLastMessage`, which excludes `dataType = 202`. Live path: the new `!isStatusMessage` gate. This matches the dual-gate invariant established in #1153.

## Deliberately not done

Sending into an archived conversation still does not unarchive it. The issue lists that as a separate trigger under Open questions.

No "keep chats archived" setting — the issue's own v1 recommendation.

## Verified

- Rebased onto `main` (`1fc3ebee4`), no conflicts. The only new main commit touching a file here is #1397 (`412bad7e9`, optimistic rollback), which rewrote `rollbackWrite` and factored out `optimisticStamp()`; the new `stampConversationArchivedAt` sits in a different region and replayed cleanly.
- `./gradlew homebase-chat:jvmTest homebase-common:jvmTest homebase-api:jvmTest` — green.
- `AutoUnarchiveTest` (6 cases) pins the decision: unarchives after the stamp; **stays archived** for a message from before it, for a message at exactly the stamp instant, for our own message, and with no baseline; never touches a non-Archived state.
- `AutoUnarchiveGateTest` (3 cases) pins the re-fire gate: five cold passes with the write never landing produce one enqueue; a re-archive re-opens the gate; conversations are gated independently.
- Both gate assertions were mutation-checked. Making `markFired` always return true fails `coldPassRepeatedWhileTheWriteNeverLands_enqueuesOnce` and `reArchivingStampsANewBaseline_soTheGateReopens`; keying it on the conversation id alone fails `reArchivingStampsANewBaseline_soTheGateReopens` and nothing else.
- `ConversationServiceLifecycleTest` archive/unarchive assertions updated 1 → 2 outbox rows (the content stamp rides alongside the tag update).
