### PR TITLE
fix(chat): make the double-tap reaction bar reachable and anchor it to the bubble (#1191)

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/Menu.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/Menu.kt
@@ -52,8 +52,13 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInRoot
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.PopupPositionProvider
 import id.homebase.chat.data.MessageUiModel
 import id.homebase.chat.services.content.ActionPolicy
 import id.homebase.core.ui.assets.HomebaseIcons
@@ -310,9 +315,10 @@ fun ReceivedMessagePopup(
 
     when (mode) {
         MessagePopupMode.Reaction -> {
-            // Defensive: this mode is only entered for kinds that allow inline
-            // reactions, so the gate is mostly belt-and-braces.
-            if (policy.allowInlineReactions) {
+            // This unanchored Popup positions against its parent — the hover-icons Row,
+            // which only has icons (and therefore a size) on desktop. Mobile renders the
+            // bar from the bubble itself via BubbleReactionPopup.
+            if (policy.allowInlineReactions && !isMobile()) {
                 Popup(
                     onDismissRequest = dismissMenu
                 ) {
@@ -514,7 +520,8 @@ fun SentMessagePopup(
 
     when (mode) {
         MessagePopupMode.Reaction -> {
-            if (policy.allowInlineReactions) {
+            // Desktop-only anchor — see ReceivedMessagePopup.
+            if (policy.allowInlineReactions && !isMobile()) {
                 Popup(
                     onDismissRequest = dismissMenu
                 ) {
@@ -618,6 +625,63 @@ enum class MessagePopupMode {
     All,
     Reaction,
     Menu,
+}
+
+/**
+ * The compact reaction bar, anchored just above the bubble it belongs to. Declare it as a
+ * child of the layout that wraps the bubble — [PopupPositionProvider.calculatePosition]
+ * receives that parent's bounds as its anchor.
+ */
+@Composable
+fun BubbleReactionPopup(
+    message: MessageUiModel,
+    userDefaultReactions: ImmutableList<String>,
+    alignToBubbleEnd: Boolean,
+    dismissMenu: () -> Unit,
+    onSelectEmoji: (String) -> Unit,
+    onShowAllEmojis: () -> Unit,
+) {
+    val policy = message.messageContent?.actions ?: ActionPolicy.Standard
+    if (!policy.allowInlineReactions) return
+    Popup(
+        popupPositionProvider = rememberAboveBubblePositionProvider(alignToBubbleEnd),
+        onDismissRequest = dismissMenu,
+    ) {
+        ReactionMenu(
+            modifier = Modifier.padding(horizontal = 16.dp),
+            userDefaultReactions = userDefaultReactions,
+            ownReactions = message.ownReactions,
+            onSelect = onSelectEmoji,
+            onShowAllEmojis = onShowAllEmojis,
+        )
+    }
+}
+
+@Composable
+private fun rememberAboveBubblePositionProvider(alignToEnd: Boolean): PopupPositionProvider {
+    val gapPx = with(LocalDensity.current) { 4.dp.roundToPx() }
+    return remember(gapPx, alignToEnd) { AboveBubblePositionProvider(gapPx, alignToEnd) }
+}
+
+internal class AboveBubblePositionProvider(
+    private val gapPx: Int,
+    private val alignToEnd: Boolean,
+) : PopupPositionProvider {
+    override fun calculatePosition(
+        anchorBounds: IntRect,
+        windowSize: IntSize,
+        layoutDirection: LayoutDirection,
+        popupContentSize: IntSize,
+    ): IntOffset {
+        val alignToRightEdge = alignToEnd == (layoutDirection == LayoutDirection.Ltr)
+        val x = if (alignToRightEdge) anchorBounds.right - popupContentSize.width
+        else anchorBounds.left
+        val maxX = (windowSize.width - popupContentSize.width).coerceAtLeast(0)
+        val maxY = (windowSize.height - popupContentSize.height).coerceAtLeast(0)
+        val above = anchorBounds.top - popupContentSize.height - gapPx
+        val y = if (above >= 0) above else (anchorBounds.bottom + gapPx).coerceAtMost(maxY)
+        return IntOffset(x.coerceIn(0, maxX), y)
+    }
 }
 
 @Composable

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubble.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubble.kt
@@ -79,6 +79,7 @@ import id.homebase.chat.services.ChatProtocol
 import id.homebase.chat.services.MessageAppData
 import id.homebase.chat.services.ReplyContext
 import id.homebase.chat.services.ReplyPreview
+import id.homebase.chat.services.content.ActionPolicy
 import id.homebase.chat.services.content.MessageContent
 import id.homebase.core.avatars.AvatarOptions
 import id.homebase.core.avatars.PublicAvatar
@@ -199,6 +200,11 @@ fun SentMessageBubble(
     var bubbleWidthPx by remember { mutableIntStateOf(0) }
     val density = LocalDensity.current
     val haptics = rememberHaptics()
+    val policy = message.messageContent?.actions ?: ActionPolicy.Standard
+    val openReactionBar: (() -> Unit)? =
+        if (onAddReaction != null && policy.allowInlineReactions && !message.isDeleted) {
+            { popupMode = MessagePopupMode.Reaction }
+        } else null
 
     Row(
         modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp)
@@ -335,11 +341,9 @@ fun SentMessageBubble(
                                     popupMode = MessagePopupMode.All
                                 }
                             },
-                            onDoubleClick = {
-                                if (onAddReaction != null) {
-                                    popupMode = MessagePopupMode.Reaction
-                                }
-                            },
+                            // Only reaches the padding around the bubble and the typed kinds
+                            // that paint their own surface; MessageBubbleRaw owns the rest.
+                            onDoubleClick = openReactionBar,
                         )
                     } else Modifier,
                 ) {
@@ -359,6 +363,7 @@ fun SentMessageBubble(
                                 popupMode = MessagePopupMode.All
                             }
                         },
+                        onDoubleClick = openReactionBar,
                         onMediaClick = onMediaClick,
                         onClickMessageId = onClickMessageId,
                         onRequestDecryptedFile = onRequestDecryptedFile,
@@ -387,6 +392,22 @@ fun SentMessageBubble(
                             onReactionClick = { onShowReactions?.invoke() },
                             onAddEmoji = onAddReaction?.let { { popupMode = MessagePopupMode.Reaction } },
                             ownReactions = message.ownReactions,
+                        )
+                    }
+                    if (isMobile() && popupMode == MessagePopupMode.Reaction && !message.isDeleted) {
+                        BubbleReactionPopup(
+                            message = message,
+                            userDefaultReactions = userDefaultReactions,
+                            alignToBubbleEnd = true,
+                            dismissMenu = { popupMode = MessagePopupMode.None },
+                            onSelectEmoji = { reaction ->
+                                popupMode = MessagePopupMode.None
+                                onAddReaction?.invoke(message.id, reaction)
+                            },
+                            onShowAllEmojis = {
+                                popupMode = MessagePopupMode.None
+                                showEmojiPicker = true
+                            },
                         )
                     }
                 }
@@ -513,6 +534,11 @@ fun ReceivedMessageBubble(
     val clipboardManager = LocalClipboard.current
     val scope = rememberCoroutineScope()
     val haptics = rememberHaptics()
+    val policy = message.messageContent?.actions ?: ActionPolicy.Standard
+    val openReactionBar: (() -> Unit)? =
+        if (onAddReaction != null && policy.allowInlineReactions && !message.isDeleted) {
+            { popupMode = MessagePopupMode.Reaction }
+        } else null
 
     Row(
         modifier = Modifier.fillMaxWidth()
@@ -556,11 +582,8 @@ fun ReceivedMessageBubble(
                                 popupMode = MessagePopupMode.All
                             }
                         },
-                        onDoubleClick = {
-                            if (onAddReaction != null) {
-                                popupMode = MessagePopupMode.Reaction
-                            }
-                        },
+                        // See SentMessageBubble — MessageBubbleRaw owns the bubble surface.
+                        onDoubleClick = openReactionBar,
                     )
                 } else Modifier.weight(1f, fill = false),
                 contentAlignment = Alignment.CenterStart,
@@ -607,6 +630,7 @@ fun ReceivedMessageBubble(
                                     popupMode = MessagePopupMode.All
                                 }
                             },
+                            onDoubleClick = openReactionBar,
                             onMediaClick = onMediaClick,
                             onClickMessageId = onClickMessageId,
                             onRequestDecryptedFile = onRequestDecryptedFile,
@@ -633,6 +657,24 @@ fun ReceivedMessageBubble(
                                 onReactionClick = { onShowReactions?.invoke() },
                                 onAddEmoji = onAddReaction?.let { { popupMode = MessagePopupMode.Reaction } },
                                 ownReactions = message.ownReactions,
+                            )
+                        }
+                        if (isMobile() && popupMode == MessagePopupMode.Reaction &&
+                            !message.isDeleted
+                        ) {
+                            BubbleReactionPopup(
+                                message = message,
+                                userDefaultReactions = userDefaultReactions,
+                                alignToBubbleEnd = false,
+                                dismissMenu = { popupMode = MessagePopupMode.None },
+                                onSelectEmoji = { reaction ->
+                                    popupMode = MessagePopupMode.None
+                                    onAddReaction?.invoke(message.id, reaction)
+                                },
+                                onShowAllEmojis = {
+                                    popupMode = MessagePopupMode.None
+                                    showEmojiPicker = true
+                                },
                             )
                         }
                     }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubbleRaw.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubbleRaw.kt
@@ -148,6 +148,8 @@ fun MessageBubbleRaw(
     authorName: String? = null,
     authorColor: Color? = null,
     onLongClick: () -> Unit,
+    // Null keeps combinedClickable's single-tap path undelayed for bubbles that can't react.
+    onDoubleClick: (() -> Unit)? = null,
     onMediaClick: (PayloadDescriptor) -> Unit,
     onClickMessageId: (Uuid) -> Unit,
     onRequestDecryptedFile: ((PayloadDescriptor) -> Unit)? = null,
@@ -468,6 +470,7 @@ fun MessageBubbleRaw(
                 Modifier.combinedClickable(
                     onClick = {},
                     onLongClick = { handleLongClick() },
+                    onDoubleClick = onDoubleClick,
                     interactionSource = pressInteractionSource,
                     indication = null
                 )
@@ -480,14 +483,18 @@ fun MessageBubbleRaw(
         color = if (isStickerBubble) Color.Transparent else backgroundColor,
     ) {
         Box {
-            // Overlay Box that captures all long clicks
+            // Sits under the content and takes every tap the content itself doesn't claim
+            // (plain body text is not a pointer-input node). It consumes the down, so the
+            // Surface's combinedClickable above never sees a second tap — the double-tap
+            // has to be handled here too, not only there.
             if (isMobile()) {
                 Box(
                     modifier = Modifier
                         .matchParentSize()
-                        .pointerInput(message.id) {
+                        .pointerInput(message.id, onDoubleClick != null) {
                             detectTapGestures(
-                                onLongPress = { handleLongClick() }
+                                onLongPress = { handleLongClick() },
+                                onDoubleTap = onDoubleClick?.let { react -> { _ -> react() } },
                             )
                         }
                 )

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/widget/AboveBubblePositionProviderTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/widget/AboveBubblePositionProviderTest.kt
@@ -1,0 +1,77 @@
+package id.homebase.chat.widget
+
+import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.LayoutDirection
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+private const val GAP = 4
+private val WINDOW = IntSize(1080, 1920)
+private val BAR = IntSize(700, 120)
+
+class AboveBubblePositionProviderTest {
+
+    private fun position(
+        anchor: IntRect,
+        alignToEnd: Boolean,
+        window: IntSize = WINDOW,
+        bar: IntSize = BAR,
+        layoutDirection: LayoutDirection = LayoutDirection.Ltr,
+    ) = AboveBubblePositionProvider(GAP, alignToEnd)
+        .calculatePosition(anchor, window, layoutDirection, bar)
+
+    @Test
+    fun `sits above the bubble with a gap`() {
+        val anchor = IntRect(300, 800, 1000, 950)
+        assertEquals(800 - BAR.height - GAP, position(anchor, alignToEnd = true).y)
+    }
+
+    @Test
+    fun `flips below when the bubble is near the top of the viewport`() {
+        val anchor = IntRect(300, 10, 1000, 160)
+        assertEquals(160 + GAP, position(anchor, alignToEnd = true).y)
+    }
+
+    @Test
+    fun `a sent bubble aligns the bar to the bubble's right edge in LTR`() {
+        val anchor = IntRect(300, 800, 1000, 950)
+        assertEquals(1000 - BAR.width, position(anchor, alignToEnd = true).x)
+    }
+
+    @Test
+    fun `a received bubble aligns the bar to the bubble's left edge in LTR`() {
+        val anchor = IntRect(300, 800, 1000, 950)
+        assertEquals(300, position(anchor, alignToEnd = false).x)
+    }
+
+    @Test
+    fun `end alignment mirrors in RTL`() {
+        val anchor = IntRect(80, 800, 780, 950)
+        assertEquals(80, position(anchor, alignToEnd = true, layoutDirection = LayoutDirection.Rtl).x)
+    }
+
+    @Test
+    fun `a bar wider than the bubble is clamped inside the window`() {
+        val narrowWindow = IntSize(720, 1600)
+        val anchor = IntRect(500, 800, 700, 950)
+        val x = position(anchor, alignToEnd = true, window = narrowWindow).x
+        assertTrue(x >= 0, "x=$x ran off the start edge")
+        assertTrue(x + BAR.width <= narrowWindow.width, "x=$x ran off the end edge")
+    }
+
+    @Test
+    fun `a bar wider than the window still starts on screen`() {
+        val tinyWindow = IntSize(400, 1600)
+        val anchor = IntRect(20, 800, 380, 950)
+        assertEquals(0, position(anchor, alignToEnd = true, window = tinyWindow).x)
+    }
+
+    @Test
+    fun `flipping below a bubble at the bottom stays inside the window`() {
+        val anchor = IntRect(300, 0, 1000, 1900)
+        val y = position(anchor, alignToEnd = true).y
+        assertTrue(y + BAR.height <= WINDOW.height, "y=$y ran off the bottom")
+    }
+}


### PR DESCRIPTION
Closes #1191.

`MessagePopupMode.Reaction` already rendered the compact bar and was already wired to double-tap on mobile. Two defects made it unreachable.

## A. The gesture was swallowed — and by more than the issue names

`onDoubleClick` sat on an outer `Box` while the bubble surface below it ran its own `combinedClickable` with no `onDoubleClick`. The issue identifies that inner clickable as the swallower. It is only half of it.

`MessageBubbleRaw` also puts a `matchParentSize()` Box running `detectTapGestures` **under** the content, declared first so it is the bottom child and collects every tap the content itself doesn't claim — which for plain body text is all of them, because text is not a pointer-input node. That detector consumes the down, so the second tap never reached the `combinedClickable` one level up either.

Wiring `onDoubleClick` only onto the `combinedClickable`, as the issue describes, would not have fixed anything for ordinary text bubbles. Both nodes had to be wired.

## B. The bar was anchored to nothing

`SentMessagePopup` / `ReceivedMessagePopup` are invoked inside the hover-icons `Row`, whose every icon is `isDesktop()`-gated — so on mobile that Row is zero-size and a bare `Popup` landed at its origin, beside the message.

That `Popup` is now desktop-only, where the hover `AddReaction` button is a real anchor and behaviour is byte-identical. Mobile renders a new `BubbleReactionPopup` declared as a child of the bubble's own wrapper, so `calculatePosition` receives the true bubble rect as `anchorBounds` — no `onGloballyPositioned` bookkeeping and no per-scroll state writes.

`AboveBubblePositionProvider` sits 4dp above the bubble, flips below when the message is too near the top of the window, aligns to the bubble's end edge for sent and start edge for received with `layoutDirection` mirroring, and clamps x into the window so a wide bar can't overflow a narrow screen.

## Gesture now agrees with `allowInlineReactions`

Kinds that disallow inline reactions (Event, Groodle, Poll, Unknown) previously got a gesture that set `MessagePopupMode.Reaction` and then rendered nothing. They now get no handler at all. A null handler also leaves `combinedClickable`'s single-tap path undelayed for those bubbles.

**Media deliberately keeps single-tap-to-open.** `MediaItem`'s `detectTapGestures` has a real `onTap`, so adding `onDoubleTap` there is the one place in this change that would cost actual single-tap latency — every image open would wait out the double-tap window. Double-tap over an image also conventionally means zoom. Media-only bubbles keep long-press for reactions; a captioned media bubble already splits correctly (tap the image to open, tap the caption to react).

## Verification

Unit: 8 pure-geometry tests for `AboveBubblePositionProvider` (above-with-gap, flip-below near top, flip stays on screen, sent/received edge alignment, RTL mirroring, clamp when the bar is wider than the bubble, clamp when wider than the window). `homebase-chat:jvmTest` green at `tests=1062 failures=0 errors=0`. Konsist `ArchitectureTest` green.

On device (iPhone 17 Pro simulator, iOS 26.5):
- Double-tap **on the bubble surface** opens the compact reaction bar — the exact case that was broken.
- The bar renders **above** the message.
- Long-press still opens the full focused overlay with its action menu, unchanged.
- Single-tap on media still opens the fullscreen viewer immediately — no added latency.

Not verified on device: the flip-below case. The chat list is clipped by the top app bar, so a bubble can't sit close enough to the window top to trigger it without being partly hidden; it is covered by unit tests instead. Desktop and web are unchanged by construction — the mobile path is `isMobile()`-gated and desktop keeps its existing anchor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)