### PR TITLE
fix(chat): thin the sticker halo and shrink the bubble sticker (#1189)

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/image/StickerImageProcessor.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/image/StickerImageProcessor.kt
@@ -22,10 +22,10 @@ private const val TAG = "StickerImageProcessor"
 object StickerImageProcessor {
 
     /**
-     * Max edge (px) of the persisted/uploaded cut-out. The chat render-side caps a
-     * sticker at `Dimens.Sticker.maxSize` (160.dp ≈ ≤480px even at 3x density), so 512
-     * gives crisp 2× display headroom while staying a tiny fraction of a full-resolution
-     * camera frame. The send path uploads images BYTE-FOR-BYTE (see
+     * Max edge (px) of the persisted/uploaded cut-out. `Dimens.Sticker.baseSize` (180.dp)
+     * is ~540px at 3x density, so 512 renders near 1:1 on the densest phones while staying
+     * a tiny fraction of a full-resolution camera frame. The send path uploads images
+     * BYTE-FOR-BYTE (see
      * [id.homebase.chat.services.builder.MessageAttachmentBuilder]), so this directly
      * bounds upload/storage/download cost. Mirrors the 512px sticker convention used by
      * Signal / WhatsApp / Telegram.
@@ -37,9 +37,9 @@ object StickerImageProcessor {
 
     // Alpha above this counts as "the subject" when building the outline mask.
     private const val OUTLINE_ALPHA_THRESHOLD = 16
-    // Outline thickness as a fraction of the (capped) longest edge. ~4–5% reads as a clean
-    // WhatsApp-style halo without looking heavy.
-    private const val OUTLINE_RADIUS_FRACTION = 0.045f
+    // Halo thickness as a fraction of the (capped) longest edge. Coupled to
+    // Dimens.Sticker.baseSize — a thinner halo renders the subject larger at the same box.
+    private const val OUTLINE_RADIUS_FRACTION = 0.03f
 
     /**
      * Adds a WhatsApp-style opaque-white outline around the alpha shape of a transparent

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/image/StickerOutlineTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/image/StickerOutlineTest.kt
@@ -88,18 +88,27 @@ class StickerOutlineTest {
 
     @Test fun outline_width_equals_radius_3() = assertOutlineWidthEqualsRadius(size = 9, r = 3)
 
+    private fun opaquePng(size: Int) = png(size) { px -> px.fill(0xFFFF0000.toInt()) }
+
     @Test fun default_outline_width_scales_with_image_size() = runTest {
-        // The default radius is a fraction of the longest edge, so a larger sticker gets a wider
-        // halo. Pins the proportional behaviour without hard-coding the exact fraction (which is
-        // tuned for look). padding added on each side == the radius used.
-        suspend fun defaultRadius(size: Int): Int {
-            val src = png(size) { px -> for (i in px.indices) px[i] = 0xFFFF0000.toInt() } // fully opaque
-            val out = ImageUtils.decodeToArgb(StickerImageProcessor.addWhiteOutline(src))!!
-            return (out.width - size) / 2
-        }
-        val small = defaultRadius(100)
-        val large = defaultRadius(400)
-        assertTrue(small >= 1, "small radius must be >= 1 (was $small)")
-        assertTrue(large > small, "outline width must grow with image size (small=$small large=$large)")
+        // Golden: r = floor(longestEdge * OUTLINE_RADIUS_FRACTION), padded on each side.
+        // At 0.03f -> 100:3, 400:12, 480:14. Retuning the look must land here deliberately.
+        suspend fun defaultRadius(size: Int): Int =
+            (ImageUtils.decodeToArgb(StickerImageProcessor.addWhiteOutline(opaquePng(size)))!!.width - size) / 2
+        assertEquals(3, defaultRadius(100), "default radius at 100px")
+        assertEquals(12, defaultRadius(400), "default radius at 400px")
+        assertEquals(14, defaultRadius(480), "default radius at 480px")
+    }
+
+    @Test fun outlined_canvas_is_src_plus_2r_and_never_exceeds_max_dim() = runTest {
+        val under = ImageUtils.decodeToArgb(StickerImageProcessor.addWhiteOutline(opaquePng(480)))!!
+        assertEquals(480 + 2 * 14, under.width, "480 + 2r fits under the cap, so the padding survives")
+        assertEquals(480 + 2 * 14, under.height)
+
+        // 600 is capped to 512 first; the padded 512 + 2*15 = 542 canvas is downscaled back
+        // under the cap, so the uploaded PNG is never larger than STICKER_MAX_DIM.
+        val over = ImageUtils.decodeToArgb(StickerImageProcessor.addWhiteOutline(opaquePng(600)))!!
+        assertEquals(StickerImageProcessor.STICKER_MAX_DIM, over.width)
+        assertEquals(StickerImageProcessor.STICKER_MAX_DIM, over.height)
     }
 }

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/ui/theme/Dimens.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/ui/theme/Dimens.kt
@@ -167,10 +167,10 @@ object Dimens {
         val previewStickerSize = 96.dp
         val previewGutterSize = 16.dp
 
-        // Preferred max edge of a sticker rendered in a chat bubble. Larger than the old
-        // flat 160.dp so cut-outs read clearly (closer to the WhatsApp/Telegram sticker
-        // size) while staying well under Signal's 512 logical-px sticker.
-        val baseSize = 220.dp
+        // Max edge of the sticker IMAGE, not of the visible cut-out: ~12% of each axis is
+        // white halo + crop margin, so the subject renders ~158.dp. Coupled to
+        // StickerImageProcessor.OUTLINE_RADIUS_FRACTION — retune the two together.
+        val baseSize = 180.dp
 
         // The base size is additionally clamped to this fraction of the viewport height so
         // a sticker can never dominate the message list on short/landscape windows. On a


### PR DESCRIPTION
Closes #1189.

Two constants, retuned as a pair because they interact.

| | before | after |
|---|---|---|
| `OUTLINE_RADIUS_FRACTION` | `0.045f` | `0.03f` |
| `Dimens.Sticker.baseSize` | `220.dp` | `180.dp` |

## Why they had to move together

`addWhiteOutline` pads the canvas by `r` on all four sides so the halo isn't clipped, so the halo inflates the image's own dimensions and the subject is already smaller than the `baseSize` box implies. Thinning the halo makes the subject appear *larger* at the same box — changing either constant alone overshoots.

Square-ish subject, source larger than the 512 cap (the normal camera-pick case):

| | before (0.045 / 220dp) | after (0.03 / 180dp) |
|---|---|---|
| `r` at 512 | 23 | 15 |
| padded canvas | 558 | 542 |
| subject % of axis | 84.96% | 87.47% |
| halo % of axis | 8.24% | 5.54% |
| **subject on screen** | **186.9 dp** | **157.4 dp** (−16%) |
| **halo per side on screen** | **9.1 dp** | **5.0 dp** (−45%) |

For reference the old flat-160 box gave a 135.9 dp subject, so 157.4 dp still sits above what motivated the 220 bump — this corrects the overshoot rather than reverting it.

Sharpness falls out of it: the subject is 474 real px in the PNG. At 3x, 186.9 dp demanded 561 px from 474 (an 18% upscale, i.e. soft); 157.4 dp demands 472 px, effectively 1:1. The `STICKER_MAX_DIM` KDoc claimed "2× display headroom" and referenced `Dimens.Sticker.maxSize`, a symbol that does not exist — both fixed.

## Already-sent stickers keep the thick halo

The outline is baked into the uploaded PNG and the send path uploads byte-for-byte, so this only affects newly created stickers. A faithful migration is not merely expensive, it is impossible: the subject's alpha edge is already painted opaque white, so halo pixels and genuinely-white subject pixels are indistinguishable and no threshold recovers the mask. Re-running the segmenter would need the original photo, which isn't retained; rewriting sent payloads on recipients' drives is wrong protocol-wise.

In a thread mixing old and new, subjects land within 3% of each other (invisible); the halo is the only visible difference.

## Tests

The existing default-radius case only asserted `small >= 1 && large > small`, which 3 and 12 still satisfy — so this **tightens** it into real goldens rather than repairing a break. Values were confirmed empirically in JVM rather than by decimal reasoning, because `r = maxOf(1, (maxOf(sw,sh) * FRACTION).toInt())` truncates on an IEEE-754 single-precision product: at size 100, `0.03f` is 0.0299999993…, so naive math gives 2, but the Float product rounds back to exactly `3.0f` and truncates to 3.

Goldens are at 100/400/480 and deliberately not 512 — the test measures `r` as `(out.width - size)/2`, which is only valid while `size + 2r <= 512`.

New test `outlined_canvas_is_src_plus_2r_and_never_exceeds_max_dim` covers the gap that had no coverage at all: 480 → `480 + 2*14 = 508` (padding survives, pins `src + 2r`), 600 → capped to 512, `512 + 2*15 = 542` → downscaled back to exactly 512×512.

## Height clamp

Clamp bites when `viewportHeightDp < baseSize / 0.35`: 628.6 dp before → 514.3 dp after. Phone portrait (~700–800 dp) unchanged; phone landscape (~360–420 dp) still clamps. The newly unclamped 514–629 dp band (small floating/split-screen) gets the full 180 dp, which is 30% of a 600 dp window — the clamp's purpose still holds.

## Tray constants left alone

`previewStickerSize`, `pageItemWidth`, `pageItemPadding`, `previewGutterSize` have **zero** references outside `Dimens.kt` — the tray actually sizes itself at `StickerTray.kt:63` with `GridCells.Adaptive(minSize = 88.dp)`. They render nothing, so they can't be out of proportion; deleting them is unrelated cleanup. The live ratio (88 dp tray tile vs 180 dp bubble box) moved from ~2.5× to ~2×.

## Verification

`homebase-chat:jvmTest --tests '*Sticker*'` green: 8 suites, 57 tests, 0 failures. `:homebase-common:compileKotlinJvm :homebase-chat:compileKotlinJvm` green. iOS simulator build (`iosApp Dev`, iPhone 17 Pro / iOS 26.5) succeeds and the app boots to the conversation list.

Halo rendered at true pixel scale (512 canvas, r=23 vs r=15) and compared on dark, light and neutral backdrops: the thinner ring reads as a deliberate outline rather than a heavy blob, and still separates the cut-out on a light wallpaper — the property the halo exists for. On pure white neither the old nor the new halo separates; that is inherent to a white halo and unchanged by this PR.

**What still wants a human eye:** the in-bubble size. Verifying it needs an actual sticker in a conversation, and creating one means sending a real message, so I did not. The issue's own standard — "whatever looks correct next to a WhatsApp sticker on a real phone" — is a judgment call worth making before merge. The two dials are independent in effect if it needs another pass: `OUTLINE_RADIUS_FRACTION` sets the halo-vs-subject ratio, `baseSize` scales both.

**Deliberately out of scope:** `cropToSubject`'s `marginFraction = 0.04f` adds ~7% of dead transparent margin per axis, and its stated rationale ("keeps the halo from being clipped") is redundant since `addWhiteOutline` pads by `r` unconditionally. Dropping it would enlarge the subject ~7% without touching the halo — a third coupled constant that belongs in its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)