### PR TITLE
feat(settings): rebuild the settings hub around what each row actually does (#1188)

### DIFF
--- a/homebase-common/src/commonMain/composeResources/values-da/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values-da/strings.xml
@@ -197,7 +197,6 @@
     <!-- Settings screen -->
     <string name="settings_appearance">Udseende</string>
     <string name="settings_haptic_feedback">Haptisk feedback</string>
-    <string name="settings_connections">Forbindelser</string>
     <string name="connections_already_sent_title">Anmodning allerede sendt</string>
     <string name="connections_already_sent_text">En forbindelsesanmodning til %1$s findes allerede. Åbn ejer konsollen for at se eller administrere den.</string>
     <string name="connections_refresh">Opdater</string>
@@ -219,7 +218,6 @@
     <string name="connections_empty_outgoing_subtitle">Tryk på + knappen for at sende en forbindelsesanmodning.</string>
     <string name="connections_send_request">Send anmodning</string>
     <string name="settings_notifications">Notifikationer</string>
-    <string name="settings_profile_info">Profiloplysninger</string>
     <string name="settings_security_setup">Sikkerhedsopsætning</string>
     <string name="settings_help">Hjælp</string>
     <string name="settings_storage">Lagerplads</string>
@@ -310,8 +308,6 @@
     <string name="settings_delete_account_dialog_title">Slet din konto?</string>
     <string name="settings_delete_account_dialog_text">Din konto er meget mere end bare denne app. Hvis du vil slette din konto kan du gøre det i ejer konsollen.</string>
     <string name="settings_open_owner_console">Åben ejer konsol</string>
-    <string name="settings_notifications_active">Notifikationer aktive</string>
-    <string name="settings_notifications_issue">Problem med notifikationer</string>
 
     <!-- Notification settings screen -->
     <string name="settings_notifications_disabled_title">Push-notifikationer er deaktiveret</string>
@@ -1194,9 +1190,26 @@
     <string name="cd_video_scrubber_frame">Videoskrubberbillede</string>
     <string name="video_web_large_playback_unsupported">Store videoer kan endnu ikke afspilles i browseren</string>
 
-    <!-- Settings section headers -->
-    <string name="settings_section_general">Generelt</string>
-    <string name="settings_section_danger_zone">Farezone</string>
+    <!-- Settings hub -->
+    <string name="settings_section_preferences">Præferencer</string>
+    <string name="settings_section_apps">Apps</string>
+    <string name="settings_section_device">Enhed</string>
+    <string name="settings_section_account_actions">Kontohandlinger</string>
+    <string name="settings_edit_profile">Rediger profil</string>
+    <string name="settings_security_setup_desc">Adgangskode og gendannelsesnøgle</string>
+    <string name="settings_notifications_status_checking">Kontrollerer…</string>
+    <string name="settings_notifications_status_on">Push-notifikationer virker</string>
+    <string name="settings_notifications_status_error">Push-notifikationer virker ikke</string>
+    <string name="settings_appearance_theme">Tema: %1$s</string>
+    <string name="settings_moments_desc">Billeder, klip og noter</string>
+    <string name="settings_vault_desc">Krypteret dokumentopbevaring</string>
+    <string name="settings_location_desc">Privat placeringshistorik</string>
+    <string name="settings_contactbook_desc">Din adressebog og cirkler</string>
+    <string name="settings_storage_desc">Caches, database og medier</string>
+    <string name="settings_storage_used">%1$s brugt på denne enhed</string>
+    <string name="settings_help_desc">Logs og diagnostik</string>
+    <string name="settings_logout_desc">Dine data forbliver på din identitet</string>
+    <string name="settings_delete_account_desc">Permanent, i din ejer konsol</string>
 
     <!-- Audio player -->
     <string name="audio_pause">Pause</string>

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -199,7 +199,6 @@
     <!-- Settings screen -->
     <string name="settings_appearance">Appearance</string>
     <string name="settings_haptic_feedback">Haptic Feedback</string>
-    <string name="settings_connections">Connections</string>
     <string name="connections_already_sent_title">Request already sent</string>
     <string name="connections_already_sent_text">A connection request to %1$s already exists. Open the owner console to view or manage it.</string>
     <string name="connections_refresh">Refresh</string>
@@ -221,8 +220,7 @@
     <string name="connections_empty_outgoing_subtitle">Tap the + button to send a connection request.</string>
     <string name="connections_send_request">Send Request</string>
     <string name="settings_notifications">Notifications</string>
-    <string name="settings_profile_info">Profile Info</string>
-    <string name="settings_security_setup">Security Setup</string>
+    <string name="settings_security_setup">Security setup</string>
     <string name="settings_help">Help</string>
     <string name="settings_storage">Storage</string>
     <string name="settings_logout">Log out</string>
@@ -312,8 +310,6 @@
     <string name="settings_delete_account_dialog_title">Delete your account?</string>
     <string name="settings_delete_account_dialog_text">Your account is much more than only this app. If you want to remove your account, you can do so in the owner console.</string>
     <string name="settings_open_owner_console">Open owner console</string>
-    <string name="settings_notifications_active">Notifications active</string>
-    <string name="settings_notifications_issue">Notifications issue</string>
 
     <!-- Notification settings screen -->
     <string name="settings_notifications_disabled_title">Push Notifications are disabled</string>
@@ -1231,9 +1227,26 @@
     <string name="cd_video_scrubber_frame">Video scrubber frame</string>
     <string name="video_web_large_playback_unsupported">Large videos can't be played in the browser yet</string>
 
-    <!-- Settings section headers -->
-    <string name="settings_section_general">General</string>
-    <string name="settings_section_danger_zone">Danger Zone</string>
+    <!-- Settings hub -->
+    <string name="settings_section_preferences">Preferences</string>
+    <string name="settings_section_apps">Apps</string>
+    <string name="settings_section_device">Device</string>
+    <string name="settings_section_account_actions">Account actions</string>
+    <string name="settings_edit_profile">Edit profile</string>
+    <string name="settings_security_setup_desc">Password and recovery key</string>
+    <string name="settings_notifications_status_checking">Checking…</string>
+    <string name="settings_notifications_status_on">Push notifications are working</string>
+    <string name="settings_notifications_status_error">Push notifications aren't working</string>
+    <string name="settings_appearance_theme">Theme: %1$s</string>
+    <string name="settings_moments_desc">Photos, clips and notes</string>
+    <string name="settings_vault_desc">Encrypted document storage</string>
+    <string name="settings_location_desc">Private location history</string>
+    <string name="settings_contactbook_desc">Your address book and circles</string>
+    <string name="settings_storage_desc">Caches, database and media</string>
+    <string name="settings_storage_used">%1$s used on this device</string>
+    <string name="settings_help_desc">Logs and diagnostics</string>
+    <string name="settings_logout_desc">Your data stays on your identity</string>
+    <string name="settings_delete_account_desc">Permanent, in your owner console</string>
 
     <!-- Audio player -->
     <string name="audio_pause">Pause</string>

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
@@ -123,6 +123,7 @@ import id.homebase.core.ui.screens.location.share.ShareLocationScreen
 import id.homebase.core.ui.screens.notifications.NotificationSettingsScreen
 import id.homebase.core.ui.screens.profile.ProfileAvatarEditScreen
 import id.homebase.core.ui.screens.profile.ProfileEditScreen
+import id.homebase.core.ui.screens.settings.SettingsActions
 import id.homebase.core.ui.screens.settings.SettingsScreen
 import androidx.compose.material3.CircularProgressIndicator
 import id.homebase.core.ui.screens.vault.VaultScreen
@@ -1259,35 +1260,37 @@ fun AppNavHost(
                             if (isAuthenticated) {
                                 SettingsScreen(
                                     viewModel = koinViewModel(),
-                                    onBackClick = { navController.popBackStack() },
-                                    onNavigateToNotifications = {
-                                        navController.navigate(Route.NotificationSettings)
-                                    },
-                                    onNavigateToAppearance = {
-                                        navController.navigate(Route.AppearanceSettings)
-                                    },
-                                    onNavigateToStorage = {
-                                        navController.navigate(Route.StorageSettings)
-                                    },
-                                    onNavigateToHelp = {
-                                        navController.navigate(Route.Help)
-                                    },
-                                    onNavigateToMomentsSettings = {
-                                        navController.navigate(Route.MomentsSettings)
-                                    },
-                                    onNavigateToVaultSettings = {
-                                        navController.navigate(Route.VaultSettings)
-                                    },
-                                    onNavigateToLocation = openLocation,
-                                    onNavigateToContactBookSettings = {
-                                        navController.navigate(Route.ContactBookSettings)
-                                    },
-                                    onNavigateToProfileEdit = {
-                                        navController.navigate(Route.ProfileEdit)
-                                    },
-                                    onNavigateToProfileAvatarEdit = {
-                                        navController.navigate(Route.ProfileAvatarEdit)
-                                    },
+                                    actions = SettingsActions(
+                                        onBack = { navController.popBackStack() },
+                                        onNotifications = {
+                                            navController.navigate(Route.NotificationSettings)
+                                        },
+                                        onAppearance = {
+                                            navController.navigate(Route.AppearanceSettings)
+                                        },
+                                        onStorage = {
+                                            navController.navigate(Route.StorageSettings)
+                                        },
+                                        onHelp = {
+                                            navController.navigate(Route.Help)
+                                        },
+                                        onMomentsSettings = {
+                                            navController.navigate(Route.MomentsSettings)
+                                        },
+                                        onVaultSettings = {
+                                            navController.navigate(Route.VaultSettings)
+                                        },
+                                        onLocation = openLocation,
+                                        onContactBookSettings = {
+                                            navController.navigate(Route.ContactBookSettings)
+                                        },
+                                        onProfileEdit = {
+                                            navController.navigate(Route.ProfileEdit)
+                                        },
+                                        onProfileAvatarEdit = {
+                                            navController.navigate(Route.ProfileAvatarEdit)
+                                        },
+                                    ),
                                 )
                             }
                         }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/settings/SettingsActions.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/settings/SettingsActions.kt
@@ -1,0 +1,19 @@
+package id.homebase.core.ui.screens.settings
+
+/**
+ * Every destination the settings hub can reach. No defaults on purpose: a route the
+ * navigation graph forgets to supply is a compile error, not a dead row.
+ */
+data class SettingsActions(
+    val onBack: () -> Unit,
+    val onNotifications: () -> Unit,
+    val onAppearance: () -> Unit,
+    val onStorage: () -> Unit,
+    val onHelp: () -> Unit,
+    val onMomentsSettings: () -> Unit,
+    val onVaultSettings: () -> Unit,
+    val onLocation: () -> Unit,
+    val onContactBookSettings: () -> Unit,
+    val onProfileEdit: () -> Unit,
+    val onProfileAvatarEdit: () -> Unit,
+)

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/settings/SettingsScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/settings/SettingsScreen.kt
@@ -1,6 +1,7 @@
 package id.homebase.core.ui.screens.settings
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -14,18 +15,17 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.ui.backhandler.BackHandler
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.automirrored.outlined.HelpOutline
 import androidx.compose.material.icons.automirrored.outlined.Logout
-import androidx.compose.material.icons.filled.ChevronLeft
 import androidx.compose.material.icons.outlined.AutoAwesome
 import androidx.compose.material.icons.outlined.Brightness6
-import androidx.compose.material.icons.outlined.BugReport
 import androidx.compose.material.icons.outlined.CheckCircle
 import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material.icons.outlined.Error
@@ -33,7 +33,7 @@ import androidx.compose.material.icons.outlined.Lock
 import androidx.compose.material.icons.outlined.LocationOn
 import androidx.compose.material.icons.outlined.Notifications
 import androidx.compose.material.icons.outlined.People
-import androidx.compose.material.icons.outlined.Person
+import androidx.compose.material.icons.outlined.PhotoCamera
 import androidx.compose.material.icons.outlined.Security
 import androidx.compose.material.icons.outlined.Storage
 import androidx.compose.material3.CircularProgressIndicator
@@ -42,25 +42,31 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import id.homebase.api.client.auth.OwnerSession
 import id.homebase.api.client.auth.initials
+import id.homebase.common.util.formatBytes
 import id.homebase.core.avatars.AvatarOptions
 import id.homebase.core.avatars.ContactAvatar
+import id.homebase.core.ui.screens.appearance.getStringResourceForTheme
 import id.homebase.core.ui.theme.ExtendedColors
 import id.homebase.core.ui.theme.HomebaseTheme
 import id.homebase.core.util.getUriHandler
@@ -72,45 +78,51 @@ import id.homebase.core.widget.SettingsRow
 import id.homebase.core.widget.SettingsRowAction
 import id.homebase.core.widget.SettingsSectionHeader
 import id.homebase.resources.MR
+import id.homebase.resources.app_version
 import id.homebase.resources.cancel
+import id.homebase.resources.cd_profile_avatar_change_photo
+import id.homebase.resources.contactbook_settings_section
+import id.homebase.resources.location_settings_section
 import id.homebase.resources.menu_back
+import id.homebase.resources.moments_settings_section
 import id.homebase.resources.settings
 import id.homebase.resources.settings_appearance
+import id.homebase.resources.settings_appearance_theme
+import id.homebase.resources.settings_contactbook_desc
 import id.homebase.resources.settings_delete_account
+import id.homebase.resources.settings_delete_account_desc
 import id.homebase.resources.settings_delete_account_dialog_text
 import id.homebase.resources.settings_delete_account_dialog_title
+import id.homebase.resources.settings_edit_profile
 import id.homebase.resources.settings_help
+import id.homebase.resources.settings_help_desc
+import id.homebase.resources.settings_location_desc
 import id.homebase.resources.settings_logout
+import id.homebase.resources.settings_logout_desc
 import id.homebase.resources.settings_logout_in_progress
-import id.homebase.resources.moments_settings_section
+import id.homebase.resources.settings_moments_desc
 import id.homebase.resources.settings_notifications
-import id.homebase.resources.settings_notifications_active
-import id.homebase.resources.settings_notifications_issue
+import id.homebase.resources.settings_notifications_status_checking
+import id.homebase.resources.settings_notifications_status_error
+import id.homebase.resources.settings_notifications_status_on
 import id.homebase.resources.settings_open_owner_console
-import id.homebase.resources.settings_profile_info
+import id.homebase.resources.settings_section_account_actions
+import id.homebase.resources.settings_section_apps
+import id.homebase.resources.settings_section_device
+import id.homebase.resources.settings_section_preferences
 import id.homebase.resources.settings_security_setup
-import id.homebase.resources.settings_section_danger_zone
-import id.homebase.resources.settings_section_general
-import id.homebase.resources.location_settings_section
-import id.homebase.resources.vault_settings_section
-import id.homebase.resources.contactbook_settings_section
+import id.homebase.resources.settings_security_setup_desc
 import id.homebase.resources.settings_storage
+import id.homebase.resources.settings_storage_desc
+import id.homebase.resources.settings_storage_used
+import id.homebase.resources.settings_vault_desc
+import id.homebase.resources.vault_settings_section
 import org.jetbrains.compose.resources.stringResource
 
 @Composable
 fun SettingsScreen(
     viewModel: SettingsViewModel,
-    onBackClick: () -> Unit,
-    onNavigateToNotifications: () -> Unit,
-    onNavigateToAppearance: () -> Unit,
-    onNavigateToStorage: () -> Unit,
-    onNavigateToHelp: () -> Unit,
-    onNavigateToMomentsSettings: () -> Unit,
-    onNavigateToVaultSettings: () -> Unit,
-    onNavigateToLocation: () -> Unit,
-    onNavigateToContactBookSettings: () -> Unit,
-    onNavigateToProfileEdit: () -> Unit,
-    onNavigateToProfileAvatarEdit: () -> Unit,
+    actions: SettingsActions,
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val uriHandler = getUriHandler()
@@ -130,12 +142,12 @@ fun SettingsScreen(
 
             SettingsUiEvent.NavigateToProfileEdit -> {
                 viewModel.eventConsumed()
-                onNavigateToProfileEdit()
+                actions.onProfileEdit()
             }
 
             SettingsUiEvent.NavigateToProfileAvatarEdit -> {
                 viewModel.eventConsumed()
-                onNavigateToProfileAvatarEdit()
+                actions.onProfileAvatarEdit()
             }
         }
     }
@@ -171,16 +183,7 @@ fun SettingsScreen(
         SettingsUi(
             uiState = uiState,
             onAction = viewModel::onAction,
-            onBackClick = onBackClick,
-            onNavigateToNotifications = onNavigateToNotifications,
-            onNavigateToAppearance = onNavigateToAppearance,
-           onNavigateToVaultSettings = onNavigateToVaultSettings,
-            onNavigateToStorage = onNavigateToStorage,
-            onNavigateToHelp = onNavigateToHelp,
-            onNavigateToMomentsSettings = onNavigateToMomentsSettings,
-            onNavigateToLocation = onNavigateToLocation,
-            onNavigateToContactBookSettings = onNavigateToContactBookSettings,
-            onAvatarClick = { viewModel.onAction(SettingsUiAction.AvatarClicked) },
+            actions = actions,
         )
 
         if (uiState.isLoggingOut) {
@@ -234,176 +237,291 @@ private fun LogoutOverlay() {
 fun SettingsUi(
     uiState: SettingsUiState,
     onAction: (SettingsUiAction) -> Unit,
-    onBackClick: () -> Unit,
-    onNavigateToNotifications: () -> Unit,
-    onNavigateToAppearance: () -> Unit,
-    onNavigateToStorage: () -> Unit,
-    onNavigateToHelp: () -> Unit,
-    onNavigateToMomentsSettings: () -> Unit,
-    onNavigateToVaultSettings: () -> Unit = {},
-    onNavigateToLocation: () -> Unit = {},
-    onNavigateToContactBookSettings: () -> Unit = {},
-    onAvatarClick: () -> Unit = {},
+    actions: SettingsActions,
 ) {
-    val scrollState = rememberScrollState()
+    val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
 
     Scaffold(
+        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
         topBar = {
-            TopAppBar(title = {
-                Text(
-                    stringResource(MR.string.settings),
-                    modifier = Modifier.testTag("settingsTitle")
-                )
-            }, navigationIcon = {
-                IconButton(onClick = onBackClick) {
-                    Icon(
-                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                        contentDescription = stringResource(MR.string.menu_back)
+            TopAppBar(
+                title = {
+                    Text(
+                        stringResource(MR.string.settings),
+                        modifier = Modifier.testTag("settingsTitle")
                     )
-                }
-            })
-        }
-    ) { innerPadding ->
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .verticalScroll(scrollState)
-                .consumeWindowInsets(innerPadding)
-                .padding(innerPadding),
-            horizontalAlignment = Alignment.CenterHorizontally
-        ) {
-            // Avatar
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .clickable(onClick = onAvatarClick)
-                    .padding(vertical = 24.dp),
-                horizontalArrangement = Arrangement.Center,
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                uiState.ownerSession?.let { ownerSession ->
-                    ContactAvatar(
-                        odinId = ownerSession.odinId,
-                        profileImageData = null,
-                        initials = ownerSession.initials(),
-                        options = AvatarOptions(
-                            size = 96.dp,
-                        ),
-                        sharedTransitionScope = null,
-                        animatedVisibilityScope = null,
-                        cacheBustKey = ownerSession.profileImageLastModified,
-                    )
-                    Spacer(modifier = Modifier.width(24.dp))
-                    Column {
-                        Text(
-                            text = ownerSession.displayName ?: "",
-                            style = MaterialTheme.typography.titleLarge
-                        )
-                        Spacer(modifier = Modifier.height(8.dp))
-                        Text(
-                            text = ownerSession.odinId.domainName,
-                            style = MaterialTheme.typography.bodyLarge
+                },
+                navigationIcon = {
+                    IconButton(
+                        onClick = actions.onBack,
+                        modifier = Modifier.testTag("settingsBackButton"),
+                    ) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(MR.string.menu_back)
                         )
                     }
-                }
+                },
+                scrollBehavior = scrollBehavior,
+            )
+        }
+    ) { innerPadding ->
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .consumeWindowInsets(innerPadding)
+                .testTag("settingsList"),
+            contentPadding = innerPadding,
+        ) {
+            item {
+                IdentityHeader(
+                    session = uiState.ownerSession,
+                    onEditProfile = { onAction(SettingsUiAction.ProfileInfoClicked) },
+                    onEditAvatar = { onAction(SettingsUiAction.AvatarClicked) },
+                )
             }
-            Spacer(modifier = Modifier.height(8.dp))
-            SettingsSectionHeader(
-                title = stringResource(MR.string.settings_section_general),
-                modifier = Modifier.padding(start = 16.dp, top = 8.dp, bottom = 4.dp),
-            )
-            SettingsRow(
-                icon = Icons.Outlined.Person,
-                title = stringResource(MR.string.settings_profile_info),
-                action = SettingsRowAction.Navigate {
-                    onAction(SettingsUiAction.ProfileInfoClicked)
-                },
-            )
-            SettingsRow(
-                modifier = Modifier.testTag("notificationsButton"),
-                icon = Icons.Outlined.Notifications,
-                title = stringResource(MR.string.settings_notifications),
-                action = SettingsRowAction.Navigate(onNavigateToNotifications),
-                status = { NotificationStatusIndicator(uiState.notificationStatus) },
-            )
-            SettingsRow(
-                modifier = Modifier.testTag("securitySetupButton"),
-                icon = Icons.Outlined.Security,
-                title = stringResource(MR.string.settings_security_setup),
-                action = SettingsRowAction.External {
-                    onAction(SettingsUiAction.SecuritySetupClicked)
-                },
-            )
-            SettingsRow(
-                modifier = Modifier.testTag("appearanceButton"),
-                icon = Icons.Outlined.Brightness6,
-                title = stringResource(MR.string.settings_appearance),
-                action = SettingsRowAction.Navigate(onNavigateToAppearance),
-            )
-            SettingsRow(
-                modifier = Modifier.testTag("storageButton"),
-                icon = Icons.Outlined.Storage,
-                title = stringResource(MR.string.settings_storage),
-                action = SettingsRowAction.Navigate(onNavigateToStorage),
-            )
-            SettingsRow(
-                modifier = Modifier.testTag("momentsSettingsButton"),
-                icon = Icons.Outlined.AutoAwesome,
-                title = stringResource(MR.string.moments_settings_section),
-                action = SettingsRowAction.Navigate(onNavigateToMomentsSettings),
-            )
-            SettingsRow(
-                icon = Icons.Outlined.Lock,
-                title = stringResource(MR.string.vault_settings_section),
-                action = SettingsRowAction.Navigate(onNavigateToVaultSettings),
-            )
-            SettingsRow(
-                modifier = Modifier.testTag("locationSettingsButton"),
-                icon = Icons.Outlined.LocationOn,
-                title = stringResource(MR.string.location_settings_section),
-                action = SettingsRowAction.Navigate(onNavigateToLocation),
-            )
-            SettingsRow(
-                modifier = Modifier.testTag("contactBookSettingsButton"),
-                icon = Icons.Outlined.People,
-                title = stringResource(MR.string.contactbook_settings_section),
-                action = SettingsRowAction.Navigate(onNavigateToContactBookSettings),
-            )
-            SettingsRow(
-                modifier = Modifier.testTag("helpButton"),
-                icon = Icons.AutoMirrored.Outlined.HelpOutline,
-                title = stringResource(MR.string.settings_help),
-                action = SettingsRowAction.Navigate(onNavigateToHelp),
-            )
-            Spacer(modifier = Modifier.height(16.dp))
-            HorizontalDivider()
-            SettingsSectionHeader(
-                title = stringResource(MR.string.settings_section_danger_zone),
-                modifier = Modifier.padding(start = 16.dp, top = 8.dp, bottom = 4.dp),
-            )
-            SettingsRow(
-                modifier = Modifier.testTag("deleteAccountButton"),
-                icon = Icons.Outlined.Delete,
-                title = stringResource(MR.string.settings_delete_account),
-                isDestructive = true,
-                action = SettingsRowAction.Invoke {
-                    onAction(SettingsUiAction.DeleteAccount)
-                },
-            )
-            SettingsRow(
-                modifier = Modifier.testTag("logoutButton"),
-                icon = Icons.AutoMirrored.Outlined.Logout,
-                title = stringResource(MR.string.settings_logout),
-                isDestructive = true,
-                action = SettingsRowAction.Invoke {
-                    onAction(SettingsUiAction.LogoutClicked)
-                },
-            )
-            Spacer(modifier = Modifier.height(32.dp))
+
+            item {
+                SettingsRow(
+                    modifier = Modifier.testTag("securitySetupButton"),
+                    icon = Icons.Outlined.Security,
+                    title = stringResource(MR.string.settings_security_setup),
+                    supportingText = stringResource(MR.string.settings_security_setup_desc),
+                    action = SettingsRowAction.External {
+                        onAction(SettingsUiAction.SecuritySetupClicked)
+                    },
+                )
+            }
+
+            item { HubSectionHeader(stringResource(MR.string.settings_section_preferences)) }
+            item {
+                SettingsRow(
+                    modifier = Modifier.testTag("notificationsButton"),
+                    icon = Icons.Outlined.Notifications,
+                    title = stringResource(MR.string.settings_notifications),
+                    supportingText = when (uiState.notificationStatus) {
+                        NotificationVerificationStatus.CHECKING ->
+                            stringResource(MR.string.settings_notifications_status_checking)
+
+                        NotificationVerificationStatus.OK ->
+                            stringResource(MR.string.settings_notifications_status_on)
+
+                        NotificationVerificationStatus.ERROR ->
+                            stringResource(MR.string.settings_notifications_status_error)
+                    },
+                    action = SettingsRowAction.Navigate(actions.onNotifications),
+                    status = { NotificationStatusIndicator(uiState.notificationStatus) },
+                )
+            }
+            item {
+                SettingsRow(
+                    modifier = Modifier.testTag("appearanceButton"),
+                    icon = Icons.Outlined.Brightness6,
+                    title = stringResource(MR.string.settings_appearance),
+                    supportingText = stringResource(
+                        MR.string.settings_appearance_theme,
+                        uiState.theme.getStringResourceForTheme(),
+                    ),
+                    action = SettingsRowAction.Navigate(actions.onAppearance),
+                )
+            }
+
+            item { HubSectionHeader(stringResource(MR.string.settings_section_apps)) }
+            item {
+                SettingsRow(
+                    modifier = Modifier.testTag("momentsSettingsButton"),
+                    icon = Icons.Outlined.AutoAwesome,
+                    title = stringResource(MR.string.moments_settings_section),
+                    supportingText = stringResource(MR.string.settings_moments_desc),
+                    action = SettingsRowAction.Navigate(actions.onMomentsSettings),
+                )
+            }
+            item {
+                SettingsRow(
+                    modifier = Modifier.testTag("vaultSettingsButton"),
+                    icon = Icons.Outlined.Lock,
+                    title = stringResource(MR.string.vault_settings_section),
+                    supportingText = stringResource(MR.string.settings_vault_desc),
+                    action = SettingsRowAction.Navigate(actions.onVaultSettings),
+                )
+            }
+            item {
+                SettingsRow(
+                    modifier = Modifier.testTag("locationSettingsButton"),
+                    icon = Icons.Outlined.LocationOn,
+                    title = stringResource(MR.string.location_settings_section),
+                    supportingText = stringResource(MR.string.settings_location_desc),
+                    action = SettingsRowAction.Navigate(actions.onLocation),
+                )
+            }
+            item {
+                SettingsRow(
+                    modifier = Modifier.testTag("contactBookSettingsButton"),
+                    icon = Icons.Outlined.People,
+                    title = stringResource(MR.string.contactbook_settings_section),
+                    supportingText = stringResource(MR.string.settings_contactbook_desc),
+                    action = SettingsRowAction.Navigate(actions.onContactBookSettings),
+                )
+            }
+
+            item { HubSectionHeader(stringResource(MR.string.settings_section_device)) }
+            item {
+                SettingsRow(
+                    modifier = Modifier.testTag("storageButton"),
+                    icon = Icons.Outlined.Storage,
+                    title = stringResource(MR.string.settings_storage),
+                    supportingText = uiState.storageUsedBytes
+                        ?.let { stringResource(MR.string.settings_storage_used, formatBytes(it)) }
+                        ?: stringResource(MR.string.settings_storage_desc),
+                    action = SettingsRowAction.Navigate(actions.onStorage),
+                )
+            }
+            item {
+                SettingsRow(
+                    modifier = Modifier.testTag("helpButton"),
+                    icon = Icons.AutoMirrored.Outlined.HelpOutline,
+                    title = stringResource(MR.string.settings_help),
+                    supportingText = stringResource(MR.string.settings_help_desc),
+                    action = SettingsRowAction.Navigate(actions.onHelp),
+                )
+            }
+            item {
+                Text(
+                    text = stringResource(MR.string.app_version, uiState.appVersion),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(start = 56.dp, end = 16.dp, top = 8.dp),
+                )
+            }
+
+            item { HubSectionHeader(stringResource(MR.string.settings_section_account_actions)) }
+            item {
+                SettingsRow(
+                    modifier = Modifier.testTag("logoutButton"),
+                    icon = Icons.AutoMirrored.Outlined.Logout,
+                    title = stringResource(MR.string.settings_logout),
+                    supportingText = stringResource(MR.string.settings_logout_desc),
+                    action = SettingsRowAction.Invoke {
+                        onAction(SettingsUiAction.LogoutClicked)
+                    },
+                )
+            }
+            item { HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp)) }
+            item {
+                SettingsRow(
+                    modifier = Modifier.testTag("deleteAccountButton"),
+                    icon = Icons.Outlined.Delete,
+                    title = stringResource(MR.string.settings_delete_account),
+                    supportingText = stringResource(MR.string.settings_delete_account_desc),
+                    isDestructive = true,
+                    action = SettingsRowAction.Invoke {
+                        onAction(SettingsUiAction.DeleteAccount)
+                    },
+                )
+            }
+
+            item { Spacer(modifier = Modifier.height(24.dp)) }
         }
     }
 }
 
+@Composable
+private fun IdentityHeader(
+    session: OwnerSession?,
+    onEditProfile: () -> Unit,
+    onEditAvatar: () -> Unit,
+) {
+    val editProfile = stringResource(MR.string.settings_edit_profile)
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .testTag("profileHeader")
+            .clickable(onClickLabel = editProfile, onClick = onEditProfile)
+            .padding(horizontal = 16.dp, vertical = 20.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        // IconButton reports a 48.dp minimum touch target, so the box is oversized to let the
+        // badge ride the avatar rim instead of covering its face. The visible disc is the icon.
+        // 85.5 = 36 (avatar radius) + 36/sqrt(2) (rim at 45 degrees) + 24 (half the button).
+        Box(modifier = Modifier.size(85.5.dp)) {
+            Box(
+                modifier = Modifier
+                    .align(Alignment.TopStart)
+                    .size(72.dp)
+                    // ContactAvatar hardcodes its own contentDescription; unsilenced it would
+                    // be read before the person's name.
+                    .clearAndSetSemantics {},
+            ) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .clip(CircleShape)
+                        .background(MaterialTheme.colorScheme.surfaceContainerHigh),
+                )
+                session?.let {
+                    ContactAvatar(
+                        odinId = it.odinId,
+                        profileImageData = null,
+                        initials = it.initials(),
+                        options = AvatarOptions(size = 72.dp),
+                        sharedTransitionScope = null,
+                        animatedVisibilityScope = null,
+                        cacheBustKey = it.profileImageLastModified,
+                    )
+                }
+            }
+            IconButton(
+                onClick = onEditAvatar,
+                modifier = Modifier
+                    .align(Alignment.BottomEnd)
+                    .testTag("avatarEditButton"),
+            ) {
+                Icon(
+                    imageVector = Icons.Outlined.PhotoCamera,
+                    contentDescription = stringResource(MR.string.cd_profile_avatar_change_photo),
+                    tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                    modifier = Modifier
+                        .size(24.dp)
+                        .clip(CircleShape)
+                        .background(MaterialTheme.colorScheme.primaryContainer)
+                        .border(2.dp, MaterialTheme.colorScheme.surface, CircleShape)
+                        .padding(5.dp),
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.width(16.dp))
+
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = session?.displayName ?: "",
+                style = MaterialTheme.typography.titleLarge,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            Text(
+                text = session?.odinId?.domainName ?: "",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+
+        Icon(
+            imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@Composable
+private fun HubSectionHeader(title: String) {
+    SettingsSectionHeader(
+        title = title,
+        modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 20.dp, bottom = 8.dp),
+    )
+}
+
+// Decorative: the row's supporting text already states the status in words.
 @Composable
 private fun NotificationStatusIndicator(status: NotificationVerificationStatus) {
     when (status) {
@@ -414,14 +532,14 @@ private fun NotificationStatusIndicator(status: NotificationVerificationStatus) 
 
         NotificationVerificationStatus.OK -> Icon(
             imageVector = Icons.Outlined.CheckCircle,
-            contentDescription = stringResource(MR.string.settings_notifications_active),
+            contentDescription = null,
             tint = ExtendedColors.Success,
             modifier = Modifier.size(20.dp),
         )
 
         NotificationVerificationStatus.ERROR -> Icon(
             imageVector = Icons.Outlined.Error,
-            contentDescription = stringResource(MR.string.settings_notifications_issue),
+            contentDescription = null,
             tint = MaterialTheme.colorScheme.error,
             modifier = Modifier.size(20.dp),
         )
@@ -435,13 +553,19 @@ fun SettingsUiPreview() {
         SettingsUi(
             uiState = SettingsUiState(),
             onAction = {},
-            onBackClick = {},
-            onNavigateToNotifications = {},
-            onNavigateToAppearance = {},
-            onNavigateToVaultSettings = {},
-            onNavigateToStorage = {},
-            onNavigateToHelp = {},
-            onNavigateToMomentsSettings = {},
+            actions = SettingsActions(
+                onBack = {},
+                onNotifications = {},
+                onAppearance = {},
+                onStorage = {},
+                onHelp = {},
+                onMomentsSettings = {},
+                onVaultSettings = {},
+                onLocation = {},
+                onContactBookSettings = {},
+                onProfileEdit = {},
+                onProfileAvatarEdit = {},
+            ),
         )
     }
 }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/settings/SettingsUiState.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/settings/SettingsUiState.kt
@@ -1,6 +1,7 @@
 package id.homebase.core.ui.screens.settings
 
 import id.homebase.api.client.auth.OwnerSession
+import id.homebase.core.settings.ThemeState
 
 enum class NotificationVerificationStatus { CHECKING, OK, ERROR }
 
@@ -9,6 +10,10 @@ data class SettingsUiState(
     val isLoggingOut: Boolean = false,
     val ownerSession: OwnerSession? = null,
     val notificationStatus: NotificationVerificationStatus = NotificationVerificationStatus.CHECKING,
+    val theme: ThemeState = ThemeState.System,
+    val appVersion: String = "",
+    /** Null until the off-main measurement lands; the row shows a description meanwhile. */
+    val storageUsedBytes: Long? = null,
 
     val uiEvent: SettingsUiEvent? = null,
     val uiDialog: SettingsUiDialog? = null,

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/settings/SettingsViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/settings/SettingsViewModel.kt
@@ -4,34 +4,49 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import co.touchlab.kermit.Logger
 import id.homebase.api.client.auth.OwnerSessionRepository
+import id.homebase.api.client.cache.CacheStats
+import id.homebase.api.client.drives.cache.DriveFileProviderCached
+import id.homebase.api.client.profile.PublicProfileProviderCached
+import id.homebase.api.sync.database.DatabaseSizeProbe
 import id.homebase.api.youauth.YouAuthFlowManager
 import id.homebase.core.logging.LoggerConfig
 import id.homebase.core.notifications.NotificationService
 import id.homebase.core.notifications.SubscriptionVerificationStatus
+import id.homebase.core.settings.UserPreferences
 import id.homebase.core.share.ShareCacheStorage
+import id.homebase.core.util.PlatformInfo
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 class SettingsViewModel(
     private val youAuthFlowManager: YouAuthFlowManager,
     private val ownerSessionRepository: OwnerSessionRepository,
     private val notificationService: NotificationService,
     private val shareCacheStorage: ShareCacheStorage,
+    private val userPreferences: UserPreferences,
+    private val platformInfo: PlatformInfo,
+    private val databaseSizeProbe: DatabaseSizeProbe,
+    private val publicProfileProviderCached: PublicProfileProviderCached,
+    private val driveFileProviderCached: DriveFileProviderCached,
 ) : ViewModel() {
 
     private companion object {
         const val TAG = "Settings"
     }
 
-    private val _uiState = MutableStateFlow(SettingsUiState())
+    private val _uiState = MutableStateFlow(SettingsUiState(appVersion = platformInfo.versionName))
     val uiState: StateFlow<SettingsUiState> = _uiState.asStateFlow()
 
     init {
         loadSettings()
+        observePreferences()
         verifyNotificationSubscription()
+        measureStorageUsage()
     }
 
     private fun loadSettings() {
@@ -39,6 +54,35 @@ class SettingsViewModel(
             ownerSessionRepository.user.collect { session ->
                 _uiState.update { it.copy(ownerSession = session) }
             }
+        }
+    }
+
+    private fun observePreferences() {
+        viewModelScope.launch {
+            userPreferences.preferenceState.collect { prefs ->
+                _uiState.update { it.copy(theme = prefs.theme) }
+            }
+        }
+    }
+
+    /**
+     * Database + managed caches, measured off the main dispatcher after first frame so
+     * opening Settings never waits on file I/O. The row shows a description until it lands.
+     */
+    private fun measureStorageUsage() {
+        viewModelScope.launch {
+            val bytes = withContext(Dispatchers.Default) {
+                runCatching {
+                    val caches = publicProfileProviderCached.getCacheStats() +
+                        driveFileProviderCached.getCacheStats()
+                    caches.sumOf { if (it.sizeBytes == CacheStats.UNAVAILABLE) 0L else it.sizeBytes } +
+                        databaseSizeProbe.sizeBytes()
+                }.getOrElse {
+                    Logger.w(tag = TAG, throwable = it) { "storage usage probe failed" }
+                    return@withContext null
+                }
+            }
+            if (bytes != null) _uiState.update { it.copy(storageUsedBytes = bytes) }
         }
     }
 

--- a/homebase-core/src/commonTest/kotlin/id/homebase/core/ui/screens/settings/SettingsUiTest.kt
+++ b/homebase-core/src/commonTest/kotlin/id/homebase/core/ui/screens/settings/SettingsUiTest.kt
@@ -1,153 +1,199 @@
 package id.homebase.core.ui.screens.settings
 
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.ComposeUiTest
 import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.semantics.getOrNull
+import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
-import androidx.compose.ui.test.performScrollTo
+import androidx.compose.ui.test.performScrollToNode
 import androidx.compose.ui.test.runComposeUiTest
+import id.homebase.core.settings.ThemeState
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 @OptIn(ExperimentalTestApi::class)
 class SettingsUiTest {
 
-    @Test
-    fun showsTitle() = runComposeUiTest {
+    /** Records which nav lambda fired, so a row wired to the wrong route fails loudly. */
+    private class Routes {
+        val fired = mutableListOf<String>()
+
+        fun actions() = SettingsActions(
+            onBack = { fired += "back" },
+            onNotifications = { fired += "notifications" },
+            onAppearance = { fired += "appearance" },
+            onStorage = { fired += "storage" },
+            onHelp = { fired += "help" },
+            onMomentsSettings = { fired += "moments" },
+            onVaultSettings = { fired += "vault" },
+            onLocation = { fired += "location" },
+            onContactBookSettings = { fired += "contactBook" },
+            onProfileEdit = { fired += "profileEdit" },
+            onProfileAvatarEdit = { fired += "profileAvatarEdit" },
+        )
+    }
+
+    private fun ComposeUiTest.tapRow(tag: String) {
+        onNodeWithTag("settingsList").performScrollToNode(hasTestTag(tag))
+        onNodeWithTag(tag).performClick()
+    }
+
+    private fun ComposeUiTest.settings(
+        uiState: SettingsUiState = SettingsUiState(),
+        routes: Routes = Routes(),
+        onAction: (SettingsUiAction) -> Unit = {},
+    ) {
         setContent {
             MaterialTheme {
-                SettingsUi(
-                    uiState = SettingsUiState(),
-                    onAction = {},
-                    onBackClick = {},
-                    onNavigateToNotifications = {},
-                    onNavigateToAppearance = {},
-                    onNavigateToStorage = {},
-                    onNavigateToHelp = {},
-                    onNavigateToMomentsSettings = {}
-                )
+                SettingsUi(uiState = uiState, onAction = onAction, actions = routes.actions())
             }
         }
+    }
+
+    @Test
+    fun showsTitle() = runComposeUiTest {
+        settings()
         onNodeWithTag("settingsTitle").assertExists()
     }
 
     @Test
-    fun showsAllMenuItems() = runComposeUiTest {
-        setContent {
-            MaterialTheme {
-                SettingsUi(
-                    uiState = SettingsUiState(),
-                    onAction = {},
-                    onBackClick = {},
-                    onNavigateToNotifications = {},
-                    onNavigateToAppearance = {},
-                    onNavigateToStorage = {},
-                    onNavigateToHelp = {},
-                    onNavigateToMomentsSettings = {}
+    fun backButtonNavigatesBack() = runComposeUiTest {
+        val routes = Routes()
+        settings(routes = routes)
+        onNodeWithTag("settingsBackButton").performClick()
+        assertEquals(listOf("back"), routes.fired)
+    }
 
-                )
-            }
+    /**
+     * Walks the hub top to bottom. Order matters: the app bar is pinned, so scrolling *up*
+     * to a row can park it under the bar and swallow the tap.
+     */
+    @Test
+    fun everyNavigationRowReachesItsOwnRoute() = runComposeUiTest {
+        val routes = Routes()
+        settings(routes = routes)
+
+        val expected = listOf(
+            "notificationsButton" to "notifications",
+            "appearanceButton" to "appearance",
+            "momentsSettingsButton" to "moments",
+            "vaultSettingsButton" to "vault",
+            "locationSettingsButton" to "location",
+            "contactBookSettingsButton" to "contactBook",
+            "storageButton" to "storage",
+            "helpButton" to "help",
+        )
+        expected.forEach { (tag, route) ->
+            tapRow(tag)
+            assertEquals(route, routes.fired.lastOrNull(), "wrong route for $tag")
         }
-        onNodeWithTag("notificationsButton").assertExists()
-        onNodeWithTag("securitySetupButton").assertExists()
-        onNodeWithTag("appearanceButton").assertExists()
-        onNodeWithTag("helpButton").assertExists()
-        onNodeWithTag("deleteAccountButton").performScrollTo().assertExists()
-        onNodeWithTag("logoutButton").performScrollTo().assertExists()
+
+        assertEquals(expected.map { it.second }, routes.fired)
     }
 
     @Test
-    fun notificationsClickNavigates() = runComposeUiTest {
-        var navigated = false
-        setContent {
-            MaterialTheme {
-                SettingsUi(
-                    uiState = SettingsUiState(),
-                    onAction = {},
-                    onBackClick = {},
-                    onNavigateToNotifications = { navigated = true },
-                    onNavigateToAppearance = {},
-                    onNavigateToStorage = {},
-                    onNavigateToHelp = {},
-                    onNavigateToMomentsSettings = {}
-
-                )
-            }
-        }
-        onNodeWithTag("notificationsButton").performClick()
-        assertTrue(navigated)
+    fun securitySetupFiresAction() = runComposeUiTest {
+        var fired = false
+        settings(onAction = { if (it is SettingsUiAction.SecuritySetupClicked) fired = true })
+        tapRow("securitySetupButton")
+        assertTrue(fired)
     }
 
     @Test
-    fun appearanceClickNavigates() = runComposeUiTest {
-        var navigated = false
-        setContent {
-            MaterialTheme {
-                SettingsUi(
-                    uiState = SettingsUiState(),
-                    onAction = {},
-                    onBackClick = {},
-                    onNavigateToNotifications = {},
-                    onNavigateToAppearance = { navigated = true },
-                    onNavigateToStorage = {},
-                    onNavigateToHelp = {},
-                    onNavigateToMomentsSettings = {}
+    fun profileHeaderOpensProfileEdit() = runComposeUiTest {
+        var fired = false
+        settings(onAction = { if (it is SettingsUiAction.ProfileInfoClicked) fired = true })
+        tapRow("profileHeader")
+        assertTrue(fired)
+    }
 
-                )
-            }
-        }
-        onNodeWithTag("appearanceButton").performClick()
-        assertTrue(navigated)
+    @Test
+    fun avatarBadgeOpensAvatarEdit() = runComposeUiTest {
+        var fired = false
+        settings(onAction = { if (it is SettingsUiAction.AvatarClicked) fired = true })
+        tapRow("avatarEditButton")
+        assertTrue(fired)
     }
 
     @Test
     fun logoutFiresAction() = runComposeUiTest {
-        var loggedOut = false
-        setContent {
-            MaterialTheme {
-                SettingsUi(
-                    uiState = SettingsUiState(),
-                    onAction = { action ->
-                        if (action is SettingsUiAction.LogoutClicked) {
-                            loggedOut = true
-                        }
-                    },
-                    onBackClick = {},
-                    onNavigateToNotifications = {},
-                    onNavigateToAppearance = {},
-                    onNavigateToStorage = {},
-                    onNavigateToHelp = {},
-                    onNavigateToMomentsSettings = {}
-
-                )
-            }
-        }
-        onNodeWithTag("logoutButton").performScrollTo().performClick()
-        assertTrue(loggedOut)
+        var fired = false
+        settings(onAction = { if (it is SettingsUiAction.LogoutClicked) fired = true })
+        tapRow("logoutButton")
+        assertTrue(fired)
     }
 
     @Test
     fun deleteAccountFiresAction() = runComposeUiTest {
-        var deleteClicked = false
-        setContent {
-            MaterialTheme {
-                SettingsUi(
-                    uiState = SettingsUiState(),
-                    onAction = { action ->
-                        if (action is SettingsUiAction.DeleteAccount) {
-                            deleteClicked = true
-                        }
-                    },
-                    onBackClick = {},
-                    onNavigateToNotifications = {},
-                    onNavigateToAppearance = {},
-                    onNavigateToStorage = {},
-                    onNavigateToHelp = {},
-                    onNavigateToMomentsSettings = {}
-                )
+        var fired = false
+        settings(onAction = { if (it is SettingsUiAction.DeleteAccount) fired = true })
+        tapRow("deleteAccountButton")
+        assertTrue(fired)
+    }
+
+    @Test
+    fun notificationRowStatesItsHealthInWords() = runComposeUiTest {
+        settings(uiState = SettingsUiState(notificationStatus = NotificationVerificationStatus.OK))
+        onNodeWithText("Push notifications are working").assertExists()
+    }
+
+    @Test
+    fun blockedNotificationsSayWhatIsWrong() = runComposeUiTest {
+        settings(
+            uiState = SettingsUiState(notificationStatus = NotificationVerificationStatus.ERROR),
+        )
+        onNodeWithText("Push notifications aren't working").assertExists()
+    }
+
+    @Test
+    fun appearanceRowShowsTheCurrentTheme() = runComposeUiTest {
+        settings(uiState = SettingsUiState(theme = ThemeState.Dark))
+        onNodeWithText("Theme: Dark").assertExists()
+    }
+
+    /**
+     * Delete opens an in-app dialog, so it must not carry the external affordance or its
+     * "Open externally" click label — Security setup one section up genuinely does leave.
+     */
+    @Test
+    fun deleteAccountDoesNotClaimToLeaveTheApp() = runComposeUiTest {
+        settings()
+        onNodeWithTag("settingsList").performScrollToNode(hasTestTag("deleteAccountButton"))
+        onNodeWithTag("deleteAccountButton").assert(
+            SemanticsMatcher("has no click label") { node ->
+                node.config.getOrNull(SemanticsActions.OnClick)?.label == null
             }
-        }
-        onNodeWithTag("deleteAccountButton").performScrollTo().performClick()
-        assertTrue(deleteClicked)
+        )
+    }
+
+    @Test
+    fun securitySetupStillAnnouncesThatItLeavesTheApp() = runComposeUiTest {
+        settings()
+        onNodeWithTag("securitySetupButton").assert(
+            SemanticsMatcher("has an 'Open externally' click label") { node ->
+                node.config.getOrNull(SemanticsActions.OnClick)?.label == "Open externally"
+            }
+        )
+    }
+
+    @Test
+    fun storageRowDescribesItselfUntilTheSizeLands() = runComposeUiTest {
+        settings()
+        onNodeWithTag("settingsList").performScrollToNode(hasTestTag("storageButton"))
+        onNodeWithText("Caches, database and media").assertExists()
+    }
+
+    @Test
+    fun storageRowShowsTheSizeOnceMeasured() = runComposeUiTest {
+        settings(uiState = SettingsUiState(storageUsedBytes = 1024L * 1024L * 3))
+        onNodeWithTag("settingsList").performScrollToNode(hasTestTag("storageButton"))
+        onNodeWithText("3.0 MB used on this device").assertExists()
     }
 }


### PR DESCRIPTION
**Layer 2 of 2 for #1188.** Stacked on #1217 — review that one first; this diff is only the hub. Closes #1188.

## Before

Thirteen visually identical rows under one "General" header. No supporting text anywhere, so you had to open a page to learn what it was. No trailing affordance on any navigating row, so a navigating row and an inert one looked the same. A silently-clickable 96dp avatar going to avatar edit **plus** a separate "Profile info" row going somewhere else — two unmarked doors into profile editing. And four of eleven routes defaulting to `= {}`, so a forgotten wiring was a silently dead row rather than a compile error.

## After

**Identity → Preferences → Apps → Device → Account actions.**

- **Identity block** folds the old avatar row and the "Profile info" row into one marked target: trailing chevron plus `clickable(onClickLabel = …)` so a screen reader announces the destination. The photo picker keeps its own destination as a nested `IconButton` badge on the avatar rim — a 48dp touch target behind a 24dp disc.
- **Security setup** sits directly under it, `OpenInNew`, because it genuinely leaves the app.
- **Every row carries supporting text**, all ≤33 characters so nothing wraps: Notifications states its health in words as well as the glyph, Appearance shows the current theme, Storage shows real usage.
- **Storage is measured off-main** in `SettingsViewModel.measureStorageUsage()` and shows a description until it lands, so entering Settings never hitches on a cache+directory walk.
- **Log out drops to neutral weight** and is separated by a `HorizontalDivider` from **Delete my account**, which is error-tinted and says "Permanent, in your owner console".
- `LazyColumn`, not `Column` + twelve hand-written `Spacer(8.dp)`.

**`SettingsActions`** replaces the eleven-lambda signature with one data class carrying **no defaults**, constructed at the `AppNavHost` call site. A route the navigation graph forgets to supply is now a compile error. `SettingsUiTest` grew 6 → 15 tests and asserts every row fires *its own* lambda, so a **mis-wired** route fails, not just a dead one.

## Two things worth reviewing closely

**Delete my account is `Invoke`, so it renders no trailing icon.** It was `External` — which rendered `OpenInNew` and announced "Open externally" — but tapping it opens an in-app confirm dialog, while Security setup one section above genuinely leaves. Same affordance, two meanings, one screen apart, in the PR whose thesis is that the trailing element tells the truth. A trailing ellipsis ("Delete my account…") was considered and rejected as an Apple/Windows convention rather than Material; this also ships on Android. The row is marked by error colour on title and icon plus its supporting text. Two tests pin the distinction from both sides.

**The leading icons are `Icons.Outlined.*`.** An earlier pass moved them to `Filled` because several `Outlined` glyphs *render* solid. A probe over each `ImageVector`'s path-node tree showed why: `Security`, `Storage` and `HelpOutline` are **single-asset** in Material — byte-identical artwork in both namespaces — so no namespace choice makes the rail fully uniform. `Outlined` won on the argument that actually matters: every sibling settings screen already uses it, and the hub was showing a solid padlock while the Vault screen one tap away showed a hollow one. The three single-asset glyphs will always read denser; that is a Material limitation, not a bug to chase. `SettingsRow`'s `icon` KDoc pins the family so this can't silently rot.

## Verification

`homebase-common:jvmTest homebase-core:jvmTest --rerun-tasks` green — 789 tests, 0 failures, Konsist included. Danish parity checked both directions: no orphans, no `settings_*` key missing from `values-da`, dead keys deleted in the same commit.

Verified on an iPhone 17 Pro simulator (iOS 26.5), light and dark. Independently UI/UX-reviewed across four rounds, scoring **6.4 → 7.9 → 7.5 → 8.7**. Confirmed from `native-describe-screen`, not inferred from code:
- Toggle rows expose **exactly one** node — `traits: ["button","selected","toggleButton"]` — so VoiceOver reads the state. Previously: a stateless button plus a second unlabeled control.
- Security setup: `label: "Security setup, Password and recovery key"` with `hint: "Open externally"` as a separate field.
- Delete my account: `traits: ["button"]`, **no hint key** — no false external claim.
- Identity row leads with `"Samwise Gamgeex, samwise.gamgee.demo.rocks"`; "Public avatar" silenced via `clearAndSetSemantics {}`.
- Every row exactly 72pt; contrast 6.2–16.8:1 light, 9.3–13.1:1 dark; ~1.86 viewports for 13 destinations.

## Known follow-ups, not in this PR

- `HelpScreen`'s `HelpSectionHeader` is a 9-call-site duplicate of the same pattern (Help + DeveloperMenuScreen) with chevrons on rows that open a browser — filed as **#1215**. Help was outside the issue's sub-screen sweep.
- Sibling screens now sharing `SettingsRow` pass no `supportingText`, so "no bare titles" holds on the hub only.
- Sibling screens have no heading landmarks; the hub now has four.
- `Icons.Outlined.People` renders solid and `PeopleOutline` exists in the bundled klib — a one-line polish item.
- The pinned app bar means `performScrollToNode` **upward** parks a row under the bar and swallows the tap; `everyNavigationRowReachesItsOwnRoute` walks strictly top-to-bottom and carries a comment saying so. Reordering the hub means reordering that list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)