### PR TITLE
ci: run PR checks on stacked pull requests, not just those targeting main

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -3,8 +3,9 @@ name: Build Check
 on:
   push:
     branches: [main]
+  # Unfiltered: a stacked PR based on a feature branch gets no checks at all if
+  # this is restricted to main, so a layer can reach merge never having compiled.
   pull_request:
-    branches: [main]
 
 jobs:
   test:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
 
 jobs:
   lint:

--- a/.github/workflows/silent-revert-check.yml
+++ b/.github/workflows/silent-revert-check.yml
@@ -9,7 +9,6 @@ name: Silent-revert check
 
 on:
   pull_request:
-    branches: [main]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Problem

Stacked pull requests get **zero** CI. Not pending, not failing — an empty check list.

All three PR-triggered workflows filtered on `branches: [main]`:

| workflow | trigger |
| --- | --- |
| `build-check.yml` | `pull_request: branches: [main]` |
| `lint.yml` | `pull_request: branches: [main]` |
| `silent-revert-check.yml` | `pull_request: branches: [main]` |

A PR whose base is a feature branch matches none of them, so nothing runs. Combined with feature branches requiring no status checks, a stacked layer can reach merge having never been compiled — the layer is only ever validated after its parent merges and GitHub auto-retargets it to `main`.

This is not a repository setting. Branch protection decides which checks are *required*; whether a workflow **runs at all** is the `on:` trigger in the workflow file.

## Change

Drop the `branches` filter from `pull_request` in all three. `push` is left on `main` only, so feature-branch pushes don't each trigger a full build — the checks come from the PR, once.

`silent-revert-check.yml` needed nothing else: it already resolves its comparison base dynamically from `github.base_ref` and fetches `origin/${{ github.base_ref }}`, so it works against a feature-branch base as-is.

## Not changed

Required status checks on `main` are untouched — still `Run unittests`, `JVM Test Results`, `Build Android & Desktop on ubuntu-latest`, `Build iOS on macos-latest`, `strict: true`. Feature branches require no contexts, so stacked layers now get **visible signal without a new hard gate**. The gate stays at the merge-to-main boundary, which is where it belongs.

## Note for whoever merges this

For `pull_request` events, Actions takes the workflow file from the **merge commit** (head merged into base), not from `main`. So merging this does not retroactively enable CI on an already-open stacked PR whose base branch predates it — `main` has to be merged into the parent feature branch first for the layer above to inherit the new trigger.

## Cost

Every stacked layer now runs the full matrix, including the macOS iOS build. If that proves too expensive, the cheaper option is to gate only the heavy job rather than the whole workflow — add to `build`:

```yaml
if: github.event_name == 'push' || github.base_ref == 'main'
```

That keeps fast signal (unit tests, lint) on every layer and pays for the full build only where it is required. Deliberately not done here: the immediate problem is layers merging uncompiled, and cost can be tuned once we see real numbers.

## Verification

All three files parse, triggers and jobs intact:

```
build-check.yml            on={'push': {'branches': ['main']}, 'pull_request': None}   jobs=['test', 'build']
lint.yml                   on={'push': {'branches': ['main']}, 'pull_request': None}   jobs=['lint']
silent-revert-check.yml    on={'pull_request': None}                                   jobs=['check']
```

(`pull_request: None` is PyYAML rendering a trigger with no filters — which is the point of the change.)

This PR targets `main`, so its own checks exercise the edited workflows directly.
