### PR TITLE
fix(i18n): make HelpUiEvent.ShowError carry a StringResource so raw strings are unrepresentable (#1229)

### DIFF
--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -307,6 +307,10 @@
     <string name="help_ffmpeg_version">FFmpeg</string>
     <string name="help_terms_privacy">Terms &amp; Privacy Policy</string>
     <string name="help_copyright">Copyright © 2024–2026 Homebase</string>
+    <string name="help_share_log_failed">Couldn't share the log: %1$s</string>
+    <string name="help_no_log_files">No log files found.</string>
+    <string name="help_logging_not_initialized">Logging isn't ready yet. Try again in a moment.</string>
+    <string name="help_developer_menu_enabled">Developer menu enabled.</string>
     <string name="settings_delete_account_dialog_title">Delete your account?</string>
     <string name="settings_delete_account_dialog_text">Your account is much more than only this app. If you want to remove your account, you can do so in the owner console.</string>
     <string name="settings_open_owner_console">Open owner console</string>

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/help/HelpScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/help/HelpScreen.kt
@@ -48,11 +48,13 @@ import id.homebase.core.widget.SettingsSectionHeader
 import id.homebase.resources.MR
 import id.homebase.resources.about_homebase
 import id.homebase.resources.dev_menu_title
+import id.homebase.resources.error_unknown
 import id.homebase.resources.help_contact_us
 import id.homebase.resources.help_copyright
 import id.homebase.resources.help_debug_log_description
 import id.homebase.resources.help_enable_error_collection
 import id.homebase.resources.help_ffmpeg_version
+import id.homebase.resources.help_share_log_failed
 import id.homebase.resources.help_submit_debug_log
 import id.homebase.resources.help_support_center
 import id.homebase.resources.help_terms_privacy
@@ -67,6 +69,7 @@ import id.homebase.resources.update_get_update
 import id.homebase.resources.update_not_supported
 import id.homebase.resources.update_using_latest_version
 import kotlinx.coroutines.launch
+import org.jetbrains.compose.resources.getString
 import org.jetbrains.compose.resources.stringResource
 
 @Composable
@@ -94,8 +97,10 @@ fun HelpScreen(
                     file = event.filePath,
                     onError = { error ->
                         scope.launch {
+                            val detail = error.message?.takeIf { it.isNotBlank() }
+                                ?: getString(MR.string.error_unknown)
                             snackbarHostState.showSnackbar(
-                                message = "Failed to share log: ${error.message}"
+                                message = getString(MR.string.help_share_log_failed, detail)
                             )
                         }
                     },
@@ -104,7 +109,7 @@ fun HelpScreen(
 
             is HelpUiEvent.ShowError -> {
                 viewModel.eventConsumed()
-                scope.launch { snackbarHostState.showSnackbar(message = event.message) }
+                scope.launch { snackbarHostState.showSnackbar(message = getString(event.res)) }
             }
 
             is HelpUiEvent.OpenDeveloperMenu -> {

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/help/HelpUiState.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/help/HelpUiState.kt
@@ -1,6 +1,7 @@
 package id.homebase.core.ui.screens.help
 
 import kotlinx.io.files.Path
+import org.jetbrains.compose.resources.StringResource
 
 data class HelpUiState(
     val appVersion: String,
@@ -29,5 +30,5 @@ sealed interface HelpUiEvent {
     data object OpenDeveloperMenu : HelpUiEvent
     data class OpenUrl(val url: String) : HelpUiEvent
     data class ShareFile(val filePath: Path) : HelpUiEvent
-    data class ShowError(val message: String) : HelpUiEvent
+    data class ShowError(val res: StringResource) : HelpUiEvent
 }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/help/HelpViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/help/HelpViewModel.kt
@@ -13,6 +13,10 @@ import id.homebase.core.ui.screens.help.HelpUiEvent.ShareFile
 import id.homebase.core.ui.screens.help.HelpUiEvent.ShowError
 import id.homebase.core.updater.UpdateAppManager
 import id.homebase.core.util.PlatformInfo
+import id.homebase.resources.MR
+import id.homebase.resources.help_developer_menu_enabled
+import id.homebase.resources.help_logging_not_initialized
+import id.homebase.resources.help_no_log_files
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -70,10 +74,14 @@ class HelpViewModel(
                     if (logFile != null) {
                         _uiState.update { it.copy(uiEvent = ShareFile(logFile)) }
                     } else {
-                        _uiState.update { it.copy(uiEvent = ShowError("No log files found")) }
+                        _uiState.update {
+                            it.copy(uiEvent = ShowError(MR.string.help_no_log_files))
+                        }
                     }
                 } else {
-                    _uiState.update { it.copy(uiEvent = ShowError("Logging not initialized")) }
+                    _uiState.update {
+                        it.copy(uiEvent = ShowError(MR.string.help_logging_not_initialized))
+                    }
                 }
             }
 
@@ -100,11 +108,10 @@ class HelpViewModel(
                     userPreferences.showDeveloperMenu = true
                     Logger.d { "Developer menu enabled after $developerTapCount taps" }
 
-                    // Optional: Show a confirmation message
                     _uiState.update {
                         it.copy(
                             showDeveloperMenu = true,
-                            uiEvent = ShowError("Developer menu enabled!"),
+                            uiEvent = ShowError(MR.string.help_developer_menu_enabled),
                         )
                     }
 


### PR DESCRIPTION
Closes #1229. **Stacked on #1227** (`fix-1215-help-settings-idioms`) — that PR rewrites `HelpScreen.kt`, so fixing this on `main` would collide when it lands. Merge #1227 first; GitHub will retarget this to `main` automatically.

## The fix

`HelpScreen.kt` had a hardcoded user-facing snackbar:

```kotlin
message = "Failed to share log: ${error.message}"
```

Rather than only swapping in a resource, `HelpUiEvent.ShowError` now carries a `StringResource` instead of a `String`:

```kotlin
- data class ShowError(val message: String) : HelpUiEvent
+ data class ShowError(val res: StringResource) : HelpUiEvent
```

so the ViewModel is **structurally unable** to emit a raw string — the same "make the wrong thing unrepresentable" move #1188 applied to row affordances. That converted three more literals in `HelpViewModel` (`No log files found`, `Logging not initialized`, `Developer menu enabled!`) as a consequence rather than by sweep.

Four new resources. The share-failure string is parameterised (`%1$s`) rather than concatenating a translated prefix onto an untranslated suffix, with an `error_unknown` fallback when the exception message is blank.

## Why the guard didn't catch it, and why I did NOT add one

Konsist's `ArchitectureTest` rejects `Text("…")` literals inside Composables. Literals reaching the user by any other route — snackbars, `contentDescription`, dialog text built outside a `Text` call — are unguarded.

I swept for the rest and found roughly **220 candidate hardcoded strings across 8 modules**. A rule broad enough to catch this class would turn `main` red on contact, so adding it here would mean either a 220-site PR or a red build. Neither belongs in this change. A narrow `showSnackbar`-only rule would stay green but catch **none** of them, since every one is constructed a layer up in a ViewModel — so it would be a guard that guards nothing.

That count is a **candidate** count, not a confirmed defect count: 24 of the `Error("…")`/`Success("…")` literals are in `homebase-api`, a network/data layer whose error strings are plausibly internal. The set needs triage before it becomes work. Filed separately rather than asserted here.

`ArchitectureTest` also exempts files starting with `Developer` (`ArchitectureTest.kt:25`), so `DeveloperMenuViewModel`'s literals are outside any rule as currently written.

## Verification

```
:homebase-core:compileKotlinJvm :homebase-common:compileKotlinJvm       BUILD SUCCESSFUL
:homebase-core:compileAndroidMain :homebase-common:compileAndroidMain   BUILD SUCCESSFUL
homebase-common:jvmTest  failures=0 errors=0   (ArchitectureTest/Konsist green)
homebase-core:jvmTest    failures=0 errors=0
```

**Device-verified on a Redmi Note 5 Pro (Android 11):** Help renders correctly and "Submit Debug Log" opens the share sheet with `homebase.log` — the success path through the rewired `ShareFile` event, no crash. The failure branch was not forced on-device; it is covered by the type change and compile-time resource resolution.

## Note

Removed the comment `// Optional: Show a confirmation message` in `HelpViewModel.kt` — it sits on a line this change rewrites and restates the code, which CLAUDE.md says shouldn't exist.
