### PR TITLE
fix(auth): point Create account at homebase.id/app-create-account (#1195)

### DIFF
--- a/homebase-auth/src/commonMain/kotlin/id/homebase/auth/login/LoginViewModel.kt
+++ b/homebase-auth/src/commonMain/kotlin/id/homebase/auth/login/LoginViewModel.kt
@@ -71,7 +71,7 @@ class LoginViewModel(
     fun onAction(action: LoginUiAction) {
         when (action) {
             is LoginUiAction.CreateAccount -> {
-                _uiState.update { it.copy(uiEvent = LoginUiEvent.OpenUrl("https://homebase.id/sign-up")) }
+                _uiState.update { it.copy(uiEvent = LoginUiEvent.OpenUrl("https://homebase.id/app-create-account")) }
             }
 
             is LoginUiAction.LoginClicked -> {


### PR DESCRIPTION
Closes #1195.

Swaps the "Create account" destination from `https://homebase.id/sign-up` to
`https://homebase.id/app-create-account`. The site owns the redirect target, so it can be
retargeted without an app release.

`LoginViewModel` is in `commonMain`, so this covers Android, iOS, Desktop and Web in one
change — all four route through the same `LoginUiAction.CreateAccount → LoginUiEvent.OpenUrl`
path. It's a plain web page, not an OAuth callback, so no session or token handling changes.

### Verification of the destination (the issue's precondition)

`https://homebase.id/app-create-account` is live and resolves — `HTTP/2 200`, served from
Netlify — and client-side redirects to `https://createme.ravenhosting.cloud/`, with a
"Continue to signup" anchor to the same URL as the no-JS fallback. It does not dead-end.

Compile-checked with `./gradlew :homebase-auth:compileKotlinJvm`.

### Not in scope

Auto-filling the Homebase ID on return (#1055) and its callback contract (#1059). Worth
noting for whoever picks those up: #1055's description is stale about the transport — Android
no longer opens sign-up in Chrome Custom Tabs, it uses the in-app `InAppBrowserActivity`
WebView (changed in #1089), and iOS uses `SFSafariViewController` via `InAppBrowser`, not
`ASWebAuthenticationSession`. Also, `homebase.id/app-create-account` currently hardcodes the
createme URL and drops the query string, so a return-URL contract needs a homebase-web change
as well as odin-js.