### PR TITLE
feat(auth): prefill the login field with an identity just created in sign-up

### DIFF
--- a/androidApp/src/main/kotlin/id/homebase/feed/MainActivity.kt
+++ b/androidApp/src/main/kotlin/id/homebase/feed/MainActivity.kt
@@ -18,6 +18,8 @@ import id.homebase.api.client.eventbus.EventBus
 import id.homebase.api.youauth.YouAuthFlowManager
 import id.homebase.core.App
 import id.homebase.core.auth.AuthConnectionCoordinator
+import id.homebase.core.config.AppConfig
+import id.homebase.core.util.CreatedIdentityRelay
 import id.homebase.core.notifications.NotificationEntry
 import id.homebase.core.notifications.NotificationIntentDecision
 import id.homebase.core.notifications.NotificationNavigationEvent
@@ -176,6 +178,19 @@ class MainActivity : AppCompatActivity() {
                 lifecycleScope.launch {
                     eventBus.emit(BackendEvent.DataUpgradeReturned)
                 }
+                intent.data = null
+                return
+            }
+
+            // Sign-up return carrying the identity that was just created.
+            // Path: homebase-fchat://create-account-callback?domain=…
+            // The in-app browser catches this in its own WebView; this is the path for a
+            // delivery that comes back through the OS instead, which would otherwise fall
+            // through to the auth callback below and be parsed as a YouAuth response.
+            if (data.host == AppConfig.CREATE_ACCOUNT_CALLBACK_HOST) {
+                val domain = data.getQueryParameter("domain")
+                Logger.i(tag = "MainActivity") { "Create-account deep link (domain=$domain)" }
+                domain?.takeIf { it.isNotBlank() }?.let { CreatedIdentityRelay.deliver(it) }
                 intent.data = null
                 return
             }

--- a/homebase-auth/src/commonMain/kotlin/id/homebase/auth/login/LoginScreen.kt
+++ b/homebase-auth/src/commonMain/kotlin/id/homebase/auth/login/LoginScreen.kt
@@ -458,6 +458,15 @@ private fun LoginForm(
         mutableStateOf(TextFieldValue(homebaseId, selection = TextRange(homebaseId.length)))
     }
 
+    // The field owns what the user types, so it seeds from state rather than reading it. Re-seed
+    // when a new value does arrive: sign-up hands back the domain it created while this screen is
+    // already composed, and a once-only seed would drop it.
+    LaunchedEffect(homebaseId) {
+        if (homebaseId.isNotBlank() && homebaseId != homebaseIdField.text) {
+            homebaseIdField = TextFieldValue(homebaseId, selection = TextRange(homebaseId.length))
+        }
+    }
+
     // Focus the ID field once on first entry — not on every re-entry/recomposition, which kept
     // re-popping the keyboard (#1054).
     var didFocus by rememberSaveable { mutableStateOf(false) }

--- a/homebase-auth/src/commonMain/kotlin/id/homebase/auth/login/LoginViewModel.kt
+++ b/homebase-auth/src/commonMain/kotlin/id/homebase/auth/login/LoginViewModel.kt
@@ -18,8 +18,10 @@ import id.homebase.core.config.AppConfig
 import id.homebase.core.config.CONFIRMED_CONNECTIONS_CIRCLE_ID
 import id.homebase.core.config.appPermissions
 import id.homebase.core.config.circleDriveTargetRequest
+import id.homebase.core.config.createAccountReturnUrl
 import id.homebase.core.config.targetDriveAccessRequest
 import id.homebase.core.notifications.NotificationService
+import id.homebase.core.util.CreatedIdentityRelay
 import id.homebase.resources.MR
 import id.homebase.resources.error_unknown
 import id.homebase.resources.login_error_generic
@@ -28,6 +30,7 @@ import id.homebase.resources.login_error_not_homebase
 import id.homebase.resources.login_error_tls
 import id.homebase.resources.login_error_unreachable
 import io.ktor.client.HttpClient
+import io.ktor.http.encodeURLParameter
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -35,9 +38,12 @@ import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.Job
+
+private const val CREATE_ACCOUNT_URL = "https://homebase.id/app-create-account"
 
 class LoginViewModel(
     private val youAuthFlowManager: YouAuthFlowManager,
@@ -58,6 +64,7 @@ class LoginViewModel(
 
     init {
         loadUsernameFromStorage()
+        observeCreatedIdentity()
         observeDriveStatuses()
         observeAuthState()
     }
@@ -71,7 +78,7 @@ class LoginViewModel(
     fun onAction(action: LoginUiAction) {
         when (action) {
             is LoginUiAction.CreateAccount -> {
-                _uiState.update { it.copy(uiEvent = LoginUiEvent.OpenUrl("https://homebase.id/app-create-account")) }
+                _uiState.update { it.copy(uiEvent = LoginUiEvent.OpenUrl(createAccountUrl())) }
             }
 
             is LoginUiAction.LoginClicked -> {
@@ -93,6 +100,32 @@ class LoginViewModel(
     }
 
     /* ---------------- PRIVATE ---------------- */
+
+    private fun createAccountUrl(): String {
+        val returnUrl = createAccountReturnUrl() ?: return CREATE_ACCOUNT_URL
+        return "$CREATE_ACCOUNT_URL?returnUrl=${returnUrl.encodeURLParameter()}"
+    }
+
+    /**
+     * Picks up the domain the sign-up flow just created and seeds the Homebase ID field with it.
+     * The value arrives over a deep link any app on the device can fire, so it is only shown once
+     * it parses as an identity.
+     */
+    private fun observeCreatedIdentity() {
+        viewModelScope.launch {
+            CreatedIdentityRelay.domain.filterNotNull().collect { domain ->
+                CreatedIdentityRelay.consume()
+                val created = try {
+                    OdinId(domain)
+                } catch (_: Exception) {
+                    Logger.w(tag = "LoginViewModel", messageString = "Ignoring unparseable created identity: $domain")
+                    return@collect
+                }
+                Logger.i(tag = "LoginViewModel", messageString = "Prefilling with created identity ${created.domainName}")
+                _uiState.update { it.copy(homebaseId = created.domainName, error = null) }
+            }
+        }
+    }
 
     private fun startLogin(homebaseIdValue: String) {
         Logger.i(tag = "LoginViewModel", messageString = "startLogin($homebaseIdValue)")

--- a/homebase-common/src/androidMain/kotlin/id/homebase/core/config/ReturnUrl.android.kt
+++ b/homebase-common/src/androidMain/kotlin/id/homebase/core/config/ReturnUrl.android.kt
@@ -3,3 +3,6 @@ package id.homebase.core.config
 actual fun returnUrl(): String = "${AppConfig.DEEP_LINK_SCHEME}://permission-callback"
 
 actual fun dataUpgradeReturnUrl(): String = "${AppConfig.DEEP_LINK_SCHEME}://data-upgrade-callback"
+
+actual fun createAccountReturnUrl(): String? =
+    "${AppConfig.DEEP_LINK_SCHEME}://${AppConfig.CREATE_ACCOUNT_CALLBACK_HOST}"

--- a/homebase-common/src/androidMain/kotlin/id/homebase/core/util/InAppBrowserActivity.kt
+++ b/homebase-common/src/androidMain/kotlin/id/homebase/core/util/InAppBrowserActivity.kt
@@ -35,7 +35,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -76,7 +75,6 @@ class InAppBrowserActivity : ComponentActivity() {
             HomebaseTheme {
                 var pageTitle by remember { mutableStateOf(host) }
                 var progress by remember { mutableFloatStateOf(0f) }
-                val surface = MaterialTheme.colorScheme.surface
 
                 Scaffold(
                     topBar = {
@@ -138,7 +136,7 @@ class InAppBrowserActivity : ComponentActivity() {
                         modifier = Modifier.fillMaxSize().padding(innerPadding),
                         factory = { context ->
                             WebView(context).apply {
-                                setBackgroundColor(surface.toArgb())
+                                // Default white canvas, not the app's surface — a page shorter than the viewport shows it below the document.
                                 webViewClient = object : WebViewClient() {
                                     // Sign-up ends by navigating at our own scheme. A WebView
                                     // can't load that and doesn't need to — this activity is

--- a/homebase-common/src/androidMain/kotlin/id/homebase/core/util/InAppBrowserActivity.kt
+++ b/homebase-common/src/androidMain/kotlin/id/homebase/core/util/InAppBrowserActivity.kt
@@ -3,6 +3,7 @@ package id.homebase.core.util
 import android.annotation.SuppressLint
 import android.os.Bundle
 import android.webkit.WebChromeClient
+import android.webkit.WebResourceRequest
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.activity.ComponentActivity
@@ -40,6 +41,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.net.toUri
+import id.homebase.core.config.AppConfig
 import id.homebase.core.ui.theme.HomebaseTheme
 import id.homebase.resources.MR
 import id.homebase.resources.close
@@ -137,7 +139,33 @@ class InAppBrowserActivity : ComponentActivity() {
                         factory = { context ->
                             WebView(context).apply {
                                 setBackgroundColor(surface.toArgb())
-                                webViewClient = WebViewClient()
+                                webViewClient = object : WebViewClient() {
+                                    // Sign-up ends by navigating at our own scheme. A WebView
+                                    // can't load that and doesn't need to — this activity is
+                                    // the thing being addressed, so read it here and close,
+                                    // rather than bouncing out through the system.
+                                    override fun shouldOverrideUrlLoading(
+                                        view: WebView,
+                                        request: WebResourceRequest,
+                                    ): Boolean {
+                                        val target = request.url
+                                        if (!target.scheme.equals(
+                                                AppConfig.DEEP_LINK_SCHEME,
+                                                ignoreCase = true,
+                                            )
+                                        ) {
+                                            return false
+                                        }
+
+                                        if (target.host == AppConfig.CREATE_ACCOUNT_CALLBACK_HOST) {
+                                            target.getQueryParameter("domain")
+                                                ?.takeIf { it.isNotBlank() }
+                                                ?.let { CreatedIdentityRelay.deliver(it) }
+                                        }
+                                        this@InAppBrowserActivity.finish()
+                                        return true
+                                    }
+                                }
                                 webChromeClient = object : WebChromeClient() {
                                     override fun onProgressChanged(view: WebView?, newProgress: Int) {
                                         progress = newProgress / 100f

--- a/homebase-common/src/androidMain/kotlin/id/homebase/core/util/InAppBrowserActivity.kt
+++ b/homebase-common/src/androidMain/kotlin/id/homebase/core/util/InAppBrowserActivity.kt
@@ -2,6 +2,7 @@ package id.homebase.core.util
 
 import android.annotation.SuppressLint
 import android.os.Bundle
+import android.view.ViewGroup
 import android.webkit.WebChromeClient
 import android.webkit.WebResourceRequest
 import android.webkit.WebView
@@ -136,6 +137,11 @@ class InAppBrowserActivity : ComponentActivity() {
                         modifier = Modifier.fillMaxSize().padding(innerPadding),
                         factory = { context ->
                             WebView(context).apply {
+                                // Without explicit MATCH_PARENT, WebView resolves every vh unit to 0 — a page laid out with min-h-screen collapses to its content height.
+                                layoutParams = ViewGroup.LayoutParams(
+                                    ViewGroup.LayoutParams.MATCH_PARENT,
+                                    ViewGroup.LayoutParams.MATCH_PARENT,
+                                )
                                 // Default white canvas, not the app's surface — a page shorter than the viewport shows it below the document.
                                 webViewClient = object : WebViewClient() {
                                     // Sign-up ends by navigating at our own scheme. A WebView

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/config/AppConfig.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/config/AppConfig.kt
@@ -39,6 +39,8 @@ object AppConfig {
     // Deep link scheme for returning from permission extension
     const val DEEP_LINK_SCHEME = "homebase-fchat"
 
+    const val CREATE_ACCOUNT_CALLBACK_HOST = "create-account-callback"
+
     const val REPORT_CONTENT_URL = "https://ravenhosting.cloud/report/content"
 }
 
@@ -64,6 +66,17 @@ expect fun returnUrl(): String
  * Same platform split as [returnUrl]: deep link on mobile, localhost loopback on desktop.
  */
 expect fun dataUpgradeReturnUrl(): String
+
+/**
+ * Return URL the sign-up flow sends the user back to once their new identity is set up,
+ * carrying the created domain as `?domain=`. Null where nothing can catch it: the owner
+ * console would redirect the browser at a scheme the OS doesn't know, so those platforms
+ * ask for no return at all and the user finishes in the browser.
+ *
+ * Mobile only today — desktop could use [id.homebase.api.browser.LocalCallbackServer] the
+ * way [returnUrl] does, once a desktop sign-up is worth the route.
+ */
+expect fun createAccountReturnUrl(): String?
 
 // Circle IDs for connected identities
 const val CONFIRMED_CONNECTIONS_CIRCLE_ID = "bb2683fa402aff866e771a6495765a15"

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/util/CreatedIdentityRelay.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/util/CreatedIdentityRelay.kt
@@ -1,0 +1,28 @@
+package id.homebase.core.util
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * The domain of an identity just created in the sign-up flow, on its way to the login screen.
+ *
+ * Written by whichever platform catches the browser coming back — the WebView on Android,
+ * `onOpenURL` on iOS — and read by LoginViewModel, which owns the field it prefills. A relay
+ * rather than a callback registration because the login screen may not exist yet when the
+ * browser returns.
+ *
+ * Reachable by any app on the device that fires the deep link, so treat the value as untrusted:
+ * the reader validates it before showing it.
+ */
+object CreatedIdentityRelay {
+    private val _domain = MutableStateFlow<String?>(null)
+    val domain: StateFlow<String?> = _domain
+
+    fun deliver(domain: String) {
+        _domain.value = domain
+    }
+
+    fun consume() {
+        _domain.value = null
+    }
+}

--- a/homebase-common/src/jvmMain/kotlin/id/homebase/core/config/ReturnUrl.jvm.kt
+++ b/homebase-common/src/jvmMain/kotlin/id/homebase/core/config/ReturnUrl.jvm.kt
@@ -46,3 +46,5 @@ private fun ensureCallbackServer(): Int {
     }
     return port
 }
+
+actual fun createAccountReturnUrl(): String? = null

--- a/homebase-common/src/nativeMain/kotlin/id/homebase/core/config/ReturnUrl.native.kt
+++ b/homebase-common/src/nativeMain/kotlin/id/homebase/core/config/ReturnUrl.native.kt
@@ -3,3 +3,6 @@ package id.homebase.core.config
 actual fun returnUrl(): String = "${AppConfig.DEEP_LINK_SCHEME}://permission-callback"
 
 actual fun dataUpgradeReturnUrl(): String = "${AppConfig.DEEP_LINK_SCHEME}://data-upgrade-callback"
+
+actual fun createAccountReturnUrl(): String? =
+    "${AppConfig.DEEP_LINK_SCHEME}://${AppConfig.CREATE_ACCOUNT_CALLBACK_HOST}"

--- a/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/config/ReturnUrl.web.kt
+++ b/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/config/ReturnUrl.web.kt
@@ -3,3 +3,5 @@ package id.homebase.core.config
 actual fun returnUrl(): String = "${AppConfig.DEEP_LINK_SCHEME}://permission-callback"
 
 actual fun dataUpgradeReturnUrl(): String = "${AppConfig.DEEP_LINK_SCHEME}://data-upgrade-callback"
+
+actual fun createAccountReturnUrl(): String? = null

--- a/iosApp/iosApp/iOSApp.swift
+++ b/iosApp/iosApp/iOSApp.swift
@@ -3,6 +3,7 @@ import FirebaseCore
 import FirebaseCrashlytics
 import FirebaseMessaging
 import ComposeApp
+import SafariServices
 import UserNotifications
 
 class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDelegate {
@@ -251,6 +252,8 @@ struct iOSApp: App {
                 handlePermissionCallbackURL(url)
             case "data-upgrade-callback":
                 handleDataUpgradeCallbackURL()
+            case "create-account-callback":
+                handleCreateAccountCallbackURL(url)
             default:
                 break
             }
@@ -273,6 +276,33 @@ struct iOSApp: App {
     /// owner-console data-upgrade page. Triggers an immediate upgrade status re-check.
     private func handleDataUpgradeCallbackURL() {
         DataUpgradeCallbackBridge.shared.handleDataUpgradeCallback()
+    }
+
+    /// Handles `homebase-fchat://create-account-callback?domain=...`, the return leg of the
+    /// sign-up flow. The owner console redirects at our scheme once the new identity is set up;
+    /// SFSafariViewController hands that to the system, which reopens the app — with the browser
+    /// still presented on top of it, so dismiss it before the login screen underneath is seen.
+    private func handleCreateAccountCallbackURL(_ url: URL) {
+        let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        if let domain = components?.queryItems?.first(where: { $0.name == "domain" })?.value,
+           !domain.isEmpty {
+            CreatedIdentityRelay.shared.deliver(domain: domain)
+        }
+        dismissInAppBrowser()
+    }
+
+    private func dismissInAppBrowser() {
+        guard var top = UIApplication.shared.connectedScenes
+            .compactMap({ ($0 as? UIWindowScene)?.keyWindow })
+            .first?.rootViewController
+        else { return }
+
+        while let presented = top.presentedViewController {
+            top = presented
+        }
+        if top is SFSafariViewController {
+            top.dismiss(animated: true)
+        }
     }
 
     /// Handles `homebase-fchat://permission-callback?status=...` URLs returned from the


### PR DESCRIPTION
Closes #1055. Layer 3 of 3 — with homebase-id/homebase-web#65 and homebase-id/odin-js#888.

"Create account" now opens sign-up with a `returnUrl`. Once the new identity finishes setup, the
owner console sends the user back to `homebase-fchat://create-account-callback?domain=<created>`
and the Homebase ID field is already filled in.

### How the return is caught

Not by the mechanism #1055 describes — that description is stale. Android hasn't used Chrome Custom
Tabs since #1089; both platforms go through `InAppBrowser`:

- **Android** — the browser is our own `InAppBrowserActivity` WebView, so `shouldOverrideUrlLoading`
  sees the navigation directly. No OS deep link, no Custom Tab, nothing to hand off. `MainActivity`
  handles the same URL too, for a delivery that *does* come through the system — without it that URL
  falls through to the auth branch and gets parsed as a YouAuth callback.
- **iOS** — `SFSafariViewController` hands an unknown scheme to the system, which reopens the app
  into `onOpenURL`. The browser stays presented on top, so it is dismissed there.

`createAccountReturnUrl()` is null on desktop and web, where no scheme is registered — those
platforms send no `returnUrl` and the user finishes in the browser exactly as today. Desktop could
use `LocalCallbackServer`, the way the permission flow does, if a desktop sign-up ever wants it.

### Device verification (Redmi Note 5 Pro, Android 11)

Both halves, on the real device:

1. **The full in-app browser path** — with the create-account URL temporarily pointed at a page that
   navigates to the callback: tapping "Create account" opened the WebView, the redirect was
   intercepted, the browser closed itself (`fg->bg` then `bg->fg` in the log), and the field showed
   the domain carried in the URL.
2. **Delivery through the OS** — `am start -d "homebase-fchat://create-account-callback?domain=…"`
   on the login screen: `MainActivity` logged the new branch and the field changed from the stored
   `bishwajeetparhi.dev` to the delivered domain.

The second case is the one that catches the `remember` trap — the field seeds from state once, so a
domain arriving while the login screen is already composed would otherwise be dropped. It re-seeds.

**iOS: verified on an iPhone 17 Pro simulator (iOS 26.5).** Logged out, tapped Create account,
`SFSafariViewController` presented the sign-up page, then fired
`homebase-fchat://create-account-callback?domain=frodo.demo.rocks` at the device. The sheet
dismissed and the login field went from the stored `samwise.gamgee.demo.rocks` to
`frodo.demo.rocks` — so `handleCreateAccountCallbackURL`, `CreatedIdentityRelay`,
`dismissInAppBrowser`'s `is SFSafariViewController` check and the `LaunchedEffect` re-seed all hold.

**iOS shows an extra confirmation Android does not.** Handing the custom scheme back while the
Safari sheet is open raises a system alert — *Open in "Homebase"? [Cancel] [Open]* — and the
hand-back only completes after the user taps Open. Android has no equivalent: the WebView's
`shouldOverrideUrlLoading` intercepts the navigation before the system is ever asked. Worth knowing
this is not the same prompt #1054 avoided, but it is one tap on the way home. I triggered it with
`simctl openurl` rather than an in-page navigation, since the endpoint I could test against does not
carry `returnUrl` yet; an in-page navigation to a custom scheme raises the same alert, but that
specific path is unconfirmed until odin-js#888 is deployed somewhere.

Compiles on JVM, Android, iosSimulatorArm64 and wasmJs.

### Trust boundary

Any app on the device can fire this deep link, so the domain is untrusted: it is only shown once it
parses as an `OdinId`. Worst case is a wrong value in an editable field the user is looking at.

### Also in here: the in-app browser's dark band

Unrelated to the hand-back, but on the same screen. The WebView canvas was painted with
`MaterialTheme.colorScheme.surface`, so in dark mode any page shorter than the viewport showed a
`#1B1C1F` band below the document — and the signup page this PR opens is exactly that.

Not a layout bug: the WebView measured `[0,242][1080,2116]`, filling the window below the top bar,
`scrollable="false"`. Sampled the band on device at full resolution — `(27, 28, 31)`, exactly
`DarkColors.Surface`.

Verified on a Redmi Note 5 Pro (Android 11) against the same page, before and after: below the
document at y=1800..2115 the pixels go from `(27, 28, 31)` to `(255, 255, 255)`.

WebView's default white is what every page we open in it expects — sign-up, owner console and
data-upgrade all render light, since we don't opt into propagating `prefers-color-scheme: dark`.
The override existed to avoid a white flash while loading in dark mode; that trade now goes the
other way.


### And the dead space below the fold

Same screen again. The sign-up page stopped two-thirds down with nothing under it. That turned out
to be ours too, and it is the more interesting of the two.

`AndroidView` built the WebView with no `LayoutParams`, so it inherited `WRAP_CONTENT`. Measured in
the running WebView over CDP:

```
height:100vh  -> 0px        width:100vw -> 392.727px
height:100dvh -> 0px        innerHeight -> 681
height:50vh   -> 0px        documentElement.clientHeight -> 681
```

Every viewport-*height* unit resolved to zero while width units were fine. The sign-up page wraps
itself in `flex min-h-screen flex-col`, so `min-height: 100vh` computed to `0px` and the wrapper
collapsed to its content — 560 CSS px inside a 681 px viewport. The rule was present and matching
(`.min-h-screen { min-height: 100vh; }`, `element.matches()` true, no competing declaration); the
unit itself was worth nothing. A freshly created `div.min-h-screen` appended at runtime measured
`0px` too.

Setting `MATCH_PARENT` explicitly fixes it — after, on the same page and device:

```
height:100vh -> 681.455px   wrapper height 560 -> 681.455   min-height 0px -> 681.455px
```

The footer now sits on the bottom edge rather than mid-page. This applies to every page the in-app
browser opens, not just sign-up.

