### PR TITLE
fix(android): keep the PDF preview rendered across configuration changes

### DIFF
--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -64,6 +64,7 @@
         <activity
             android:exported="true"
             android:name=".MainActivity"
+            android:configChanges="orientation|screenSize|screenLayout|smallestScreenSize|keyboardHidden|uiMode"
             android:windowSoftInputMode="adjustResize"
             android:theme="@style/Theme.Homebase.Splash"
             android:launchMode="singleTask">

--- a/homebase-common/src/androidMain/kotlin/id/homebase/core/pdf/PdfPageViewer.android.kt
+++ b/homebase-common/src/androidMain/kotlin/id/homebase/core/pdf/PdfPageViewer.android.kt
@@ -69,9 +69,16 @@ actual fun PdfPageViewer(
             val fm = activity.supportFragmentManager
             val container = frameLayout.getChildAt(0) as? FragmentContainerView ?: return@AndroidView
             val existing = fm.findFragmentByTag(fragmentTag) as? PdfViewerFragment
-            if (existing == null) {
+            // An Activity recreation (rotation, theme or locale change, split-screen resize)
+            // builds a new container while the FragmentManager restores the old fragment against
+            // the container it was added to — which is gone. Its view has nowhere to live, so the
+            // page area renders blank and stays blank, because the fragment is still findable by
+            // tag. Host a fresh one whenever the one we find isn't in the container we just built.
+            val orphaned = existing != null && existing.view?.parent !== container
+            if (existing == null || orphaned) {
                 val fragment = PdfViewerFragment()
                 fm.beginTransaction()
+                    .apply { if (existing != null) remove(existing) }
                     .replace(container.id, fragment, fragmentTag)
                     .commitAllowingStateLoss()
                 fm.executePendingTransactions()


### PR DESCRIPTION
Closes #1247. Takes both options from the issue, because they fix different halves.

### B — the actual defect (`PdfPageViewer.android.kt`)

An Activity recreation builds a new `FragmentContainerView` (`View.generateViewId()` hands out a
new id each time) while the `FragmentManager` restores the `PdfViewerFragment` against the
container it was added to, which no longer exists. Its view has nowhere to live — and because the
fragment is still findable by tag, `update()` short-circuits to `else if (existing.documentUri !=
uri)`, so the blank never recovers.

The viewer now hosts a fresh fragment whenever the one it finds isn't in the container it just
built:

```kotlin
val orphaned = existing != null && existing.view?.parent !== container
```

### A — stop recreating for the common cases (`AndroidManifest.xml`)

`orientation|screenSize|screenLayout|smallestScreenSize|keyboardHidden|uiMode` on `MainActivity`.
Rotation and theme switches no longer tear down the Activity, so the reading position survives —
which B alone doesn't give you, since it re-hosts a fresh fragment that reopens at page 1.

`uiMode` is safe here: `HomebaseTheme` drives colours from `isSystemInDarkTheme()` and
`UpdateEdgeToEdge` re-applies the system-bar style from a `SideEffect`, both in composition. Neither
depends on the Activity being recreated. Verified on device.

Deliberately **not** declared: `density`, `fontScale`, `locale`, `layoutDirection`. Each one you
declare is one you promise to handle by hand, and a full resource reload is the right default there.
Those still recreate the Activity — which is exactly the path B covers.

### Why not A alone

A removes rotation as a trigger but leaves the orphaning in place. With only the list the issue
proposes, a `uiMode` change still recreates, the ViewModel-held overlay brings the PDF screen
straight back, and it's blank — with no rotation to point at and no obvious repro. Fixing the cause
and removing the trigger are different jobs.

### Device verification (Redmi Note 5 Pro, Android 11)

Reproduced first, on a build with neither change: open the PDF, rotate → top bar intact, document
area completely blank.

Then with both:

1. **Rotate portrait ↔ landscape** — document stays rendered, same page, scroll position kept.
2. **`settings put system font_scale 1.15` with the PDF open** — `fontScale` isn't in the
   `configChanges` list, so this is a genuine Activity recreation (the top-bar text visibly grows,
   confirming resources reloaded). The document re-hosts and renders. **This is B verified on its
   own, with A unable to help.**
3. **`cmd uimode night no` with the PDF open** — theme flips to light, status-bar icons flip with
   it, document stays rendered, no recreation.

Smoke tests across rotation, per the acceptance criteria: conversation list and chat re-layout
cleanly; a bottom sheet (sticker actions) stays open and re-lays out; the composer keeps typed text
with the IME up.

Not covered: preserving position across the config changes that still recreate (2 above reopens at
page 1). `PdfViewerFragment` doesn't expose its scroll state, so that needs more than this fix is
worth.