### PR TITLE
Batch syncAll() page-1 pulls into one query-batch-collection call

### DIFF
--- a/homebase-api/build.gradle.kts
+++ b/homebase-api/build.gradle.kts
@@ -170,6 +170,7 @@ kotlin {
         "id.homebase.api.sync.database.OutboxSetNextRunTimeTest",
         "id.homebase.api.sync.database.OutboxSyncTest",
         "id.homebase.api.sync.database.OutboxTest",
+        "id.homebase.api.sync.DriveSyncCollectionTest",
         "id.homebase.api.sync.DriveSyncManagerTest",
         "id.homebase.api.sync.DriveSyncTest",
         "id.homebase.api.sync.LogoutLoginRoundTripTest",

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveSync.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveSync.kt
@@ -107,30 +107,90 @@ class DriveSync(
             return null
         }
         syncing.value = true // Atomic — mirrors the sync-lock lifetime below
-        job = scope.launch {
-            try {
-                performSync()
-            } finally {
-                job = null
-                syncing.value = false
-                lastStoppedAt.value = UnixTimeUtc().milliseconds
-                mutex.unlock()
-            }
-            if (killroy.value) {
-                Logger.i("DriveSync: killroy triggered recursive sync for drive $driveId")
-                sync()
-            }
-        }
-
+        job = launchRound(prefetched = null)
         return job
     }
 
-    private suspend fun performSync() {
+    /** True when this drive is hosted on a peer (community owner) — excluded from the own-host collection. */
+    internal val isRemote: Boolean get() = ownerOdinId != null
+
+    /** Witness that [beginBatchedRound] holds the sync lock; must be handed back to [resumeBatchedRound]. */
+    internal class BatchedRound(val request: QueryBatchRequest?)
+
+    /**
+     * Batched-round entry: takes the sync lock and returns this round's page-1 request so
+     * [DriveSyncManager.syncAll] can fold it into one query-batch-collection call. Null = a round
+     * is already in flight (killroy set — identical semantics to [sync]). A null [BatchedRound.request]
+     * means "hold the lock but run a plain round" (fresh sync whose policy pre-steps move the cursor
+     * before page 1). The lock stays held across the collection round trip, so killroy coalescing and
+     * cursor confinement keep exactly [sync]'s semantics; the caller MUST always follow up with
+     * [resumeBatchedRound], on every path.
+     *
+     * Started is emitted HERE, not at resume — the round begins now, and the drive must show
+     * Synchronizing while the collection round trip is in flight.
+     */
+    internal suspend fun beginBatchedRound(): BatchedRound? {
+        if (!mutex.tryLock()) {
+            killroy.value = true // Atomic
+            return null
+        }
+        syncing.value = true // Atomic
+        eventBus.emit(BackendEvent.DriveEvent.Started(driveId))
+        val prefetchable = cursor != null ||
+            (policy.fullSyncWindow == null && policy.initialQueries.isEmpty())
+        return BatchedRound(if (prefetchable) buildPageRequest() else null)
+    }
+
+    /**
+     * Batched-round completion: runs the normal sync round, consuming [prefetched] as page 1 when
+     * given. `prefetched = null` runs a plain per-drive round — that IS the fallback for a failed
+     * or missing collection section.
+     */
+    internal fun resumeBatchedRound(@Suppress("UNUSED_PARAMETER") round: BatchedRound, prefetched: QueryBatchResponse?): Job {
+        val newJob = launchRound(prefetched, startedEmitted = true)
+        job = newJob
+        return newJob
+    }
+
+    private fun launchRound(prefetched: QueryBatchResponse?, startedEmitted: Boolean = false): Job = scope.launch {
+        try {
+            performSync(prefetched, startedEmitted)
+        } finally {
+            job = null
+            syncing.value = false
+            lastStoppedAt.value = UnixTimeUtc().milliseconds
+            mutex.unlock()
+        }
+        if (killroy.value) {
+            Logger.i("DriveSync: killroy triggered recursive sync for drive $driveId")
+            sync()
+        }
+    }
+
+    // The single request shape for a sync page — the per-drive loop and the batched section are
+    // both built here so the two paths can never drift. The collection drops maxRecords at
+    // conversion (the budget is collection-level).
+    private fun buildPageRequest() = QueryBatchRequest(
+        queryParams = FileQueryParams(
+            // we want deleted too since we resync when the socket gets a file deleted event
+        ),
+        resultOptionsRequest = QueryBatchResultOptionsRequest(
+            maxRecords = batchSize,
+            includeMetadataHeader = true,
+            cursorState = cursor?.toJson(),
+            includeTransferHistory = true,
+            ordering = QueryBatchSortOrder.OldestFirst,
+            sorting = QueryBatchSortField.AnyChangeDate
+        )
+    )
+
+    private suspend fun performSync(prefetched: QueryBatchResponse? = null, startedEmitted: Boolean = false) {
         var totalCount = 0
         var queryBatchResponse: QueryBatchResponse? = null
         var pendingDbJob: Deferred<Unit>? = null
+        var pendingPrefetch = prefetched
 
-        eventBus.emit(BackendEvent.DriveEvent.Started(driveId))
+        if (!startedEmitted) eventBus.emit(BackendEvent.DriveEvent.Started(driveId))
 
         // Snapshot fresh-sync state BEFORE the windowed loop below mutates `cursor`.
         // Fresh = first login or a discarded stale cursor (loadCursor returned null).
@@ -160,25 +220,19 @@ class DriveSync(
 
         while (true) {
             Logger.i("Synchronizing drive $driveId")
-            val request = QueryBatchRequest(
-                queryParams = FileQueryParams(
-                    // we want deleted too since we resync when the socket gets a file deleted event
-                ),
-                resultOptionsRequest = QueryBatchResultOptionsRequest(
-                    maxRecords = batchSize,
-                    includeMetadataHeader = true,
-                    cursorState = cursor?.toJson(),
-                    includeTransferHistory = true,
-                    ordering = QueryBatchSortOrder.OldestFirst,
-                    sorting = QueryBatchSortField.AnyChangeDate
-                )
-            )
+            val request = buildPageRequest()
+            // Consume the collection-prefetched page 1 exactly once. Don't clear killroy on
+            // that iteration — a change signalled during the collection round trip must
+            // survive into the post-round recursive re-sync.
+            val fromPrefetch = pendingPrefetch != null
 
             var recordsRead = 0
             val durationMs = measureTimedValue {
                 try {
-                    killroy.value = false // Atomic
-                    queryBatchResponse = driveQueryProvider.queryBatch(driveId, request, ownerOdinId)
+                    if (!fromPrefetch) killroy.value = false // Atomic
+                    queryBatchResponse = pendingPrefetch
+                        ?: driveQueryProvider.queryBatch(driveId, request, ownerOdinId)
+                    pendingPrefetch = null
 
                     if (queryBatchResponse.cursorState != null)
                         cursor = QueryBatchCursor.fromJson(queryBatchResponse.cursorState)
@@ -276,7 +330,8 @@ class DriveSync(
                 }
             }
 
-            if (recordsRead > 0) {
+            // A prefetched page has ~0ms duration — adapting on it would spuriously double batchSize.
+            if (recordsRead > 0 && !fromPrefetch) {
                 val batchWas = batchSize
                 if (durationMs.duration.inWholeMilliseconds > 2000)
                     batchSize = ((batchSize * 3) / 4).coerceIn(50, 1000)

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveSyncManager.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveSyncManager.kt
@@ -570,8 +570,9 @@ class DriveSyncManager(
     }
 
     companion object {
-        /** Global record budget for the syncAll collection call — greedy in-order fill server-side. */
-        private const val COLLECTION_BUDGET = 500
+        /** Global record budget for the syncAll collection call — greedy in-order fill server-side.
+         *  1000 is the server's clamp ceiling; asking for more would be silently reduced. */
+        private const val COLLECTION_BUDGET = 1000
 
         /** Floor of the remote-drive retry backoff (first failure waits this long). */
         private const val REMOTE_RETRY_BASE_MS = 1_000L

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveSyncManager.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/DriveSyncManager.kt
@@ -2,6 +2,12 @@ package id.homebase.api.sync
 
 import co.touchlab.kermit.Logger
 import id.homebase.api.client.auth.CredentialsManager
+import id.homebase.api.client.drives.CollectionQueryParamSection
+import id.homebase.api.client.drives.CollectionSectionResultOptions
+import id.homebase.api.client.drives.QueryBatchCollectionRequest
+import id.homebase.api.client.drives.QueryBatchCollectionSection
+import id.homebase.api.client.drives.QueryBatchResponse
+import id.homebase.api.client.drives.QueryBatchSectionStatus
 import id.homebase.api.client.drives.query.DriveQueryProvider
 import id.homebase.api.client.eventbus.BackendEvent
 import id.homebase.api.client.eventbus.EventBus
@@ -45,6 +51,11 @@ class DriveSyncManager(
     // homebase-core's AppModule where chat-specific fileTypes are visible; this layer
     // stays drive-agnostic.
     private val driveSyncPolicies: Map<Uuid, DriveSyncPolicy> = emptyMap(),
+    // Drives likely to carry a large backlog (feed, moments, chat), ordered — placed LAST in the
+    // syncAll collection so the greedy budget serves every small drive first; a big drive only
+    // takes the remainder and continues per-drive. Assembled in AppModule, same key space as
+    // [mandatoryDrives]; this layer stays drive-agnostic.
+    private val collectionTail: List<Uuid> = emptyList(),
 ) {
     // Immutable map reference — always replaced, never mutated in-place, preventing CME.
     // All writes are serialized via driveSyncsMutex, which provides the happens-before
@@ -256,16 +267,131 @@ class DriveSyncManager(
             return
         }
         val snapshot = driveSyncsMutex.withLock { driveSyncs.toList() }
-        // Kick every drive, but only barrier on the user's OWN drives. A remote (owner-hosted) drive
-        // whose owner is offline/slow must not stall the aggregate round via joinAll — its sync is
-        // launched fire-and-forget and reconciled independently through the Stopped/backoff path.
-        val ownJobs = mutableListOf<Job>()
-        for ((driveId, sync) in snapshot) {
-            val job = sync.sync() ?: continue
-            if (_driveStatuses.value[driveId]?.isRemote != true) ownJobs.add(job)
+
+        // Fold the own-host drives' page-1 pulls into ONE query-batch-collection call (#1102).
+        // beginBatchedRound holds each drive's sync lock across the round trip, so killroy
+        // coalescing and cursor confinement keep exactly sync()'s semantics; every fallback —
+        // whole-call failure, failed section, missing section — is resumeBatchedRound(null),
+        // which IS today's per-drive round. [collectionTail] drives go last so the greedy
+        // budget serves every small drive before a large backlog takes the remainder.
+        // Remote (owner-hosted) drives can't join an own-host collection: kicked fire-and-forget
+        // as before, so an offline owner never stalls the aggregate round.
+        val tailOrder = collectionTail.withIndex().associate { (i, id) -> id to i }
+        val ordered = snapshot.sortedBy { (driveId, _) -> tailOrder[driveId] ?: -1 }
+
+        val rounds = mutableListOf<BatchedDrive>()
+        for ((driveId, sync) in ordered) {
+            if (sync.isRemote) {
+                sync.sync()
+                continue
+            }
+            val round = sync.beginBatchedRound() ?: continue // busy → killroy set, as today
+            rounds += BatchedDrive(driveId, sync, round)
         }
-        ownJobs.joinAll()
+        if (rounds.isEmpty()) return
+
+        // Manager scope, not the caller's coroutine: a cancelled caller (e.g. a ViewModel scope
+        // going away mid-round) must not strand N drives holding their sync locks.
+        scope.launch { runCollectionRound(rounds) }.join()
     }
+
+    private class BatchedDrive(val driveId: Uuid, val sync: DriveSync, val round: DriveSync.BatchedRound)
+
+    private suspend fun runCollectionRound(rounds: List<BatchedDrive>) {
+        // A collection of one is a query-batch with extra wrapping — skip straight to per-drive.
+        val sections = rounds.filter { it.round.request != null }
+        val response = if (sections.size >= 2) {
+            runCatching {
+                driveQueryProvider.queryBatchCollection(
+                    QueryBatchCollectionRequest(
+                        queries = sections.map { bd ->
+                            val pageRequest = bd.round.request!!
+                            val opts = pageRequest.resultOptionsRequest
+                            CollectionQueryParamSection(
+                                name = bd.driveId.toString(),
+                                driveId = bd.driveId,
+                                queryParams = pageRequest.queryParams,
+                                // maxRecords is deliberately absent: the budget is collection-level.
+                                resultOptionsRequest = CollectionSectionResultOptions(
+                                    cursorState = opts.cursorState,
+                                    includeMetadataHeader = opts.includeMetadataHeader,
+                                    includeTransferHistory = opts.includeTransferHistory,
+                                    ordering = opts.ordering,
+                                    sorting = opts.sorting,
+                                ),
+                            )
+                        },
+                        maxRecords = COLLECTION_BUDGET,
+                    )
+                )
+            }.onFailure { e ->
+                // Also reached on caller cancellation — the NonCancellable resume below still runs.
+                Logger.e(tag = "DriveSync") {
+                    "DriveSync collection: whole-call FAILED (${e::class.simpleName}: ${e.message}) — " +
+                        "falling back to per-drive for ${sections.size} drives"
+                }
+            }.getOrNull()
+        } else null
+
+        val byName = response?.results?.associateBy { it.name }
+        var ok = 0
+        var exhausted = 0
+        val failed = mutableListOf<String>()
+
+        // Every begun drive MUST be resumed — its sync lock is held until the resumed round's
+        // finally releases it. NonCancellable so a cancelled round can't strand a locked drive.
+        val jobs = withContext(NonCancellable) {
+            rounds.map { bd ->
+                val label = _driveStatuses.value[bd.driveId]?.label ?: "?"
+                val section = byName?.get(bd.driveId.toString())
+                val prefetch = when {
+                    section == null -> {
+                        if (byName != null && bd.round.request != null) {
+                            failed += label
+                            Logger.w(tag = "DriveSync") {
+                                "DriveSync collection: section=$label(${bd.driveId}) MISSING from response — " +
+                                    "falling back to per-drive"
+                            }
+                        }
+                        null
+                    }
+
+                    section.isFailure -> {
+                        failed += label
+                        Logger.w(tag = "DriveSync") {
+                            "DriveSync collection: section=$label(${bd.driveId}) ${section.describeFailure()} — " +
+                                "falling back to per-drive"
+                        }
+                        null
+                    }
+
+                    else -> {
+                        if (section.status == QueryBatchSectionStatus.BudgetExhausted) exhausted++ else ok++
+                        section.toQueryBatchResponse()
+                    }
+                }
+                bd.sync.resumeBatchedRound(bd.round, prefetch)
+            }
+        }
+        if (response != null) {
+            Logger.i(tag = "DriveSync") {
+                "DriveSync collection: requested=${sections.size} ok=$ok budgetExhausted=$exhausted " +
+                    "failed=${failed.size}${if (failed.isEmpty()) "" else "(${failed.joinToString()})"}" +
+                    (rounds.size - sections.size).let { if (it > 0) " plain=$it" else "" }
+            }
+        }
+        jobs.joinAll()
+    }
+
+    private fun QueryBatchCollectionSection.toQueryBatchResponse() = QueryBatchResponse(
+        name = name,
+        invalidDrive = invalidDrive,
+        queryTime = queryTime,
+        includeMetadataHeader = includeMetadataHeader,
+        cursorState = cursorState,
+        searchResults = searchResults,
+        hasMoreRows = hasMoreRows,
+    )
 
     suspend fun syncAllFailed() {
         val failedIds = _driveStatuses.value
@@ -444,6 +570,9 @@ class DriveSyncManager(
     }
 
     companion object {
+        /** Global record budget for the syncAll collection call — greedy in-order fill server-side. */
+        private const val COLLECTION_BUDGET = 500
+
         /** Floor of the remote-drive retry backoff (first failure waits this long). */
         private const val REMOTE_RETRY_BASE_MS = 1_000L
         /** Ceiling of the remote-drive retry backoff — an offline owner is polled at most this often. */

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/DriveSyncCollectionTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/DriveSyncCollectionTest.kt
@@ -1,0 +1,674 @@
+package id.homebase.api.sync
+
+import id.homebase.api.client.CryptoHelper
+import id.homebase.api.client.auth.ApiCredentials
+import id.homebase.api.client.auth.CredentialsManager
+import id.homebase.api.client.drives.QueryBatchCollectionRequest
+import id.homebase.api.client.drives.QueryBatchRequest
+import id.homebase.api.client.drives.QueryBatchResponse
+import id.homebase.api.client.drives.query.DriveQueryProvider
+import id.homebase.api.client.drives.query.QueryBatchCursor
+import id.homebase.api.client.eventbus.BackendEvent
+import id.homebase.api.client.eventbus.EventBus
+import id.homebase.api.common.OdinId
+import id.homebase.api.common.SecureByteArray
+import id.homebase.api.common.time.UnixTimeUtc
+import id.homebase.api.serialization.OdinSystemSerializer
+import id.homebase.api.sync.database.CursorStorage
+import id.homebase.api.sync.database.DatabaseManager
+import id.homebase.api.sync.database.createInMemoryDatabase
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.MockRequestHandleScope
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.engine.mock.toByteArray
+import io.ktor.client.request.HttpRequestData
+import io.ktor.client.request.HttpResponseData
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlin.uuid.Uuid
+
+/**
+ * The syncAll() query-batch-collection wire-up (#1102): one batched page-1 call for the
+ * own-host drives, each section routed back into its DriveSync as a prefetched first page,
+ * with resumeBatchedRound(null) as the per-drive fallback for every degraded path.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class DriveSyncCollectionTest {
+
+    private val sharedSecret = ByteArray(16)
+
+    private suspend fun buildCredentials(): CredentialsManager {
+        val credentialsManager = CredentialsManager()
+        credentialsManager.setActiveCredentials(
+            ApiCredentials.create(
+                domain = OdinId("test.homebase.id"),
+                clientAccessToken = "fake-token",
+                sharedSecret = SecureByteArray(sharedSecret.copyOf())
+            )
+        )
+        return credentialsManager
+    }
+
+    private fun buildManager(
+        db: DatabaseManager,
+        credentialsManager: CredentialsManager,
+        eventBus: EventBus,
+        scope: CoroutineScope,
+        mockEngine: MockEngine,
+        mandatoryDrives: Map<Uuid, String>,
+        collectionTail: List<Uuid> = emptyList(),
+    ): DriveSyncManager {
+        val driveQueryProvider = DriveQueryProvider(HttpClient(mockEngine), credentialsManager)
+        return DriveSyncManager(
+            driveQueryProvider = driveQueryProvider,
+            credentialsManager = credentialsManager,
+            eventBus = eventBus,
+            scope = scope,
+            databaseManager = db,
+            mandatoryDrives = mandatoryDrives,
+            collectionTail = collectionTail,
+        )
+    }
+
+    private suspend fun parseCollectionRequest(request: HttpRequestData): QueryBatchCollectionRequest {
+        val envelope = request.body.toByteArray().decodeToString()
+        val json = CryptoHelper.decryptContentAsString(envelope, sharedSecret)
+        return OdinSystemSerializer.deserialize(json)
+    }
+
+    private suspend fun parseQueryBatchRequest(request: HttpRequestData): QueryBatchRequest {
+        val envelope = request.body.toByteArray().decodeToString()
+        val json = CryptoHelper.decryptContentAsString(envelope, sharedSecret)
+        return OdinSystemSerializer.deserialize(json)
+    }
+
+    private fun isCollectionPath(request: HttpRequestData) =
+        request.url.encodedPath == "/api/v2/drives/query-batch-collection"
+
+    private fun sectionJson(
+        name: String,
+        status: String = "ok",
+        invalidDrive: Boolean = false,
+        cursorState: String? = null,
+        hasMoreRows: Boolean = false,
+    ): String {
+        val cursor = cursorState?.let {
+            "\"" + it.replace("\\", "\\\\").replace("\"", "\\\"") + "\""
+        } ?: "null"
+        return """{"name":"$name","invalidDrive":$invalidDrive,"status":"$status","queryTime":0,""" +
+            """"includeMetadataHeader":false,"cursorState":$cursor,"searchResults":[],""" +
+            """"hasMoreRows":$hasMoreRows}"""
+    }
+
+    private fun collectionBody(vararg sections: String) =
+        """{"results":[${sections.joinToString(",")}]}"""
+
+    private fun emptyOkBody(cursorState: String? = null, hasMoreRows: Boolean = false): String {
+        val cursor = cursorState?.let {
+            "\"" + it.replace("\\", "\\\\").replace("\"", "\\\"") + "\""
+        } ?: "null"
+        return """{"name":null,"invalidDrive":false,"queryTime":0,"includeMetadataHeader":false,""" +
+            """"cursorState":$cursor,"searchResults":[],"hasMoreRows":$hasMoreRows}"""
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Manager level
+    // ---------------------------------------------------------------------------------------------
+
+    @Test
+    fun syncAllIssuesOneCollectionForOwnDrives() {
+        val db = DatabaseManager({ createInMemoryDatabase() })
+        runTest {
+            val eventBus = EventBus()
+            val drives = List(3) { Uuid.random() }
+            lateinit var engine: MockEngine
+            engine = MockEngine { request ->
+                if (isCollectionPath(request)) {
+                    val req = parseCollectionRequest(request)
+                    respond(
+                        collectionBody(*req.queries.map { sectionJson(it.name) }.toTypedArray()),
+                        HttpStatusCode.OK
+                    )
+                } else {
+                    respond(emptyOkBody(), HttpStatusCode.OK)
+                }
+            }
+            val manager = buildManager(
+                db, buildCredentials(), eventBus, backgroundScope, engine,
+                mandatoryDrives = drives.associateWith { "Drive $it" },
+            )
+            val events = mutableListOf<BackendEvent>()
+            val collector = launch { eventBus.events.collect { events.add(it) } }
+
+            manager.start()
+            runCurrent()
+            manager.syncAll()
+            runCurrent()
+
+            assertEquals(1, engine.requestHistory.size, "3 own drives must produce exactly 1 request")
+            val request = engine.requestHistory.single()
+            assertTrue(isCollectionPath(request), "The single request must be the collection call")
+            val parsed = parseCollectionRequest(request)
+            assertEquals(drives.map { it.toString() }.toSet(), parsed.queries.map { it.name }.toSet())
+            drives.forEach { driveId ->
+                assertTrue(
+                    events.any {
+                        it is BackendEvent.DriveEvent.Stopped && it.driveId == driveId &&
+                            it.result is BackendEvent.DriveResult.Completed
+                    },
+                    "Drive $driveId should complete from its collection section"
+                )
+            }
+            collector.cancel()
+        }
+        db.close()
+    }
+
+    @Test
+    fun budgetExhaustedSectionContinuesPerDrive() {
+        val db = DatabaseManager({ createInMemoryDatabase() })
+        runTest {
+            val eventBus = EventBus()
+            val drives = List(3) { Uuid.random() }
+            val starved = drives[2]
+            // Seed a real cursor so the starved drive's submitted cursorState is non-trivial.
+            val seeded = QueryBatchCursor.fromStartPoint(UnixTimeUtc(111_222L))
+            CursorStorage(db, starved).saveCursor(seeded)
+
+            lateinit var engine: MockEngine
+            engine = MockEngine { request ->
+                if (isCollectionPath(request)) {
+                    val req = parseCollectionRequest(request)
+                    respond(
+                        collectionBody(
+                            *req.queries.map { section ->
+                                if (section.name == starved.toString()) {
+                                    // Echo the submitted cursor verbatim, as the server does.
+                                    sectionJson(
+                                        section.name, status = "budgetExhausted",
+                                        cursorState = section.resultOptionsRequest.cursorState,
+                                        hasMoreRows = true,
+                                    )
+                                } else sectionJson(section.name)
+                            }.toTypedArray()
+                        ),
+                        HttpStatusCode.OK
+                    )
+                } else {
+                    respond(emptyOkBody(), HttpStatusCode.OK)
+                }
+            }
+            val manager = buildManager(
+                db, buildCredentials(), eventBus, backgroundScope, engine,
+                mandatoryDrives = drives.associateWith { "Drive $it" },
+            )
+
+            manager.start()
+            runCurrent()
+            manager.syncAll()
+            runCurrent()
+
+            val perDrive = engine.requestHistory.filterNot { isCollectionPath(it) }
+            assertEquals(1, perDrive.size, "Only the budget-starved drive continues per-drive")
+            assertTrue(
+                perDrive.single().url.encodedPath.contains(starved.toString()),
+                "The follow-up must target the starved drive"
+            )
+            assertEquals(
+                seeded.toJson(),
+                parseQueryBatchRequest(perDrive.single()).resultOptionsRequest.cursorState,
+                "The per-drive continuation must carry the echoed (submitted) cursor"
+            )
+        }
+        db.close()
+    }
+
+    @Test
+    fun failedSectionFallsBackPerDriveAndKeepsUnmountSemantics() {
+        val db = DatabaseManager({ createInMemoryDatabase() })
+        runTest {
+            val eventBus = EventBus()
+            val drives = List(3) { Uuid.random() }
+            val revoked = drives[1]
+            lateinit var engine: MockEngine
+            engine = MockEngine { request ->
+                when {
+                    isCollectionPath(request) -> {
+                        val req = parseCollectionRequest(request)
+                        respond(
+                            collectionBody(
+                                *req.queries.map { section ->
+                                    if (section.name == revoked.toString()) {
+                                        sectionJson(section.name, status = "noReadGrant", invalidDrive = true)
+                                    } else sectionJson(section.name)
+                                }.toTypedArray()
+                            ),
+                            HttpStatusCode.OK
+                        )
+                    }
+                    // The per-drive fallback confirms the revocation through the existing 403 path.
+                    request.url.encodedPath.contains(revoked.toString()) ->
+                        respond("", HttpStatusCode.Forbidden)
+                    else -> respond(emptyOkBody(), HttpStatusCode.OK)
+                }
+            }
+            val manager = buildManager(
+                db, buildCredentials(), eventBus, backgroundScope, engine,
+                mandatoryDrives = drives.associateWith { "Drive $it" },
+            )
+            val events = mutableListOf<BackendEvent>()
+            val collector = launch { eventBus.events.collect { events.add(it) } }
+
+            manager.start()
+            runCurrent()
+            manager.syncAll()
+            runCurrent()
+
+            assertTrue(
+                events.any {
+                    it is BackendEvent.DriveEvent.Stopped && it.driveId == revoked &&
+                        it.result is BackendEvent.DriveResult.PermissionDenied
+                },
+                "The revoked drive must go through the existing 403 → PermissionDenied path"
+            )
+            // The eventBus collector unmounts on PermissionDenied — same as a per-drive 403 today.
+            runCurrent()
+            assertFalse(
+                manager.driveStatuses.value.containsKey(revoked),
+                "PermissionDenied must unmount the drive for the session"
+            )
+            // The healthy drives completed from their sections, no per-drive calls for them.
+            val perDrive = engine.requestHistory.filterNot { isCollectionPath(it) }
+            assertEquals(1, perDrive.size, "Only the failed section falls back per-drive")
+            collector.cancel()
+        }
+        db.close()
+    }
+
+    @Test
+    fun collectionHttpFailureFallsBackPerDrive() {
+        val db = DatabaseManager({ createInMemoryDatabase() })
+        runTest {
+            val eventBus = EventBus()
+            val drives = List(3) { Uuid.random() }
+            lateinit var engine: MockEngine
+            engine = MockEngine { request ->
+                if (isCollectionPath(request)) {
+                    respond("boom", HttpStatusCode.InternalServerError)
+                } else {
+                    respond(emptyOkBody(), HttpStatusCode.OK)
+                }
+            }
+            val manager = buildManager(
+                db, buildCredentials(), eventBus, backgroundScope, engine,
+                mandatoryDrives = drives.associateWith { "Drive $it" },
+            )
+            val events = mutableListOf<BackendEvent>()
+            val collector = launch { eventBus.events.collect { events.add(it) } }
+
+            manager.start()
+            runCurrent()
+            manager.syncAll()
+            runCurrent()
+
+            val perDrive = engine.requestHistory.filterNot { isCollectionPath(it) }
+            assertEquals(3, perDrive.size, "Every drive must fall back to its own per-drive round")
+            drives.forEach { driveId ->
+                assertEquals(
+                    1,
+                    events.count { it is BackendEvent.DriveEvent.Started && it.driveId == driveId },
+                    "Exactly one round per drive despite the failed collection"
+                )
+                assertTrue(
+                    events.any {
+                        it is BackendEvent.DriveEvent.Stopped && it.driveId == driveId &&
+                            it.result is BackendEvent.DriveResult.Completed
+                    },
+                    "Drive $driveId must complete via the fallback"
+                )
+            }
+            collector.cancel()
+        }
+        db.close()
+    }
+
+    @Test
+    fun missingSectionFallsBackPerDrive() {
+        val db = DatabaseManager({ createInMemoryDatabase() })
+        runTest {
+            val eventBus = EventBus()
+            val drives = List(3) { Uuid.random() }
+            val dropped = drives[0]
+            lateinit var engine: MockEngine
+            engine = MockEngine { request ->
+                if (isCollectionPath(request)) {
+                    val req = parseCollectionRequest(request)
+                    respond(
+                        collectionBody(
+                            *req.queries.filter { it.name != dropped.toString() }
+                                .map { sectionJson(it.name) }.toTypedArray()
+                        ),
+                        HttpStatusCode.OK
+                    )
+                } else {
+                    respond(emptyOkBody(), HttpStatusCode.OK)
+                }
+            }
+            val manager = buildManager(
+                db, buildCredentials(), eventBus, backgroundScope, engine,
+                mandatoryDrives = drives.associateWith { "Drive $it" },
+            )
+            val events = mutableListOf<BackendEvent>()
+            val collector = launch { eventBus.events.collect { events.add(it) } }
+
+            manager.start()
+            runCurrent()
+            manager.syncAll()
+            runCurrent()
+
+            val perDrive = engine.requestHistory.filterNot { isCollectionPath(it) }
+            assertEquals(1, perDrive.size, "A dropped section must NOT read as 'no changes' — it re-queries per-drive")
+            assertTrue(perDrive.single().url.encodedPath.contains(dropped.toString()))
+            drives.forEach { driveId ->
+                assertTrue(
+                    events.any {
+                        it is BackendEvent.DriveEvent.Stopped && it.driveId == driveId &&
+                            it.result is BackendEvent.DriveResult.Completed
+                    },
+                    "Drive $driveId must still complete"
+                )
+            }
+            collector.cancel()
+        }
+        db.close()
+    }
+
+    @Test
+    fun remoteDriveExcludedFromCollection() {
+        val db = DatabaseManager({ createInMemoryDatabase() })
+        runTest {
+            val eventBus = EventBus()
+            val ownDrives = List(2) { Uuid.random() }
+            val remoteDrive = Uuid.random()
+            lateinit var engine: MockEngine
+            engine = MockEngine { request ->
+                if (isCollectionPath(request)) {
+                    val req = parseCollectionRequest(request)
+                    respond(
+                        collectionBody(*req.queries.map { sectionJson(it.name) }.toTypedArray()),
+                        HttpStatusCode.OK
+                    )
+                } else {
+                    respond(emptyOkBody(), HttpStatusCode.OK)
+                }
+            }
+            val manager = buildManager(
+                db, buildCredentials(), eventBus, backgroundScope, engine,
+                mandatoryDrives = ownDrives.associateWith { "Own $it" },
+            )
+            // Mount the peer drive before start() so it isn't kicked at mount time.
+            manager.mountDrive(remoteDrive, "Community", ownerOdinId = OdinId("peer.example.com"))
+            manager.start()
+            runCurrent()
+            manager.syncAll()
+            runCurrent()
+
+            val collection = engine.requestHistory.single { isCollectionPath(it) }
+            val parsed = parseCollectionRequest(collection)
+            assertFalse(
+                parsed.queries.any { it.name == remoteDrive.toString() },
+                "A peer-hosted drive must not be a section of the own-host collection"
+            )
+            val peerRequests = engine.requestHistory.filter { it.url.encodedPath.startsWith("/api/v2/peer/") }
+            assertEquals(1, peerRequests.size, "The remote drive must still sync over the peer path")
+            assertTrue(peerRequests.single().url.encodedPath.contains(remoteDrive.toString()))
+        }
+        db.close()
+    }
+
+    @Test
+    fun singleEligibleDriveSkipsCollection() {
+        val db = DatabaseManager({ createInMemoryDatabase() })
+        runTest {
+            val eventBus = EventBus()
+            val driveId = Uuid.random()
+            lateinit var engine: MockEngine
+            engine = MockEngine { respond(emptyOkBody(), HttpStatusCode.OK) }
+            val manager = buildManager(
+                db, buildCredentials(), eventBus, backgroundScope, engine,
+                mandatoryDrives = mapOf(driveId to "Only Drive"),
+            )
+
+            manager.start()
+            runCurrent()
+            manager.syncAll()
+            runCurrent()
+
+            assertEquals(1, engine.requestHistory.size)
+            assertFalse(
+                isCollectionPath(engine.requestHistory.single()),
+                "A collection of one is a query-batch with extra wrapping — go straight per-drive"
+            )
+        }
+        db.close()
+    }
+
+    @Test
+    fun busyDriveGetsKillroyNotSection() {
+        val db = DatabaseManager({ createInMemoryDatabase() })
+        runTest {
+            val eventBus = EventBus()
+            val drives = List(3) { Uuid.random() }
+            val busy = drives[2]
+            lateinit var engine: MockEngine
+            engine = MockEngine { request ->
+                when {
+                    isCollectionPath(request) -> {
+                        val req = parseCollectionRequest(request)
+                        respond(
+                            collectionBody(*req.queries.map { sectionJson(it.name) }.toTypedArray()),
+                            HttpStatusCode.OK
+                        )
+                    }
+                    // The busy drive's in-flight per-drive round never returns.
+                    request.url.encodedPath.contains(busy.toString()) -> awaitCancellation()
+                    else -> respond(emptyOkBody(), HttpStatusCode.OK)
+                }
+            }
+            val manager = buildManager(
+                db, buildCredentials(), eventBus, backgroundScope, engine,
+                mandatoryDrives = drives.associateWith { "Drive $it" },
+            )
+
+            manager.start()
+            runCurrent()
+            manager.syncDrive(busy) // takes the busy drive's sync lock, hangs on HTTP
+            runCurrent()
+            manager.syncAll()
+            runCurrent()
+
+            val collection = engine.requestHistory.single { isCollectionPath(it) }
+            val parsed = parseCollectionRequest(collection)
+            assertEquals(2, parsed.queries.size, "The locked drive must not be a section")
+            assertFalse(parsed.queries.any { it.name == busy.toString() })
+        }
+        db.close()
+    }
+
+    @Test
+    fun collectionTailDrivesOrderedLast() {
+        val db = DatabaseManager({ createInMemoryDatabase() })
+        runTest {
+            val eventBus = EventBus()
+            val chatLike = Uuid.random()
+            val feedLike = Uuid.random()
+            val small = List(2) { Uuid.random() }
+            // Mount order puts the tail drives FIRST to prove the ordering is applied, not incidental.
+            val mounts = linkedMapOf(
+                chatLike to "Chat", feedLike to "Feed",
+                small[0] to "Contacts", small[1] to "Profile",
+            )
+            lateinit var engine: MockEngine
+            engine = MockEngine { request ->
+                if (isCollectionPath(request)) {
+                    val req = parseCollectionRequest(request)
+                    respond(
+                        collectionBody(*req.queries.map { sectionJson(it.name) }.toTypedArray()),
+                        HttpStatusCode.OK
+                    )
+                } else respond(emptyOkBody(), HttpStatusCode.OK)
+            }
+            val manager = buildManager(
+                db, buildCredentials(), eventBus, backgroundScope, engine,
+                mandatoryDrives = mounts,
+                collectionTail = listOf(feedLike, chatLike), // chat expected largest → very last
+            )
+
+            manager.start()
+            runCurrent()
+            manager.syncAll()
+            runCurrent()
+
+            val parsed = parseCollectionRequest(engine.requestHistory.single { isCollectionPath(it) })
+            val names = parsed.queries.map { it.name }
+            assertEquals(
+                listOf(small[0].toString(), small[1].toString(), feedLike.toString(), chatLike.toString()),
+                names,
+                "Small drives first (mount order), then the tail in its given order, chat very last"
+            )
+        }
+        db.close()
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // DriveSync level
+    // ---------------------------------------------------------------------------------------------
+
+    private suspend fun buildSync(
+        db: DatabaseManager,
+        mockEngine: MockEngine,
+        eventBus: EventBus,
+        scope: CoroutineScope,
+        driveId: Uuid,
+    ): DriveSync {
+        val credentialsManager = buildCredentials()
+        val driveQueryProvider = DriveQueryProvider(HttpClient(mockEngine), credentialsManager)
+        return DriveSync(
+            identityId = credentialsManager.requireActiveCredentials().getIdentityId(),
+            driveId = driveId,
+            driveQueryProvider = driveQueryProvider,
+            databaseManager = db,
+            eventBus = eventBus,
+            scope = scope,
+        )
+    }
+
+    @Test
+    fun prefetchedPageConsumedWithoutHttpAndAdvancesCursor() {
+        val db = DatabaseManager({ createInMemoryDatabase() })
+        runTest {
+            val eventBus = EventBus()
+            val driveId = Uuid.random()
+            val engine = MockEngine { respond(emptyOkBody(), HttpStatusCode.OK) }
+            val sync = buildSync(db, engine, eventBus, backgroundScope, driveId)
+            val prefetchCursor = QueryBatchCursor.fromStartPoint(UnixTimeUtc(42_000L)).toJson()
+
+            val round = sync.beginBatchedRound()
+            assertNotNull(round, "Idle drive must hand out a batched round")
+            assertNotNull(round.request, "Default policy must be prefetchable")
+            sync.resumeBatchedRound(
+                round,
+                QueryBatchResponse(cursorState = prefetchCursor, hasMoreRows = false)
+            ).join()
+            runCurrent()
+
+            assertEquals(0, engine.requestHistory.size, "A done prefetched page must cost zero HTTP calls")
+
+            // The next round proves the in-memory cursor advanced to the prefetched cursorState.
+            sync.sync()?.join()
+            runCurrent()
+            assertEquals(1, engine.requestHistory.size)
+            assertEquals(
+                prefetchCursor,
+                parseQueryBatchRequest(engine.requestHistory.single()).resultOptionsRequest.cursorState,
+            )
+        }
+        db.close()
+    }
+
+    @Test
+    fun prefetchedPageWithMoreRowsPaginatesPerDrive() {
+        val db = DatabaseManager({ createInMemoryDatabase() })
+        runTest {
+            val eventBus = EventBus()
+            val driveId = Uuid.random()
+            val engine = MockEngine { respond(emptyOkBody(), HttpStatusCode.OK) }
+            val sync = buildSync(db, engine, eventBus, backgroundScope, driveId)
+            val echoedCursor = QueryBatchCursor.fromStartPoint(UnixTimeUtc(77_000L)).toJson()
+
+            val round = sync.beginBatchedRound()!!
+            sync.resumeBatchedRound(
+                round,
+                // What a budgetExhausted section looks like after toQueryBatchResponse():
+                // no rows, the submitted cursor echoed, more rows advertised.
+                QueryBatchResponse(cursorState = echoedCursor, hasMoreRows = true)
+            ).join()
+            runCurrent()
+
+            assertEquals(1, engine.requestHistory.size, "hasMoreRows must continue per-drive")
+            assertEquals(
+                echoedCursor,
+                parseQueryBatchRequest(engine.requestHistory.single()).resultOptionsRequest.cursorState,
+                "Page 2 must resume from the prefetched page's cursor"
+            )
+        }
+        db.close()
+    }
+
+    @Test
+    fun killroySetDuringBatchedRoundTriggersResync() {
+        val db = DatabaseManager({ createInMemoryDatabase() })
+        runTest {
+            val eventBus = EventBus()
+            val driveId = Uuid.random()
+            val engine = MockEngine { respond(emptyOkBody(), HttpStatusCode.OK) }
+            val sync = buildSync(db, engine, eventBus, backgroundScope, driveId)
+
+            val events = mutableListOf<BackendEvent>()
+            val collector = launch { eventBus.events.collect { events.add(it) } }
+            runCurrent() // subscribe the collector before begin emits Started
+
+            val round = sync.beginBatchedRound()!!
+            // A WS change lands mid-collection: sync() finds the lock held and flags killroy.
+            assertEquals(null, sync.sync(), "sync() during a batched round must coalesce, not run")
+            sync.resumeBatchedRound(
+                round,
+                QueryBatchResponse(cursorState = null, hasMoreRows = false)
+            ).join()
+            // The killroy re-sync is a NEW job launched from the batched round's tail. Its HTTP
+            // hops to a real dispatcher, so assert on the Started event it emits on the test
+            // scheduler at performSync entry — the deterministic proof a follow-up round ran.
+            advanceUntilIdle()
+
+            assertEquals(
+                2,
+                events.count { it is BackendEvent.DriveEvent.Started && it.driveId == driveId },
+                "The change signalled during the collection round trip must trigger a follow-up round"
+            )
+            collector.cancel()
+        }
+        db.close()
+    }
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
@@ -118,6 +118,8 @@ import id.homebase.core.moments.services.MomentsVideoSession
 import id.homebase.api.client.eventbus.EventBus
 import id.homebase.api.sync.database.OutboxSync
 import id.homebase.api.sync.database.enqueued
+import id.homebase.core.config.chatLabeledDrive
+import id.homebase.core.config.feedLabeledDrive
 import id.homebase.core.config.momentsLabeledDrive
 import id.homebase.core.moments.services.MomentsUserStateStore
 import id.homebase.core.sync.DriveRegistry
@@ -429,6 +431,13 @@ val appModule = module {
             //         ),
             //     ),
             // ),
+            // Likely-large drives go LAST in the syncAll batch-collection so the greedy budget
+            // serves every small drive first; chat is expected largest and goes very last.
+            collectionTail = listOf(
+                feedLabeledDrive.drive.alias,
+                momentsLabeledDrive.drive.alias,
+                chatLabeledDrive.drive.alias,
+            ),
         )
     }
 


### PR DESCRIPTION
Closes #1102. Builds on #1241's API (odin-core#1629/#1630); the batching contract was verified 5/5 against a live tenant — [results](https://github.com/homebase-id/chat-kmp/pull/1241#issuecomment-5202736761).

## What

`syncAll()` now folds every idle own-host drive's page-1 pull into **one** `query-batch-collection` call (global budget 500), then hands each drive its section as a prefetched first page. In steady state, a sync cycle is **1 round trip instead of ~7**. This fires on WS connect (incl. first login), background fetch, and dev-menu Force Sync All — zero changes at the call sites.

Deliberately scoped to `syncAll()` only: WS-triggered `syncDrive()`, the retry cadence, pages 2+, and cursor persistence are untouched and stay per-drive.

## How it stays light

The key observation: a `budgetExhausted` section (0 rows, submitted cursor echoed, `hasMoreRows: true`) is *already* a valid first page for the existing `performSync` loop — the drive writes nothing, keeps its cursor, and continues per-drive from page 2. So there is no multi-round collection drain, no rotation, no starvation, and no new orchestration component. Drives the budget didn't reach self-serve immediately in their own coroutine.

- **`DriveSync.beginBatchedRound()` / `resumeBatchedRound()`** mirror `sync()`'s tryLock-else-killroy structure on the **same mutex**, held across the collection round trip — a WS change mid-collection coalesces exactly as if the drive were mid-`queryBatch`. `Started` is emitted at begin, so drives show Synchronizing during the RTT.
- **`buildPageRequest()`** is extracted from the loop and shared verbatim by both paths — they cannot drift. The collection drops `maxRecords` at section conversion (type-enforced; the budget is collection-level).
- **`performSync(prefetched)`** consumes the section as its first iteration: killroy is not cleared on that iteration (a change signalled during the RTT must survive into the recursive re-sync) and `batchSize` is not adapted (a ~0ms prefetch would spuriously double it).

## Fallbacks — all the same move

Whole-call failure, missing section, failed section → `resumeBatchedRound(null)` = today's per-drive round. In particular a `noReadGrant` section is **not** mapped to unmount: the per-drive fallback receives the real 403 and the existing `PermissionDenied` → unmount path fires. Section status never drives unmount decisions — otherwise `driveNotFound`/`driveArchived` sections would silently unmount drives. The resume loop runs on the manager scope under `NonCancellable`, so a cancelled caller (dev-menu ViewModel navigating away) cannot strand drives holding their sync locks.

No circuit breaker, deliberately: the server contract is fixed and live-verified, so a whole-call failure now means the network is down — where per-drive fails identically. The per-round fallback is the entire resilience story.

## Section order

Small drives first (mount order), then `collectionTail = [feed, moments, chat]` from `AppModule` — chat last, expected largest. The server fills the budget greedily in request order, so big-first would starve every small drive into a per-drive fallback call (the live probe demonstrated exactly this); big-last serves the small drives inside the one call while large backlogs paginate per-drive as they would anyway.

Considered and deferred (with the reasoning recorded): a per-section `minRecords` floor server-side, guaranteeing every drive is checked in round 1. Only cold start / long-absence catch-up suffers without it, and the per-drive continuations self-heal that case.

## Logging

Per #1102's mandatory-logging requirement, all under `tag = "DriveSync"`:
- one summary per round: `DriveSync collection: requested=N ok=N budgetExhausted=N failed=N(labels)`
- one warn per failed/missing section with `describeFailure()` and the drive label
- one distinct error for whole-call failure, naming the fallback

## Tests

12 new tests in `DriveSyncCollectionTest` (MockEngine, dispatch-by-path): one-collection-per-syncAll, budget-exhausted continuation carrying the echoed cursor, failed-section → per-drive 403 → unmount parity, whole-call-failure fallback with exactly one Started/Stopped per drive, missing-section fallback, remote-drive exclusion (still peer-queried), single-drive skip, busy-drive killroy coalescing, tail ordering, prefetch-without-HTTP + cursor advance, prefetch pagination, killroy-during-RTT re-sync.

Not tested: the `batchSize`-adaptation skip on prefetched iterations — it needs decodable row fixtures (`HomebaseFile` requires `KeyHeader`/`FileMetadata`) for a one-line guard.

`homebase-api:jvmTest` green (1150 tests); core/common/chat suites green; Android + wasmJs compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019zvEmySUkpvfYSBV6Djoau
