### PR TITLE
Log shared HTTP-error responses under HttpIO, not DriveUploadProvider

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/OdinApiProviderBase.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/OdinApiProviderBase.kt
@@ -2,7 +2,6 @@ package id.homebase.api.client
 
 import co.touchlab.kermit.Logger
 import id.homebase.api.client.auth.CredentialsManager
-import id.homebase.api.client.drives.upload.DriveUploadProvider.Companion.TAG
 import id.homebase.api.common.SecureByteArray
 import id.homebase.api.serialization.OdinSystemSerializer
 import io.ktor.client.HttpClient
@@ -523,7 +522,7 @@ abstract class OdinApiProviderBase(
         when (response.status) {
             400 -> {
                 val problem = deserialize<ProblemDetails>(response.body)
-                Logger.e(tag = TAG) {
+                Logger.e(tag = "HttpIO") {
                     "BadRequest (400) Returned from Server - code: ${problem.errorCodeEnumOrUnhandled()} (raw: ${problem.errorCode()}).  title: ${problem.title}"
                 }
 


### PR DESCRIPTION
OdinApiProviderBase.throwForFailure is the shared error path for every provider — reads, peer queries, auth, uploads alike — but its 400 log line borrowed `TAG` from `DriveUploadProvider`, so **every** non-2xx response anywhere in the app was stamped `DriveUploadProvider`. In practice this mislabels triage: a peer temporal-**read** failure read as an upload problem ("maybe a lingering upload") when combing the log.

One-line fix: log under `HttpIO`, the tag `HttpClientProvider` already uses for the outgoing request lines — so a request and its error response now correlate under a single grep. The import of `DriveUploadProvider.Companion.TAG` (its only external use) goes with it; `DriveUploadProvider`'s own logging is unchanged.

No behavior change beyond the tag string. `homebase-api:jvmTest` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019zvEmySUkpvfYSBV6Djoau
