### PR TITLE
Windowed chat sync Part 2: load older messages from the server on local EOS

### DIFF
--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/DriveSyncCollectionTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/DriveSyncCollectionTest.kt
@@ -7,6 +7,7 @@ import id.homebase.api.client.drives.QueryBatchCollectionRequest
 import id.homebase.api.client.drives.QueryBatchRequest
 import id.homebase.api.client.drives.QueryBatchResponse
 import id.homebase.api.client.drives.query.DriveQueryProvider
+import id.homebase.api.client.drives.query.FileQueryParams
 import id.homebase.api.client.drives.query.QueryBatchCursor
 import id.homebase.api.client.eventbus.BackendEvent
 import id.homebase.api.client.eventbus.EventBus
@@ -37,6 +38,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.days
 import kotlin.uuid.Uuid
 
 /**
@@ -69,6 +71,7 @@ class DriveSyncCollectionTest {
         mockEngine: MockEngine,
         mandatoryDrives: Map<Uuid, String>,
         collectionTail: List<Uuid> = emptyList(),
+        driveSyncPolicies: Map<Uuid, DriveSyncPolicy> = emptyMap(),
     ): DriveSyncManager {
         val driveQueryProvider = DriveQueryProvider(HttpClient(mockEngine), credentialsManager)
         return DriveSyncManager(
@@ -78,6 +81,7 @@ class DriveSyncCollectionTest {
             scope = scope,
             databaseManager = db,
             mandatoryDrives = mandatoryDrives,
+            driveSyncPolicies = driveSyncPolicies,
             collectionTail = collectionTail,
         )
     }
@@ -547,6 +551,168 @@ class DriveSyncCollectionTest {
                 listOf(small[0].toString(), small[1].toString(), feedLike.toString(), chatLike.toString()),
                 names,
                 "Small drives first (mount order), then the tail in its given order, chat very last"
+            )
+        }
+        db.close()
+    }
+
+    @Test
+    fun freshPolicyDriveExcludedFromCollectionAndRunsPolicyPreSteps() {
+        val db = DatabaseManager({ createInMemoryDatabase() })
+        runTest {
+            val eventBus = EventBus()
+            val plain = List(2) { Uuid.random() }
+            val windowed = Uuid.random()
+            lateinit var engine: MockEngine
+            engine = MockEngine { request ->
+                if (isCollectionPath(request)) {
+                    val req = parseCollectionRequest(request)
+                    respond(
+                        collectionBody(*req.queries.map { sectionJson(it.name) }.toTypedArray()),
+                        HttpStatusCode.OK
+                    )
+                } else {
+                    respond(emptyOkBody(), HttpStatusCode.OK)
+                }
+            }
+            val manager = buildManager(
+                db, buildCredentials(), eventBus, backgroundScope, engine,
+                mandatoryDrives = (plain + windowed).associateWith { "Drive $it" },
+                driveSyncPolicies = mapOf(
+                    windowed to DriveSyncPolicy(
+                        fullSyncWindow = 30.days,
+                        initialQueries = listOf(FileQueryParams(fileType = listOf(8888))),
+                    )
+                ),
+            )
+
+            val before = UnixTimeUtc().milliseconds
+            manager.start()
+            runCurrent()
+            manager.syncAll()
+            runCurrent()
+            val after = UnixTimeUtc().milliseconds
+
+            val collection = engine.requestHistory.single { isCollectionPath(it) }
+            assertEquals(
+                plain.map { it.toString() }.toSet(),
+                parseCollectionRequest(collection).queries.map { it.name }.toSet(),
+                "A fresh drive with policy pre-steps must not be a collection section"
+            )
+
+            val perDrive = engine.requestHistory.filterNot { isCollectionPath(it) }
+            assertEquals(2, perDrive.size, "Policy drive: initial query, then the windowed crawl")
+            perDrive.forEach {
+                assertTrue(it.url.encodedPath.contains(windowed.toString()))
+            }
+            val initialQuery = parseQueryBatchRequest(perDrive[0])
+            assertEquals(listOf(8888), initialQuery.queryParams.fileType)
+            assertEquals(null, initialQuery.resultOptionsRequest.cursorState)
+            val crawl = parseQueryBatchRequest(perDrive[1])
+            assertEquals(null, crawl.queryParams.fileType, "The windowed crawl is the plain sync query")
+            val floor = QueryBatchCursor.fromJson(assertNotNull(crawl.resultOptionsRequest.cursorState))
+                .paging!!.time.milliseconds
+            val thirtyDaysMs = 30L * 24 * 60 * 60 * 1000
+            assertTrue(
+                floor in (before - thirtyDaysMs)..(after - thirtyDaysMs),
+                "The crawl cursor must be seeded at now - fullSyncWindow (floor=$floor)"
+            )
+        }
+        db.close()
+    }
+
+    @Test
+    fun policyExclusionBelowTwoSectionsSkipsCollectionEntirely() {
+        val db = DatabaseManager({ createInMemoryDatabase() })
+        runTest {
+            val eventBus = EventBus()
+            val plain = Uuid.random()
+            val windowed = Uuid.random()
+            lateinit var engine: MockEngine
+            engine = MockEngine { respond(emptyOkBody(), HttpStatusCode.OK) }
+            val manager = buildManager(
+                db, buildCredentials(), eventBus, backgroundScope, engine,
+                mandatoryDrives = mapOf(plain to "Plain", windowed to "Windowed"),
+                driveSyncPolicies = mapOf(
+                    windowed to DriveSyncPolicy(
+                        fullSyncWindow = 30.days,
+                        initialQueries = listOf(FileQueryParams(fileType = listOf(8888))),
+                    )
+                ),
+            )
+            val events = mutableListOf<BackendEvent>()
+            val collector = launch { eventBus.events.collect { events.add(it) } }
+
+            manager.start()
+            runCurrent()
+            manager.syncAll()
+            runCurrent()
+
+            assertFalse(
+                engine.requestHistory.any { isCollectionPath(it) },
+                "One eligible section left is not a collection"
+            )
+            listOf(plain, windowed).forEach { driveId ->
+                assertTrue(
+                    events.any {
+                        it is BackendEvent.DriveEvent.Stopped && it.driveId == driveId &&
+                            it.result is BackendEvent.DriveResult.Completed
+                    },
+                    "Drive $driveId must complete via its per-drive round"
+                )
+            }
+            collector.cancel()
+        }
+        db.close()
+    }
+
+    @Test
+    fun policyDriveWithExistingCursorJoinsCollection() {
+        val db = DatabaseManager({ createInMemoryDatabase() })
+        runTest {
+            val eventBus = EventBus()
+            val plain = List(2) { Uuid.random() }
+            val windowed = Uuid.random()
+            val seeded = QueryBatchCursor.fromStartPoint(UnixTimeUtc(333_444L))
+            CursorStorage(db, windowed).saveCursor(seeded)
+
+            lateinit var engine: MockEngine
+            engine = MockEngine { request ->
+                if (isCollectionPath(request)) {
+                    val req = parseCollectionRequest(request)
+                    respond(
+                        collectionBody(*req.queries.map { sectionJson(it.name) }.toTypedArray()),
+                        HttpStatusCode.OK
+                    )
+                } else {
+                    respond(emptyOkBody(), HttpStatusCode.OK)
+                }
+            }
+            val manager = buildManager(
+                db, buildCredentials(), eventBus, backgroundScope, engine,
+                mandatoryDrives = (plain + windowed).associateWith { "Drive $it" },
+                driveSyncPolicies = mapOf(
+                    windowed to DriveSyncPolicy(
+                        fullSyncWindow = 30.days,
+                        initialQueries = listOf(FileQueryParams(fileType = listOf(8888))),
+                    )
+                ),
+            )
+
+            manager.start()
+            runCurrent()
+            manager.syncAll()
+            runCurrent()
+
+            val request = engine.requestHistory.single()
+            assertTrue(isCollectionPath(request), "An incremental policy drive is prefetchable — one collection call only")
+            val parsed = parseCollectionRequest(request)
+            assertEquals(3, parsed.queries.size)
+            assertEquals(
+                seeded.toJson(),
+                parsed.queries.single { it.name == windowed.toString() }
+                    .resultOptionsRequest.cursorState,
+                "The policy drive's section must carry its persisted cursor"
             )
         }
         db.close()

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiAction.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiAction.kt
@@ -242,6 +242,8 @@ sealed interface ConversationListUiAction {
     /** Fetch the next page of older messages into the visible window. */
     data class LoadOlderMessages(val conversationId: Uuid) : ConversationListUiAction
 
+    data class LoadOlderMessagesFromServer(val conversationId: Uuid) : ConversationListUiAction
+
     /** Fetch the next page of newer messages into the visible window. */
     data class LoadNewerMessages(val conversationId: Uuid) : ConversationListUiAction
 

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiState.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiState.kt
@@ -133,6 +133,12 @@ data class MessageListUiState(
     val isLoadingOlder: Boolean = false,
     /** A loadNewer fetch is in flight; suppresses re-entry. */
     val isLoadingNewer: Boolean = false,
+    /** Windowed sync (#1223): the server may hold messages older than local EOS;
+     *  drives the "Load more" row at the top once local paging is exhausted. */
+    val serverHasMoreOlder: Boolean = false,
+    /** A loadOlderMessagesFromServer fetch is in flight; renders the top row as a
+     *  spinner and suppresses re-entry. */
+    val isLoadingOlderFromServer: Boolean = false,
     /** Set when the user taps a reply-preview that points at an Event message;
      *  the screen renders [id.homebase.chat.event.EventDetailDialog] keyed off
      *  this state. Null means no host-level event detail is open. */
@@ -277,6 +283,10 @@ sealed class MessageListContentModel(val id: String) {
 
     /** Spinner row at the top of the list while older messages are loading. */
     data object LoadingOlder : MessageListContentModel("loading-older")
+
+    /** "Load more" row at the top of the list when local history is exhausted but
+     *  the server may hold older messages (windowed sync, #1223). */
+    data object LoadServerHistory : MessageListContentModel("load-server-history")
 
     /** Spinner row at the bottom of the list while newer messages are loading. */
     data object LoadingNewer : MessageListContentModel("loading-newer")

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
@@ -1334,6 +1334,19 @@ class ConversationListViewModel(
                 viewModelScope.launch { chatMessageStream.loadOlderMessages(action.conversationId) }
             }
 
+            is ConversationListUiAction.LoadOlderMessagesFromServer -> {
+                viewModelScope.launch {
+                    try {
+                        chatMessageStream.loadOlderMessagesFromServer(action.conversationId)
+                    } catch (e: Exception) {
+                        Logger.e(throwable = e, tag = TAG) {
+                            "load older from server failed id=${action.conversationId}: ${e.message}"
+                        }
+                        sendEvent(ShowErrorMessage("Failed to load older messages: ${e.message}"))
+                    }
+                }
+            }
+
             is ConversationListUiAction.LoadNewerMessages -> {
                 viewModelScope.launch { chatMessageStream.loadNewerMessages(action.conversationId) }
             }
@@ -1897,6 +1910,10 @@ class ConversationListViewModel(
                                 val models: MutableList<MessageListContentModel> = mutableListOf()
                                 if (window.hasOlderMessages) {
                                     models.add(MessageListContentModel.LoadingOlder)
+                                } else if (window.serverHasMoreOlder) {
+                                    // Local EOS on a windowed-synced drive: older history may
+                                    // still exist on the server (#1223).
+                                    models.add(MessageListContentModel.LoadServerHistory)
                                 } else {
                                     models.add(MessageListContentModel.Header)
                                 }
@@ -2046,6 +2063,8 @@ class ConversationListViewModel(
                                     hasNewerMessages = window.hasNewerMessages,
                                     isLoadingOlder = window.isLoadingOlder,
                                     isLoadingNewer = window.isLoadingNewer,
+                                    serverHasMoreOlder = window.serverHasMoreOlder,
+                                    isLoadingOlderFromServer = window.isLoadingOlderFromServer,
                                 )
                             }
 

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageStream.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageStream.kt
@@ -358,7 +358,6 @@ class ChatMessageStream(
             val start = TimeSource.Monotonic.markNow()
             val anchor = window.messages.firstOrNull()?.sqlUserDate?.toEpochMilliseconds()
             val page = serverHistory.fetchOlderPage(conversationId, anchor)
-            paginatedState.setServerHasMoreOlder(conversationId, page.serverHasMore)
             val result = fetchMessages(
                 conversationId = conversationId,
                 limit = PaginatedConversationState.PAGE_SIZE,
@@ -371,6 +370,12 @@ class ChatMessageStream(
                 olderCursor = result.cursor,
                 hasMore = result.hasMoreRows,
             )
+            // AFTER the prepend: flipping serverHasMoreOlder=false first would swap the
+            // top row pill → Header for one frame, and the Header's disappearance on the
+            // insertion emission defeats both LazyColumn key anchoring and the prepend
+            // compensation in ConversationContent (which keys off a marker row being
+            // first-visible). See #1223.
+            paginatedState.setServerHasMoreOlder(conversationId, page.serverHasMore)
             Logger.i(tag = "ChatPaging") {
                 "loadOlderFromServer($conversationId) fetched=${page.upsertedCount} " +
                     "localPage=${result.records.size} localHasMore=${result.hasMoreRows} " +

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageStream.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageStream.kt
@@ -50,7 +50,8 @@ class ChatMessageStream(
     private val eventBus: EventBus,
     private val scope: CoroutineScope,
     private val driveFileProvider: DriveFileProvider,
-    private val optimisticWriter: OptimisticWriter
+    private val optimisticWriter: OptimisticWriter,
+    private val serverHistory: ChatServerHistory,
 ) : MessageLookup {
     /** Set by ConversationStream to let us skip messages for left conversations. */
     var isConversationLeft: (Uuid) -> Boolean = { false }
@@ -105,6 +106,7 @@ class ChatMessageStream(
                         paginatedState.reset()
                         _pinnedMessages.value = emptyMap()
                         autoPinHandled.clear()
+                        serverHistory.reset()
                     }
                     is BackendEvent.OutboxEvent.OptimisticRollback -> {
                         if (event.driveId == chatDrive) {
@@ -247,6 +249,7 @@ class ChatMessageStream(
                 messages = result.records,
                 olderCursor = result.cursor,
                 hasOlderMessages = result.hasMoreRows,
+                serverHasMoreOlder = serverHistory.mayHaveOlderHistory(conversationId),
             )
             paginatedState.endInitialLoad(conversationId)
         } catch (t: Throwable) {
@@ -273,6 +276,7 @@ class ChatMessageStream(
                 messages = fresh.records,
                 olderCursor = fresh.cursor,
                 hasOlderMessages = fresh.hasMoreRows,
+                serverHasMoreOlder = serverHistory.mayHaveOlderHistory(conversationId),
                 merge = true,
             )
         }
@@ -327,6 +331,53 @@ class ChatMessageStream(
             }
         } catch (t: Throwable) {
             paginatedState.setLoadingOlder(conversationId, false)
+            throw t
+        }
+    }
+
+    /**
+     * Windowed sync (#1223): local history is exhausted but the server may hold older
+     * messages — fetch one server page, upsert it locally (drive cursor untouched), then
+     * re-read through the normal local paging path so [MessageWindow.olderCursor] and
+     * [MessageWindow.hasOlderMessages] advance atomically and local auto-paging resumes.
+     */
+    suspend fun loadOlderMessagesFromServer(conversationId: Uuid) {
+        val window = paginatedState.getWindow(conversationId) ?: run {
+            Logger.d(tag = "ChatPaging") { "loadOlderFromServer($conversationId) skip: no window" }
+            return
+        }
+        if (window.isLoadingOlderFromServer || window.hasOlderMessages || !window.serverHasMoreOlder) {
+            Logger.d(tag = "ChatPaging") {
+                "loadOlderFromServer($conversationId) skip: loading=${window.isLoadingOlderFromServer} " +
+                    "hasLocalOlder=${window.hasOlderMessages} serverHasMore=${window.serverHasMoreOlder}"
+            }
+            return
+        }
+        paginatedState.setLoadingOlderFromServer(conversationId, true)
+        try {
+            val start = TimeSource.Monotonic.markNow()
+            val anchor = window.messages.firstOrNull()?.sqlUserDate?.toEpochMilliseconds()
+            val page = serverHistory.fetchOlderPage(conversationId, anchor)
+            paginatedState.setServerHasMoreOlder(conversationId, page.serverHasMore)
+            val result = fetchMessages(
+                conversationId = conversationId,
+                limit = PaginatedConversationState.PAGE_SIZE,
+                cursor = window.olderCursor,
+                sortOrder = QueryBatchSortOrder.NewestFirst,
+            )
+            paginatedState.prependOlderMessages(
+                conversationId = conversationId,
+                olderMessages = result.records,
+                olderCursor = result.cursor,
+                hasMore = result.hasMoreRows,
+            )
+            Logger.i(tag = "ChatPaging") {
+                "loadOlderFromServer($conversationId) fetched=${page.upsertedCount} " +
+                    "localPage=${result.records.size} localHasMore=${result.hasMoreRows} " +
+                    "serverHasMore=${page.serverHasMore} took=${start.elapsedNow()}"
+            }
+        } catch (t: Throwable) {
+            paginatedState.setLoadingOlderFromServer(conversationId, false)
             throw t
         }
     }
@@ -466,6 +517,7 @@ class ChatMessageStream(
             hasOlderMessages = olderHalf.hasMoreRows,
             newerCursor = newerHalf.cursor,
             hasNewerMessages = newerHalf.hasMoreRows,
+            serverHasMoreOlder = serverHistory.mayHaveOlderHistory(conversationId),
             merge = merge,
         )
         Logger.d(tag = "ChatPaging") {

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatServerHistory.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatServerHistory.kt
@@ -1,0 +1,99 @@
+package id.homebase.chat.services
+
+import co.touchlab.kermit.Logger
+import id.homebase.api.client.auth.CredentialsManager
+import id.homebase.api.client.drives.QueryBatchRequest
+import id.homebase.api.client.drives.QueryBatchResultOptionsRequest
+import id.homebase.api.client.drives.QueryBatchSortField
+import id.homebase.api.client.drives.QueryBatchSortOrder
+import id.homebase.api.client.drives.query.DriveQueryProvider
+import id.homebase.api.client.drives.query.FileQueryParams
+import id.homebase.api.client.drives.query.QueryBatchCursor
+import id.homebase.api.common.time.UnixTimeUtc
+import id.homebase.api.sync.database.DatabaseManager
+import id.homebase.api.sync.database.MainIndexMetaHelpers
+import id.homebase.core.config.chatTargetDrive
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlin.uuid.Uuid
+
+/**
+ * Server-side backfill for windowed-synced conversations (#1223): when local history is
+ * exhausted but the drive was fresh-synced with a [id.homebase.api.sync.DriveSyncPolicy]
+ * window, older messages still exist on the server. [fetchOlderPage] pulls one page of
+ * them and upserts locally with cursor = null so the drive's incremental sync cursor is
+ * never touched.
+ *
+ * Completeness ("the server truly has nothing older") is tracked in memory per session:
+ * cheap, self-healing, and reset on logout together with the windows themselves.
+ */
+class ChatServerHistory(
+    private val credentialsManager: CredentialsManager,
+    private val dbm: DatabaseManager,
+    private val driveQueryProvider: DriveQueryProvider,
+) {
+    data class OlderPage(val upsertedCount: Int, val serverHasMore: Boolean)
+
+    private val chatDrive = chatTargetDrive.alias
+    private val fileProcessor = MainIndexMetaHelpers.HomebaseFileProcessor(dbm)
+    private val mutex = Mutex()
+    private val completedConversations = mutableSetOf<Uuid>()
+
+    suspend fun mayHaveOlderHistory(conversationId: Uuid): Boolean =
+        mutex.withLock { conversationId !in completedConversations }
+
+    /**
+     * Fetch up to [SERVER_HISTORY_PAGE_SIZE] messages strictly older than
+     * [oldestLocalSqlUserDateMs] (null = empty local window → newest server page) and
+     * upsert them into the local index. Overlap at a tied userDate boundary is expected
+     * and harmless — the modified-timestamp guard in the upsert rejects rows we already
+     * have. Network failures propagate; the caller resets its loading state and the
+     * button stays pressable.
+     */
+    suspend fun fetchOlderPage(conversationId: Uuid, oldestLocalSqlUserDateMs: Long?): OlderPage {
+        val creds = credentialsManager.requireActiveCredentials()
+        val request = QueryBatchRequest(
+            queryParams = FileQueryParams(
+                fileType = listOf(ChatProtocol.MessageFileType),
+                groupId = listOf(conversationId),
+            ),
+            resultOptionsRequest = QueryBatchResultOptionsRequest(
+                cursorState = oldestLocalSqlUserDateMs?.let {
+                    QueryBatchCursor.fromStartPoint(UnixTimeUtc(it)).toJson()
+                },
+                maxRecords = SERVER_HISTORY_PAGE_SIZE,
+                includeMetadataHeader = true,
+                includeTransferHistory = true,
+                ordering = QueryBatchSortOrder.NewestFirst,
+                sorting = QueryBatchSortField.UserDate,
+            ),
+        )
+        val response = driveQueryProvider.queryBatch(chatDrive, request)
+
+        val upserted = if (response.searchResults.isNotEmpty()) {
+            fileProcessor.baseUpsertEntryZapZap(
+                identityId = creds.getIdentityId(),
+                driveId = chatDrive,
+                fileHeaders = response.searchResults,
+                cursor = null,
+            ).size
+        } else 0
+
+        if (!response.hasMoreRows) {
+            mutex.withLock { completedConversations.add(conversationId) }
+        }
+        Logger.i(tag = "ChatPaging") {
+            "fetchOlderPage($conversationId) anchor=$oldestLocalSqlUserDateMs " +
+                "fetched=${response.searchResults.size} upserted=$upserted serverHasMore=${response.hasMoreRows}"
+        }
+        return OlderPage(upsertedCount = upserted, serverHasMore = response.hasMoreRows)
+    }
+
+    fun reset() {
+        completedConversations.clear()
+    }
+
+    companion object {
+        const val SERVER_HISTORY_PAGE_SIZE = 1000
+    }
+}

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/PaginatedConversationState.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/PaginatedConversationState.kt
@@ -28,6 +28,9 @@ data class MessageWindow(
     val hasNewerMessages: Boolean = false,
     val isLoadingOlder: Boolean = false,
     val isLoadingNewer: Boolean = false,
+    /** Windowed sync (#1223): the server may hold messages older than local EOS. */
+    val serverHasMoreOlder: Boolean = false,
+    val isLoadingOlderFromServer: Boolean = false,
 )
 
 /**
@@ -145,6 +148,7 @@ class PaginatedConversationState(
         hasOlderMessages: Boolean = false,
         newerCursor: QueryBatchCursor? = null,
         hasNewerMessages: Boolean = false,
+        serverHasMoreOlder: Boolean = false,
         merge: Boolean = false,
     ) {
         _windows.update { current ->
@@ -163,6 +167,7 @@ class PaginatedConversationState(
                 newerCursor = newerCursor,
                 hasOlderMessages = hasOlderMessages,
                 hasNewerMessages = hasNewerMessages,
+                serverHasMoreOlder = serverHasMoreOlder,
             ))
         }
     }
@@ -193,6 +198,7 @@ class PaginatedConversationState(
                 newerCursor = newerCursor,
                 hasNewerMessages = hasNewer,
                 isLoadingOlder = false,
+                isLoadingOlderFromServer = false,
             ))
         }
     }
@@ -273,6 +279,20 @@ class PaginatedConversationState(
         _windows.update { current ->
             val existing = current[conversationId] ?: return@update current
             current + (conversationId to existing.copy(isLoadingNewer = loading))
+        }
+    }
+
+    fun setLoadingOlderFromServer(conversationId: Uuid, loading: Boolean) {
+        _windows.update { current ->
+            val existing = current[conversationId] ?: return@update current
+            current + (conversationId to existing.copy(isLoadingOlderFromServer = loading))
+        }
+    }
+
+    fun setServerHasMoreOlder(conversationId: Uuid, value: Boolean) {
+        _windows.update { current ->
+            val existing = current[conversationId] ?: return@update current
+            current + (conversationId to existing.copy(serverHasMoreOlder = value))
         }
     }
 

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
@@ -80,6 +80,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
@@ -1002,6 +1003,43 @@ fun ConversationContent(
                     }
                 }
 
+                // Prepend compensation (#1223): when an older page lands while the viewport
+                // is parked on a top marker row, key-based anchoring can't hold a message
+                // steady — the "Load more" pill's key vanishes and the spinner row sits
+                // ABOVE the insertion point — so the viewport teleports to the top of the
+                // prepended block and the proximity trigger chain-loads from there. Pin the
+                // first visible message row at its previous pixel offset instead; only
+                // Message/pending rows are stable anchors (a date Section moves up when
+                // older same-day messages land above it). requestScrollToItem applies at
+                // the next measure, so there is no intermediate frame.
+                var prevMergedItems by remember(conversation.conversation.id) {
+                    mutableStateOf(mergedItems)
+                }
+                SideEffect {
+                    if (prevMergedItems === mergedItems) return@SideEffect
+                    prevMergedItems = mergedItems
+                    val visible = listState.layoutInfo.visibleItemsInfo
+                    val firstKey = visible.firstOrNull()?.key
+                    if (firstKey != MessageListContentModel.LoadServerHistory.id &&
+                        firstKey != MessageListContentModel.LoadingOlder.id
+                    ) return@SideEffect
+                    val indexByKey = HashMap<String, Int>(mergedItems.size)
+                    mergedItems.forEachIndexed { i, item ->
+                        when (item) {
+                            is MessageListContentModel.Message -> indexByKey[item.id] = i
+                            is PendingOutgoingMessage -> indexByKey["pending-${item.id}"] = i
+                            else -> {}
+                        }
+                    }
+                    val anchor = visible.firstOrNull {
+                        (it.key as? String)?.let(indexByKey::containsKey) == true
+                    } ?: return@SideEffect
+                    val newIndex = indexByKey.getValue(anchor.key as String)
+                    if (newIndex > anchor.index) {
+                        listState.requestScrollToItem(newIndex, -anchor.offset)
+                    }
+                }
+
                 val currentMergedItems by rememberUpdatedState(mergedItems)
                 // The section walk runs INSIDE the snapshotFlow block so that snapshotFlow's
                 // built-in dedup compares the resolved `LocalDate?` (O(1)) instead of a
@@ -1215,16 +1253,26 @@ fun ConversationContent(
 
                                     is MessageListContentModel.LoadingOlder,
                                     is MessageListContentModel.LoadingNewer -> {
+                                        // The row is a "more exists" placeholder keeping the Header
+                                        // honest; it only animates while a fetch is in flight — an
+                                        // idle perpetual spinner reads as a hang.
+                                        val isFetching =
+                                            if (item is MessageListContentModel.LoadingOlder) uiState.isLoadingOlder
+                                            else uiState.isLoadingNewer
                                         Box(
                                             modifier = (if (animationsEnabled) Modifier.animateItem() else Modifier)
                                                 .fillMaxWidth()
                                                 .padding(vertical = 16.dp),
                                             contentAlignment = Alignment.Center,
                                         ) {
-                                            CircularProgressIndicator(
-                                                modifier = Modifier.size(24.dp),
-                                                strokeWidth = 2.dp,
-                                            )
+                                            Box(modifier = Modifier.size(24.dp)) {
+                                                if (isFetching) {
+                                                    CircularProgressIndicator(
+                                                        modifier = Modifier.size(24.dp),
+                                                        strokeWidth = 2.dp,
+                                                    )
+                                                }
+                                            }
                                         }
                                     }
 

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
@@ -187,6 +187,7 @@ import id.homebase.resources.chat_unpin_message
 import id.homebase.resources.chat_message_search_no_results
 import id.homebase.resources.chat_message_search_result_count
 import id.homebase.resources.chat_next_result
+import id.homebase.resources.chat_load_older_messages
 import id.homebase.resources.chat_no_messages
 import id.homebase.resources.chat_not_connected_description
 import id.homebase.resources.chat_not_connected_incoming_description
@@ -1224,6 +1225,34 @@ fun ConversationContent(
                                                 modifier = Modifier.size(24.dp),
                                                 strokeWidth = 2.dp,
                                             )
+                                        }
+                                    }
+
+                                    is MessageListContentModel.LoadServerHistory -> {
+                                        Box(
+                                            modifier = (if (animationsEnabled) Modifier.animateItem() else Modifier)
+                                                .fillMaxWidth()
+                                                .padding(vertical = 8.dp),
+                                            contentAlignment = Alignment.Center,
+                                        ) {
+                                            if (uiState.isLoadingOlderFromServer) {
+                                                CircularProgressIndicator(
+                                                    modifier = Modifier.size(24.dp),
+                                                    strokeWidth = 2.dp,
+                                                )
+                                            } else {
+                                                TextButton(
+                                                    onClick = {
+                                                        onUiAction(
+                                                            ConversationListUiAction.LoadOlderMessagesFromServer(
+                                                                conversation.conversation.id
+                                                            )
+                                                        )
+                                                    }
+                                                ) {
+                                                    Text(stringResource(MR.string.chat_load_older_messages))
+                                                }
+                                            }
                                         }
                                     }
                                 }

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageStreamLoadRaceTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageStreamLoadRaceTest.kt
@@ -18,6 +18,7 @@ import id.homebase.api.client.contacts.ContactsProvider
 import id.homebase.api.client.drives.HomebaseFile
 import id.homebase.api.client.drives.cache.DriveFileProviderCached
 import id.homebase.api.client.drives.files.DriveFileProvider
+import id.homebase.api.client.drives.query.DriveQueryProvider
 import id.homebase.api.client.eventbus.BackendEvent
 import id.homebase.api.client.eventbus.EventBus
 import id.homebase.api.client.identity.PublicIdentityRepository
@@ -392,6 +393,11 @@ class ChatMessageStreamLoadRaceTest {
                 dbm = dbm,
                 eventBus = eventBus,
                 outboxSync = outboxSync,
+            ),
+            serverHistory = ChatServerHistory(
+                credentialsManager = credentialsManager,
+                dbm = dbm,
+                driveQueryProvider = DriveQueryProvider(httpClient, credentialsManager),
             ),
         )
         return Fixture(dbm, eventBus, gate, stream)

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageStreamPagingTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageStreamPagingTest.kt
@@ -850,4 +850,49 @@ class ChatMessageStreamPagingTest {
             "the newly-arrived latest-page row must not appear until the user pages back to the latest",
         )
     }
+
+    /**
+     * Windowed-sync server backfill (#1223): `loadOlderMessagesFromServer` upserts a
+     * server page below local EOS, then re-reads with the window's HELD olderCursor.
+     * This proves that read pattern works: rows landing under an exhausted cursor
+     * are returned by the next fetch on that same cursor, disjoint from the loaded
+     * window, and re-raise hasMoreRows when they exceed the page size.
+     */
+    @Test
+    fun rowsUpsertedBelowExhaustedCursor_areReachableViaHeldOlderCursor() = runTest {
+        val conversationId = Uuid.random()
+        val baseTime = 1_700_000_000_000L
+
+        // The windowed fresh sync left only 5 recent messages locally.
+        val recent = (0 until 5).map { i ->
+            seedMessage(conversationId, userDateMs = baseTime + i * 1000L)
+        }
+        val (firstPage, hasMore, heldCursor) = fetchPage(conversationId, limit = 10)
+        assertEquals(5, firstPage.size)
+        assertFalse(hasMore, "local EOS — the exhausted state the server backfill starts from")
+
+        // A server page of 7 older messages lands (baseUpsertEntryZapZap path —
+        // seedMessage writes through the same convert+upsert pipeline).
+        val older = (1..7).map { i ->
+            seedMessage(conversationId, userDateMs = baseTime - i * 1000L)
+        }
+
+        // The re-read uses the held cursor with the normal local page size.
+        val (page2, more2, cursor2) = fetchPage(conversationId, limit = 4, cursor = heldCursor)
+        assertEquals(4, page2.size, "backfilled rows must be visible under the held cursor")
+        assertTrue(more2, "3 of 7 backfilled rows remain — hasMoreRows must be re-raised")
+        assertTrue(
+            page2.none { it.id in recent },
+            "the re-read page must be disjoint from the already-loaded window",
+        )
+
+        val (page3, more3, _) = fetchPage(conversationId, limit = 4, cursor = cursor2)
+        assertEquals(3, page3.size)
+        assertFalse(more3, "after draining the backfill, local EOS again")
+        assertEquals(
+            older.toSet(),
+            (page2 + page3).map { it.id }.toSet(),
+            "every backfilled row is reached exactly once — no gaps, no duplicates",
+        )
+    }
 }

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatServerHistoryTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatServerHistoryTest.kt
@@ -1,0 +1,271 @@
+@file:OptIn(ExperimentalUuidApi::class)
+
+package id.homebase.chat.services
+
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import id.homebase.api.client.CryptoHelper
+import id.homebase.api.client.auth.ApiCredentials
+import id.homebase.api.client.auth.CredentialsManager
+import id.homebase.api.client.drives.FileStateFilter
+import id.homebase.api.client.drives.QueryBatchRequest
+import id.homebase.api.client.drives.QueryBatchSortField
+import id.homebase.api.client.drives.QueryBatchSortOrder
+import id.homebase.api.client.drives.query.DriveQueryProvider
+import id.homebase.api.client.drives.query.QueryBatchCursor
+import id.homebase.api.common.OdinId
+import id.homebase.api.common.SecureByteArray
+import id.homebase.api.common.time.UnixTimeUtc
+import id.homebase.api.serialization.OdinSystemSerializer
+import id.homebase.api.sync.database.CursorStorage
+import id.homebase.api.sync.database.DatabaseManager
+import id.homebase.api.sync.database.OdinDatabase
+import id.homebase.api.sync.database.QueryBatch
+import id.homebase.core.config.chatTargetDrive
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.engine.mock.toByteArray
+import io.ktor.client.request.HttpRequestData
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.test.runTest
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+/**
+ * The windowed-sync server backfill (#1223): request shape, local upsert without touching
+ * the drive sync cursor, and the per-session completeness flag.
+ */
+class ChatServerHistoryTest {
+
+    private val sharedSecret = ByteArray(16)
+    private val chatDriveId = chatTargetDrive.alias
+    private val testIdentityId = Uuid.parse("7b1be23b-48bb-4304-bc7b-db5910c09a92")
+
+    private lateinit var dbm: DatabaseManager
+    private lateinit var credentialsManager: CredentialsManager
+
+    @BeforeTest
+    fun setUp() = runTest {
+        dbm = DatabaseManager({
+            val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+            OdinDatabase.Schema.create(driver)
+            driver
+        })
+        credentialsManager = CredentialsManager().apply {
+            setActiveCredentials(
+                ApiCredentials.create(
+                    domain = OdinId("owner.test"),
+                    clientAccessToken = "test-token",
+                    sharedSecret = SecureByteArray(sharedSecret.copyOf())
+                )
+            )
+        }
+    }
+
+    @AfterTest
+    fun tearDown() {
+        dbm.close()
+    }
+
+    // ---------- helpers ----------
+
+    private fun buildHistory(engine: MockEngine) = ChatServerHistory(
+        credentialsManager = credentialsManager,
+        dbm = dbm,
+        driveQueryProvider = DriveQueryProvider(HttpClient(engine), credentialsManager),
+    )
+
+    private suspend fun parseRequest(request: HttpRequestData): QueryBatchRequest {
+        val envelope = request.body.toByteArray().decodeToString()
+        val json = CryptoHelper.decryptContentAsString(envelope, sharedSecret)
+        return OdinSystemSerializer.deserialize(json)
+    }
+
+    /** A ServerFile as the query-batch wire returns it (unencrypted content). */
+    private fun serverFileJson(
+        conversationId: Uuid,
+        userDateMs: Long,
+        uniqueId: Uuid = Uuid.random(),
+    ): String {
+        val content = """{\"message\":\"msg\",\"deliveryStatus\":20,\"isEdited\":false,\"version\":1}"""
+        return """{
+            "fileId": "${Uuid.random()}",
+            "driveId": "$chatDriveId",
+            "fileState": "active",
+            "fileSystemType": "standard",
+            "sharedSecretEncryptedKeyHeader": {
+                "encryptionVersion": 1,
+                "iv": "AAAAAAAAAAAAAAAAAAAAAA==",
+                "encryptedAesKey": "AAAAAAAAAAAAAAAAAAAAAA=="
+            },
+            "fileMetadata": {
+                "globalTransitId": "${Uuid.random()}",
+                "created": $userDateMs,
+                "updated": $userDateMs,
+                "isEncrypted": false,
+                "senderOdinId": "owner.test",
+                "originalAuthor": "owner.test",
+                "appData": {
+                    "uniqueId": "$uniqueId",
+                    "fileType": ${ChatProtocol.MessageFileType},
+                    "dataType": 0,
+                    "groupId": "$conversationId",
+                    "userDate": $userDateMs,
+                    "content": "$content",
+                    "archivalStatus": 0
+                },
+                "versionTag": "${Uuid.random()}",
+                "payloads": []
+            },
+            "serverMetadata": {
+                "accessControlList": {"requiredSecurityGroup": "owner"},
+                "doNotIndex": false,
+                "allowDistribution": true,
+                "fileSystemType": "standard",
+                "fileByteCount": 100,
+                "originalRecipientCount": 0
+            },
+            "priority": 300,
+            "fileByteCount": 100
+        }"""
+    }
+
+    private fun responseBody(
+        results: List<String>,
+        hasMoreRows: Boolean,
+        cursorState: String? = null,
+    ): String {
+        val cursor = cursorState?.let {
+            "\"" + it.replace("\\", "\\\\").replace("\"", "\\\"") + "\""
+        } ?: "null"
+        return """{"name":null,"invalidDrive":false,"queryTime":0,"includeMetadataHeader":true,""" +
+            """"cursorState":$cursor,"searchResults":[${results.joinToString(",")}],""" +
+            """"hasMoreRows":$hasMoreRows}"""
+    }
+
+    private suspend fun localMessageCount(conversationId: Uuid): Int =
+        QueryBatch(testIdentityId).queryBatchAsync(
+            dbm = dbm,
+            driveId = chatDriveId,
+            noOfItems = 100,
+            cursor = null,
+            sortOrder = QueryBatchSortOrder.NewestFirst,
+            sortField = QueryBatchSortField.UserDate,
+            fileSystemType = 0,
+            fileState = FileStateFilter.All,
+            filetypesAnyOf = listOf(ChatProtocol.MessageFileType),
+            groupIdAnyOf = listOf(conversationId),
+        ).records.size
+
+    // ---------- tests ----------
+
+    @Test
+    fun fetchOlderPage_requestShape() = runTest {
+        val conversationId = Uuid.random()
+        val anchor = 1_700_000_000_000L
+        val engine = MockEngine { respond(responseBody(emptyList(), hasMoreRows = false), HttpStatusCode.OK) }
+
+        buildHistory(engine).fetchOlderPage(conversationId, anchor)
+
+        val request = engine.requestHistory.single()
+        assertEquals("/api/v2/drives/$chatDriveId/files/query-batch", request.url.encodedPath)
+        val parsed = parseRequest(request)
+        assertEquals(listOf(ChatProtocol.MessageFileType), parsed.queryParams.fileType)
+        assertEquals(listOf(conversationId), parsed.queryParams.groupId)
+        assertEquals(ChatServerHistory.SERVER_HISTORY_PAGE_SIZE, parsed.resultOptionsRequest.maxRecords)
+        assertEquals(QueryBatchSortOrder.NewestFirst, parsed.resultOptionsRequest.ordering)
+        assertEquals(QueryBatchSortField.UserDate, parsed.resultOptionsRequest.sorting)
+        val cursor = QueryBatchCursor.fromJson(assertNotNull(parsed.resultOptionsRequest.cursorState))
+        assertEquals(anchor, cursor.paging?.time?.milliseconds)
+        assertNull(cursor.paging?.row, "fromStartPoint anchors on time only; ties overlap by design")
+    }
+
+    @Test
+    fun fetchOlderPage_emptyLocalWindowSendsNullCursor() = runTest {
+        val engine = MockEngine { respond(responseBody(emptyList(), hasMoreRows = false), HttpStatusCode.OK) }
+
+        buildHistory(engine).fetchOlderPage(Uuid.random(), oldestLocalSqlUserDateMs = null)
+
+        assertNull(parseRequest(engine.requestHistory.single()).resultOptionsRequest.cursorState)
+    }
+
+    @Test
+    fun fetchOlderPage_upsertsLocallyWithoutTouchingDriveCursor() = runTest {
+        val conversationId = Uuid.random()
+        val driveCursor = QueryBatchCursor.fromStartPoint(UnixTimeUtc(555_666L))
+        CursorStorage(dbm, chatDriveId).saveCursor(driveCursor)
+
+        val base = 1_600_000_000_000L
+        val engine = MockEngine {
+            respond(
+                responseBody(
+                    listOf(
+                        serverFileJson(conversationId, base + 1000),
+                        serverFileJson(conversationId, base + 2000),
+                    ),
+                    hasMoreRows = true,
+                ),
+                HttpStatusCode.OK
+            )
+        }
+        val history = buildHistory(engine)
+
+        val page = history.fetchOlderPage(conversationId, base + 10_000)
+
+        assertEquals(2, page.upsertedCount)
+        assertTrue(page.serverHasMore)
+        assertTrue(history.mayHaveOlderHistory(conversationId))
+        assertEquals(2, localMessageCount(conversationId), "Fetched headers must land in the local index")
+        assertEquals(
+            driveCursor.toJson(),
+            assertNotNull(CursorStorage(dbm, chatDriveId).loadCursor()).toJson(),
+            "The server backfill must NEVER advance the drive's persisted sync cursor"
+        )
+    }
+
+    @Test
+    fun fetchOlderPage_reUpsertOfKnownRowsIsHarmless() = runTest {
+        val conversationId = Uuid.random()
+        val base = 1_600_000_000_000L
+        val fixedUnique = Uuid.random()
+        val body = responseBody(
+            listOf(serverFileJson(conversationId, base + 1000, uniqueId = fixedUnique)),
+            hasMoreRows = false,
+        )
+        val engine = MockEngine { respond(body, HttpStatusCode.OK) }
+        val history = buildHistory(engine)
+
+        history.fetchOlderPage(conversationId, base + 10_000)
+        history.reset() // allow the second probe
+        history.fetchOlderPage(conversationId, base + 10_000)
+
+        assertEquals(1, localMessageCount(conversationId), "Tied-boundary overlap must not duplicate rows")
+    }
+
+    @Test
+    fun fetchOlderPage_lastPageMarksConversationComplete() = runTest {
+        val conversationId = Uuid.random()
+        val other = Uuid.random()
+        val engine = MockEngine { respond(responseBody(emptyList(), hasMoreRows = false), HttpStatusCode.OK) }
+        val history = buildHistory(engine)
+
+        assertTrue(history.mayHaveOlderHistory(conversationId))
+        val page = history.fetchOlderPage(conversationId, 1_700_000_000_000L)
+
+        assertFalse(page.serverHasMore)
+        assertEquals(0, page.upsertedCount)
+        assertFalse(history.mayHaveOlderHistory(conversationId), "Empty page = server truly has no more")
+        assertTrue(history.mayHaveOlderHistory(other), "Completeness is per conversation")
+
+        history.reset()
+        assertTrue(history.mayHaveOlderHistory(conversationId), "Logout reset clears the session flag")
+    }
+}

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/PaginatedConversationStateTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/PaginatedConversationStateTest.kt
@@ -476,4 +476,55 @@ class PaginatedConversationStateTest {
             "refilling the trimmed slice via the recovered cursor must not duplicate rows",
         )
     }
+
+    // ---------- windowed-sync server-backfill flags (#1223) ----------
+
+    @Test
+    fun serverFlags_defaultFalseAndSettersUpdateThem() {
+        val state = PaginatedConversationState()
+        state.setInitialWindow(convoId, listOf(message(userDateMs = 10, conversationId = convoId)))
+
+        val initial = state.getWindow(convoId)!!
+        assertFalse(initial.serverHasMoreOlder)
+        assertFalse(initial.isLoadingOlderFromServer)
+
+        state.setServerHasMoreOlder(convoId, true)
+        state.setLoadingOlderFromServer(convoId, true)
+        val updated = state.getWindow(convoId)!!
+        assertTrue(updated.serverHasMoreOlder)
+        assertTrue(updated.isLoadingOlderFromServer)
+    }
+
+    @Test
+    fun setInitialWindow_seedsServerHasMoreOlder() {
+        val state = PaginatedConversationState()
+        state.setInitialWindow(
+            convoId,
+            listOf(message(userDateMs = 10, conversationId = convoId)),
+            serverHasMoreOlder = true,
+        )
+        assertTrue(state.getWindow(convoId)!!.serverHasMoreOlder)
+    }
+
+    @Test
+    fun prependOlderMessages_clearsServerLoadingFlag() {
+        val state = PaginatedConversationState()
+        state.setInitialWindow(
+            convoId,
+            listOf(message(userDateMs = 100, conversationId = convoId)),
+            serverHasMoreOlder = true,
+        )
+        state.setLoadingOlderFromServer(convoId, true)
+
+        state.prependOlderMessages(
+            convoId,
+            listOf(message(userDateMs = 50, conversationId = convoId)),
+            QueryBatchCursor(),
+            hasMore = false,
+        )
+
+        val window = state.getWindow(convoId)!!
+        assertFalse(window.isLoadingOlderFromServer, "The local re-read is the terminal step of the server path")
+        assertTrue(window.serverHasMoreOlder, "Completeness is decided by the server response, not the re-read")
+    }
 }

--- a/homebase-common/src/commonMain/composeResources/values-da/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values-da/strings.xml
@@ -651,6 +651,7 @@
     <string name="chat_clear">Ryd</string>
     <string name="chat_options">Samtale menu</string>
     <string name="chat_no_messages">Ingen beskeder endnu</string>
+    <string name="chat_load_older_messages">Indlæs flere</string>
     <string name="chat_new_messages">Nye beskeder</string>
     <string name="chat_connection_invited">Inviteret</string>
     <string name="chat_connection_wants_to_connect">Vil forbinde</string>

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -678,6 +678,7 @@
     <string name="chat_clear">Clear</string>
     <string name="chat_options">Conversation options</string>
     <string name="chat_no_messages">No messages yet</string>
+    <string name="chat_load_older_messages">Load more</string>
     <string name="chat_new_messages">New messages</string>
     <string name="chat_connection_invited">Invited</string>
     <string name="chat_connection_wants_to_connect">Wants to connect</string>

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
@@ -13,7 +13,11 @@ import id.homebase.api.file.wipeOutboxStaging
 import id.homebase.api.client.upgrade.IdentityUpgradeProvider
 import id.homebase.core.config.dataUpgradeReturnUrl
 
+import id.homebase.api.client.drives.SystemDriveConstants
+import id.homebase.api.client.drives.query.FileQueryParams
 import id.homebase.api.sync.DriveSyncManager
+import id.homebase.api.sync.DriveSyncPolicy
+import kotlin.time.Duration.Companion.days
 import id.homebase.api.youauth.YouAuthFlowManager
 import okio.Path.Companion.toPath
 import id.homebase.auth.login.LoginViewModel
@@ -49,6 +53,7 @@ import id.homebase.chat.services.ChatMessageSenderService
 import id.homebase.chat.services.ChatMessageStream
 import id.homebase.chat.services.ChatNotificationMessageResolver
 import id.homebase.chat.services.ChatProtocol
+import id.homebase.chat.services.ChatServerHistory
 import id.homebase.chat.services.LocalAttachmentContextStore
 import id.homebase.chat.services.MessageAppData
 import id.homebase.chat.services.content.MessageContentParser
@@ -409,28 +414,18 @@ val appModule = module {
         DriveSyncManager(
             get(), get(), get(), get(), get(),
             mandatoryDrives = mandatorySyncDrives.associate { it.drive.alias to it.label },
-            // Per-drive fresh-sync policy (sync-back window + custom initial queries) is
-            // wired and tested, but no drive opts in yet — chat behaves like every other
-            // drive (sync everything). Part 2 re-enables the chat policy below together
-            // with the "load older messages when scrolling to the top" feature; until
-            // then a fresh login would only see the last N days, which is confusing
-            // without that scroll-to-load path. Diagnostics confirmed the window itself
-            // is correct (cursor: zero duplicates / no floor breaches at 7/30/60 days).
-            //
-            // To re-enable, add the imports
-            //   id.homebase.api.client.drives.SystemDriveConstants
-            //   id.homebase.api.client.drives.query.FileQueryParams
-            //   id.homebase.api.sync.DriveSyncPolicy
-            //   kotlin.time.Duration.Companion.days
-            // and pass:
-            // driveSyncPolicies = mapOf(
-            //     SystemDriveConstants.chatDrive.alias to DriveSyncPolicy(
-            //         fullSyncWindow = 30.days,
-            //         initialQueries = listOf(
-            //             FileQueryParams(fileType = listOf(ChatProtocol.ConversationFileType)),
-            //         ),
-            //     ),
-            // ),
+            // Windowed fresh sync (#1223): first login pulls only the last 14 days of
+            // chat plus the FULL conversation list (initialQueries); older history is
+            // reachable per conversation via ChatMessageStream.loadOlderMessagesFromServer
+            // (the "Load more" row at the top of a conversation).
+            driveSyncPolicies = mapOf(
+                SystemDriveConstants.chatDrive.alias to DriveSyncPolicy(
+                    fullSyncWindow = 14.days,
+                    initialQueries = listOf(
+                        FileQueryParams(fileType = listOf(ChatProtocol.ConversationFileType)),
+                    ),
+                ),
+            ),
             // Likely-large drives go LAST in the syncAll batch-collection so the greedy budget
             // serves every small drive first; chat is expected largest and goes very last.
             collectionTail = listOf(
@@ -714,9 +709,10 @@ val appModule = module {
     // emits after successful group creation, ConversationListViewModel collects and
     // surfaces the IntroducePreflight dialog if any recipient is non-Ready.
     singleOf(::PostCreateIntroductionPreflightBus)
+    singleOf(::ChatServerHistory)
     single {
         ChatMessageStream(
-            get(), get(), get(), get(), get(), get(), get(), get(),
+            get(), get(), get(), get(), get(), get(), get(), get(), get(),
         ).also { stream ->
             // #887: wire auto-pin at construction, NOT in onPostAuthenticated. That
             // post-auth block is deferred and frequently never runs on a warm


### PR DESCRIPTION
Closes #1223.

## What

First login now syncs only the **last 14 days** of chat messages plus the **full conversation list**, and older history is loaded on demand per conversation.

- **Chat `DriveSyncPolicy` enabled** (`AppModule.kt`): `fullSyncWindow = 14.days` + `initialQueries = [FileQueryParams(fileType = [ConversationFileType])]`. The conversation list stays complete; only per-conversation message history is windowed.
- **New `ChatServerHistory`** (homebase-chat): fetches up to **1000** older messages via the server `queryBatch` — `NewestFirst`/`UserDate`, `fileType=[MessageFileType]`, `groupId=[conversationId]`, cursor anchored at the oldest local message's `sqlUserDate` (`fromStartPoint`, time-only → tied-userDate overlap is expected and deduped by the modified-timestamp upsert guard). Upserts via `baseUpsertEntryZapZap(cursor = null)` — **the drive sync cursor is never touched** (same rule as `initialQueries`).
- **`ChatMessageStream.loadOlderMessagesFromServer`**: guards (local paging must be exhausted), fetches the server page, then re-reads with the window's held `olderCursor` through the existing `fetchMessages`/`prependOlderMessages` path — so the freshly landed rows surface atomically and local auto-paging resumes for the remainder of the 1000.
- **UI: manual "Load more" row** (v1 deliberately a button, not a scroll trigger — easier to test/debug). New top-of-list model: `LoadingOlder` (local paging) → `LoadServerHistory` (local EOS, server may have more) → `Header` (true beginning). Swaps to the spinner while the server fetch is in flight; failure shows a snackbar and the button stays pressable. Strings added in `values/` + `values-da/`.
- **Completeness is in-memory, per session**: a page with `hasMoreRows = false` marks the conversation complete and the button never reappears this session (a fully-local conversation costs one visible dud press per session). Logout resets it together with the windows.

## QB-collection interplay (#1102)

No production sync-engine change needed: `DriveSync.beginBatchedRound`'s `prefetchable` rule already keeps a fresh policy-bearing drive out of the batched collection round and resumes it as a plain per-drive round (initialQueries + window seed). That rule was **untested** — this PR adds three `DriveSyncCollectionTest` cases: fresh policy drive excluded + runs its pre-steps per-drive (window floor asserted at now − 30d), exclusion below 2 sections skips the collection entirely, and a policy drive **with** a cursor joins the collection carrying it.

## Tests

- `ChatServerHistoryTest` (new, MockEngine + in-memory DB): request shape, null-anchor (empty local window → newest server page), **drive cursor provably unchanged after a backfill**, overlap re-upsert produces no duplicate rows, completeness flag semantics + reset.
- `ChatMessageStreamPagingTest`: rows upserted below an exhausted cursor are reachable via the held `olderCursor` — disjoint from the loaded window, `hasMoreRows` re-raised, no gaps/dupes.
- `PaginatedConversationStateTest`: new flags default false, setters, `prependOlderMessages` clears the server-loading flag.
- Full `jvmTest` green on homebase-chat/api/auth/common; wasmJs + Android compile clean.

## Out of scope (follow-up)

If `runInitialQueries` fails mid-fresh-sync it is never retried once the window cursor persists (conversations outside the window would be missing until re-login). Known, deliberately deferred — to be designed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BBCgi3yhNE1T5qkUx5R7su