### PR TITLE
Login wait screen: say "check your browser" during the YouAuth round-trip

### DIFF
--- a/homebase-auth/src/commonMain/kotlin/id/homebase/auth/login/LoginScreen.kt
+++ b/homebase-auth/src/commonMain/kotlin/id/homebase/auth/login/LoginScreen.kt
@@ -69,6 +69,7 @@ import id.homebase.resources.failed
 import id.homebase.resources.homebase_logo
 import id.homebase.resources.loading
 import id.homebase.resources.login_authenticating
+import id.homebase.resources.login_waiting_for_browser
 import id.homebase.resources.login_continue_button
 import id.homebase.resources.login_create_account_button
 import id.homebase.resources.login_id_label
@@ -205,7 +206,8 @@ fun LoginUi(
                 pendingAuthUrl != null -> LoginPopupBlocked(onContinue = onContinueAuth)
                 uiState.isLoading -> LoginLoading(
                     driveProgresses = uiState.driveProgresses,
-                    isPinging = uiState.isPinging
+                    isPinging = uiState.isPinging,
+                    isAwaitingAuthConfirmation = uiState.isAwaitingAuthConfirmation,
                 )
                 uiState.isAuthenticated -> LoginSuccess()
                 else ->
@@ -299,7 +301,11 @@ private fun LoginPopupBlocked(onContinue: () -> Unit) {
 /* ---------- STATES ---------- */
 
 @Composable
-private fun LoginLoading(driveProgresses: ImmutableList<DriveProgress>, isPinging: Boolean = false) {
+private fun LoginLoading(
+    driveProgresses: ImmutableList<DriveProgress>,
+    isPinging: Boolean = false,
+    isAwaitingAuthConfirmation: Boolean = false,
+) {
     Column(horizontalAlignment = Alignment.CenterHorizontally) {
         Text(
             text = stringResource(MR.string.loading),
@@ -312,7 +318,10 @@ private fun LoginLoading(driveProgresses: ImmutableList<DriveProgress>, isPingin
             CircularProgressIndicator()
             Spacer(modifier = Modifier.height(16.dp))
             Text(
-                text = stringResource(MR.string.login_authenticating),
+                text = stringResource(
+                    if (isAwaitingAuthConfirmation) MR.string.login_waiting_for_browser
+                    else MR.string.login_authenticating
+                ),
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 modifier = Modifier.testTag("authenticating_text"),

--- a/homebase-auth/src/commonMain/kotlin/id/homebase/auth/login/LoginUiState.kt
+++ b/homebase-auth/src/commonMain/kotlin/id/homebase/auth/login/LoginUiState.kt
@@ -10,6 +10,9 @@ data class LoginUiState(
     val homebaseId: String = "",
     val isLoading: Boolean = false,
     val isPinging: Boolean = false,
+    /** The YouAuth authorize page is open in the user's browser and we're waiting for
+     *  the confirmation callback — the loading screen says "check your browser". */
+    val isAwaitingAuthConfirmation: Boolean = false,
     val isAuthenticated: Boolean = false,
     val error: LoginError? = null,
     // Raw technical detail for the current [error] (exception type + message, or HTTP

--- a/homebase-auth/src/commonMain/kotlin/id/homebase/auth/login/LoginViewModel.kt
+++ b/homebase-auth/src/commonMain/kotlin/id/homebase/auth/login/LoginViewModel.kt
@@ -306,17 +306,30 @@ class LoginViewModel(
                             if (syncStopped || syncCannotStart) {
                                 handleAuthenticatedUser()
                             } else {
-                                _uiState.update { it.copy(isLoading = true) }
+                                _uiState.update {
+                                    it.copy(isLoading = true, isAwaitingAuthConfirmation = false)
+                                }
                             }
                         }
 
-                        is YouAuthState.Authenticating,
+                        is YouAuthState.Authenticating -> {
+                            _uiState.update {
+                                it.copy(isLoading = true, isAwaitingAuthConfirmation = true)
+                            }
+                        }
+
                         is YouAuthState.Initializing -> {
                             _uiState.update { it.copy(isLoading = true) }
                         }
 
                         is YouAuthState.Unauthenticated -> {
-                            _uiState.update { it.copy(isLoading = false, isAuthenticated = false) }
+                            _uiState.update {
+                                it.copy(
+                                    isLoading = false,
+                                    isAuthenticated = false,
+                                    isAwaitingAuthConfirmation = false,
+                                )
+                            }
                         }
 
                         is YouAuthState.Error -> {
@@ -324,6 +337,7 @@ class LoginViewModel(
                                 it.copy(
                                     isLoading = false,
                                     isAuthenticated = false,
+                                    isAwaitingAuthConfirmation = false,
                                     error = LoginError.Message(authState.message)
                                 )
                             }

--- a/homebase-common/src/commonMain/composeResources/values-da/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values-da/strings.xml
@@ -180,6 +180,7 @@
     <string name="login_try_again_button">Prøv igen</string>
     <string name="login_create_account_button">Opret konto</string>
     <string name="login_authenticating">Authentikerer…</string>
+    <string name="login_waiting_for_browser">Venter på login-bekræftelse — tjek din browser</string>
     <string name="login_successful">Login lykkedes</string>
     <string name="login_progress_sync">Synkroniserer drev %1$s</string>
     <string name="login_progress_sync_count">Poster %1$s / %2$s synkroniseret</string>

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -182,6 +182,7 @@
     <string name="login_try_again_button">Try again</string>
     <string name="login_create_account_button">Create account</string>
     <string name="login_authenticating">Authenticating…</string>
+    <string name="login_waiting_for_browser">Waiting for login confirmation — check your browser</string>
     <string name="login_successful">Login successful</string>
     <string name="login_progress_sync">Syncing drive %1$s</string>
     <string name="login_progress_sync_count">Records %1$s / %2$s synced</string>


### PR DESCRIPTION
While `YouAuthState.Authenticating` the login loading screen showed the generic "Authenticating…", giving no hint that the app is waiting for the user to **confirm the login in their system browser**. When the browser tab fails to surface (observed today on Linux desktop: `xdg-open` reported success but snap Firefox never showed the authorize page), the screen reads as a hang.

- New `LoginUiState.isAwaitingAuthConfirmation`, set only in the `Authenticating` branch (cleared on Authenticated/Unauthenticated/Error), so the post-auth sync-wait keeps the existing message.
- `LoginLoading` swaps the sub-text for `login_waiting_for_browser`: "Waiting for login confirmation — check your browser" (+ Danish).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BBCgi3yhNE1T5qkUx5R7su