### PR TITLE
fix(chat): hug the image in a reply-over-media bubble (#1224)

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubbleRaw.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubbleRaw.kt
@@ -603,11 +603,10 @@ fun MessageBubbleRaw(
                         }
                     },
                 ) { measurables, constraints ->
-                    val minContentWidth = Dimens.MediaBubble.minWidthWithContent.roundToPx()
-                        .coerceAtMost(constraints.maxWidth)
-                    val mediaPlaceable = measurables[1].measure(
-                        constraints.copy(minWidth = minContentWidth)
-                    )
+                    // No captioned-image min-width floor here: the image itself only fills that
+                    // floor when a caption is present, so flooring the bubble alone left the
+                    // bubble background showing beside a narrow portrait. The quote ellipsizes.
+                    val mediaPlaceable = measurables[1].measure(constraints.copy(minWidth = 0))
                     val width = mediaPlaceable.width
                     val replyPlaceable = measurables[0].measure(
                         constraints.copy(minWidth = width, maxWidth = width)

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/widget/BubbleLayoutInvariantTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/widget/BubbleLayoutInvariantTest.kt
@@ -385,6 +385,59 @@ class BubbleLayoutInvariantTest {
     }
 
     /**
+     * #1224: an image with a reply quote and NO caption hugs the image — reply, bubble and
+     * image share one width, so no bubble background shows beside the photo.
+     *
+     * The reply-over-media Layout floored the media placeable (so the bubble and the reply too)
+     * to the 240dp CAPTIONED-image min-width, but the image only fills that floor when a caption
+     * is present: TALL_PORTRAIT's height-capped 144dp image sat in a 240dp bubble, leaving the
+     * reported strip. Aspects at or above the floor are the unchanged control.
+     */
+    @Test
+    fun imageWithReply_noCaption_bubbleHugsImage() = runComposeUiTest {
+        // The reply quote's own horizontal insets: 6dp on the reply Row + 8dp on its Column.
+        val replyQuoteInset = 14f
+        val failures = mutableListOf<String>()
+        for (sent in listOf(true, false))
+            for (aspect in listOf(
+                Aspect.TALL_PORTRAIT, Aspect.PORTRAIT, Aspect.SQUARE, Aspect.LANDSCAPE, Aspect.PANORAMA,
+            )) {
+                val case = Case(
+                    name = "1img/$aspect/reply/${if (sent) "sent" else "recv"}",
+                    sent = sent, images = 1, caption = Caption.NONE, reply = true, aspect = aspect,
+                )
+                render(case)
+                val bubble = boundsOf(ChatBubbleTestTags.BUBBLE)
+                val media = boundsOf(ChatBubbleTestTags.MEDIA)
+                val quote = quoteTextBounds()
+                val mediaWidth = media.right.value - media.left.value
+                val bubbleWidth = bubble.right.value - bubble.left.value
+
+                if (!approx(mediaWidth, bubbleWidth))
+                    failures += "[${case.name}] bubble is wider than the image (background strip): " +
+                        "media.width=$mediaWidth bubble.width=$bubbleWidth"
+                if (!approx(media.left.value, bubble.left.value))
+                    failures += "[${case.name}] left strip: media.left=${media.left.value} bubble.left=${bubble.left.value}"
+                if (!approx(media.right.value, bubble.right.value))
+                    failures += "[${case.name}] right strip beside the image: " +
+                        "media.right=${media.right.value} bubble.right=${bubble.right.value}"
+                // The quote is measured at the media width, so its text can never reach past
+                // the image's right edge less the reply's own inset.
+                if (quote.right.value > media.right.value - replyQuoteInset + tol)
+                    failures += "[${case.name}] reply quote overhangs the image: " +
+                        "quote.right=${quote.right.value} media.right=${media.right.value}"
+                // Only at TALL_PORTRAIT's width is the fixture quote (182dp intrinsic) wider than
+                // the room it gets, so only there does its ellipsized text prove the exact clamp.
+                if (aspect == Aspect.TALL_PORTRAIT &&
+                    !approx(media.right.value - quote.right.value, replyQuoteInset)
+                )
+                    failures += "[${case.name}] reply quote does not fill the image width: " +
+                        "quote.right=${quote.right.value} media.right=${media.right.value}"
+            }
+        assertTrue(failures.isEmpty(), "reply-over-media hug failures:\n" + failures.joinToString("\n"))
+    }
+
+    /**
      * Regression guard: media-only bubbles (no caption, any image count) are UNCHANGED —
      * the media fills the whole bubble, no inset, no gap.
      */


### PR DESCRIPTION
Fixes #1224.

## Symptom

A sent/received image message with a reply quote and **no caption** rendered a grey strip to the right of a narrow portrait image: the bubble (and the reply box above it) were wider than the photo, so the bubble's `surfaceContainerHigh` background showed beside it.

## Root cause

`MessageBubbleRaw.kt`'s `replyMediaOnly` custom `Layout` measured the media with `minWidth = Dimens.MediaBubble.minWidthWithContent` (240dp) and then sized the bubble and the reply to the resulting placeable:

```kotlin
val minContentWidth = Dimens.MediaBubble.minWidthWithContent.roundToPx()
    .coerceAtMost(constraints.maxWidth)
val mediaPlaceable = measurables[1].measure(constraints.copy(minWidth = minContentWidth))
val width = mediaPlaceable.width
```

240dp is the *caption* min-width. The branch that makes the image itself fill it — `narrowCaptioned` in `MediaMessage.kt` — is gated on `hasCaption`, which a reply never sets. The media `Box` does not propagate min constraints to its child, so the box widened to 240dp while the image inside kept its natural width and stayed left-aligned. A 1080x2400 photo is height-capped at `MediaBubble.maxHeight` (320dp), i.e. 144dp wide — 96dp of bubble background beside it.

## Fix

Drop the caption floor in that `Layout`: measure the media at its natural width, set the bubble width to it, and constrain the reply to that width. A reply quote ellipsizes fine at the image's width; only a caption needs the floor so its text can't collapse to one character per line.

Unchanged: landscape/wide images (already >= 240dp), both captioned paths (inline and block keep the floor), media-only bubbles, galleries and the caption inset. A gallery pinned to the 210dp album width on a narrow screen now hugs too, instead of showing a 30dp strip.

Tradeoff worth naming: an extremely tall image (a full-page screenshot, natural width well under 150dp) now yields a correspondingly narrow bubble with a hard-ellipsized quote, where before it got a 240dp bubble with a large strip. That matches how the same image already renders in a media-only bubble; widening the bubble past the image can only be fixed properly by making the media fill (crop), which is a separate design call.

## Test

`BubbleLayoutInvariantTest.imageWithReply_noCaption_bubbleHugsImage` — {sent, received} x 1 image x reply x no caption over TALL_PORTRAIT / PORTRAIT / SQUARE / LANDSCAPE / PANORAMA, asserting `media.width == bubble.width`, both edges flush, and that the reply quote never reaches past the image's right edge (and exactly fills it at TALL_PORTRAIT, where the fixture quote overflows).

**Before the fix** (`./gradlew :homebase-chat:jvmTest --tests '*BubbleLayoutInvariantTest.imageWithReply_noCaption_bubbleHugsImage*'`):

```
BubbleLayoutInvariantTest[jvm] > imageWithReply_noCaption_bubbleHugsImage[jvm] FAILED

java.lang.AssertionError: reply-over-media hug failures:
[1img/TALL_PORTRAIT/reply/sent] bubble is wider than the image (background strip): media.width=144.0 bubble.width=240.0
[1img/TALL_PORTRAIT/reply/sent] right strip beside the image: media.right=144.0 bubble.right=240.0
[1img/TALL_PORTRAIT/reply/sent] reply quote overhangs the image: quote.right=196.0 media.right=144.0
[1img/TALL_PORTRAIT/reply/sent] reply quote does not fill the image width: quote.right=196.0 media.right=144.0
[1img/TALL_PORTRAIT/reply/recv] bubble is wider than the image (background strip): media.width=144.0 bubble.width=240.0
[1img/TALL_PORTRAIT/reply/recv] right strip beside the image: media.right=144.0 bubble.right=240.0
[1img/TALL_PORTRAIT/reply/recv] reply quote overhangs the image: quote.right=196.0 media.right=144.0
[1img/TALL_PORTRAIT/reply/recv] reply quote does not fill the image width: quote.right=196.0 media.right=144.0
```

The wide aspects passed before the fix, which is the "unchanged" half of the case.

**After the fix** (`./gradlew :homebase-chat:jvmTest --tests '*BubbleLayoutInvariantTest*'`, 12/12):

```
BUILD SUCCESSFUL
('12', '0')   # tests, failures
  ok: singleImageWithCaption_wideAuthorName_noGap[jvm]
  ok: galleryWithCaption_consistentEdgeInset[jvm]
  ok: textBubble_hugsText_singleGapBeforeTimestamp[jvm]
  ok: imageWithReply_noCaption_bubbleHugsImage[jvm]
  ok: galleryWithCaption_mediaFullBleed_captionInset[jvm]
  ok: singleDocument_compactCard_noMediaVoid[jvm]
  ok: mediaOnly_unchanged_mediaFillsBubble[jvm]
  ok: textOnly_hasCaption_noMedia[jvm]
  ok: singleImageWithCaption_noGap_everyAspectRatio[jvm]
  ok: singleImageWithCaption_unchanged_edgeToEdge[jvm]
  ok: replyQuote_notCrushedByShortReplyText[jvm]
  ok: authorName_tightGapAboveText[jvm]
```

Full module suite (`./gradlew :homebase-chat:jvmTest`): **1095 tests, 0 failures**.