### PR TITLE
feat(share): recognise a shared vCard on the descriptor path, so iOS sends a contact card

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/contactcard/SharedVCardDetector.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/contactcard/SharedVCardDetector.kt
@@ -1,0 +1,94 @@
+package id.homebase.chat.contactcard
+
+import co.touchlab.kermit.Logger
+import id.homebase.core.share.SharedContentDescriptor
+import kotlin.coroutines.cancellation.CancellationException
+
+/**
+ * Recognises a contact share that arrived as a [SharedContentDescriptor] and turns it into a
+ * [VCardContact].
+ *
+ * This is the non-Android delivery shape: the iOS share extension writes the descriptor to the
+ * App Group, and `ShareCacheStorage` has a jvmMain actual too. A `.vcf` misses the extension's
+ * image/movie/url/plainText branches — `public.vcard` conforms to `public.text`, not
+ * `public.plain-text` — so it lands as a generic `FILE` with `mimeTypes = ["text/vcard"]`.
+ *
+ * Semantics mirror Android's `ContactShareDetector`. Returns null for anything that isn't a
+ * parseable contact; the caller then sends the raw file/text as before, so a share is never
+ * dropped. A multi-contact `.vcf` yields its FIRST block; the rest are logged and ignored.
+ */
+object SharedVCardDetector {
+
+    private const val TAG = "ContactShare"
+
+    /** Bigger than any plausible vCard; stops a mislabelled 500 MB file being slurped into RAM. */
+    const val MAX_VCARD_BYTES = 1024L * 1024
+
+    private val VCARD_MIME_TYPES = setOf(
+        "text/vcard",
+        "text/x-vcard",
+        // Pre-RFC-6350 exporters still emit text/directory for a vCard.
+        "text/directory",
+    )
+
+    suspend fun detect(
+        descriptor: SharedContentDescriptor,
+        fileSize: (fileName: String) -> Long,
+        readFileText: suspend (fileName: String) -> String,
+    ): VCardContact? {
+        // A lone vcf only: the contact card replaces the whole share, so anything shared
+        // alongside it would be silently dropped.
+        val vCardFile = descriptor.fileNames.singleOrNull()?.takeIf {
+            isVCardMime(descriptor.mimeTypes.firstOrNull()) || it.endsWith(".vcf", ignoreCase = true)
+        }
+
+        val source = when {
+            vCardFile != null -> readCapped(vCardFile, fileSize, readFileText)
+            // Some senders put the card body straight in the share text.
+            descriptor.fileNames.isEmpty() -> descriptor.text
+            else -> null
+        } ?: return null
+
+        if (!VCardParser.looksLikeVCard(source)) return null
+
+        val cards = VCardParser.parse(source)
+        if (cards.isEmpty()) {
+            Logger.w(tag = TAG) { "vCard detected but nothing parsed; falling back to raw share" }
+            return null
+        }
+        if (cards.size > 1) {
+            Logger.i(tag = TAG) { "vCard carries ${cards.size} blocks; sending the first only" }
+        }
+        return cards.first()
+    }
+
+    private suspend fun readCapped(
+        fileName: String,
+        fileSize: (String) -> Long,
+        readFileText: suspend (String) -> String,
+    ): String? = try {
+        if (fileSize(fileName) > MAX_VCARD_BYTES) {
+            Logger.w(tag = TAG) { "Shared vCard exceeds $MAX_VCARD_BYTES bytes; sending it as a file" }
+            null
+        } else {
+            readFileText(fileName)
+        }
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        Logger.w(tag = TAG, throwable = e) { "Failed to read shared vCard" }
+        null
+    }
+
+    private fun isVCardMime(mimeType: String?): Boolean =
+        mimeType?.substringBefore(';')?.trim()?.lowercase() in VCARD_MIME_TYPES
+}
+
+/**
+ * Normalizes a parsed vCard into the wire descriptor. Implemented in homebase-core, which owns
+ * `ContactFieldValidation` (E.164) — homebase-chat does not depend on it, so the send path takes
+ * the conversion by injection.
+ */
+fun interface VCardDescriptorFactory {
+    fun toDescriptor(contact: VCardContact): ContactCardDescriptor?
+}

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
@@ -18,6 +18,7 @@ import id.homebase.api.client.eventbus.EventBus
 import id.homebase.api.coroutines.ioDispatcher
 import id.homebase.core.emoji.EmojiNormalization.distinctByEmoji
 import id.homebase.api.file.FileOperationsProvider
+import id.homebase.chat.contactcard.VCardDescriptorFactory
 import id.homebase.chat.conversationlist.ConversationListUiEvent.NavigateBack
 import id.homebase.chat.conversationlist.ConversationListUiEvent.NavigateToNewConversation
 import id.homebase.chat.conversationlist.ConversationListUiEvent.ShowErrorMessage
@@ -161,6 +162,7 @@ class ConversationListViewModel(
     private val connectionRequestService: ConnectionRequestService,
     private val driveFileProvider: DriveFileProvider,
     private val shareContentProcessor: ShareContentProcessor,
+    private val vCardDescriptorFactory: VCardDescriptorFactory,
     private val localVideoContextStore: LocalAttachmentContextStore,
     private val pendingNotificationTap: PendingNotificationTap,
     private val cropResultBus: id.homebase.imageeditor.ui.CropResultBus,
@@ -263,6 +265,7 @@ class ConversationListViewModel(
         fileOperationsProvider = fileOperationsProvider,
         localVideoContextStore = localVideoContextStore,
         shareContentProcessor = shareContentProcessor,
+        vCardDescriptorFactory = vCardDescriptorFactory,
         userPreferences = userPreferences,
         sendEvent = ::sendEvent,
         dispatch = ::onAction,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/MessageActionsHandler.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/MessageActionsHandler.kt
@@ -8,6 +8,8 @@ import id.homebase.api.image.ImageHeaderParser
 import id.homebase.api.image.ImageUtils
 import id.homebase.api.image.convertHeicToJpeg
 import id.homebase.api.util.truncateToCodePoints
+import id.homebase.chat.contactcard.SharedVCardDetector
+import id.homebase.chat.contactcard.VCardDescriptorFactory
 import id.homebase.chat.conversationlist.ConversationListUiDialog.DeleteMessage
 import id.homebase.chat.conversationlist.ConversationListUiDialog.DiscardDraft
 import id.homebase.chat.conversationlist.ConversationListUiEvent.ShowErrorMessage
@@ -123,6 +125,7 @@ internal class MessageActionsHandler(
     private val fileOperationsProvider: FileOperationsProvider,
     private val localVideoContextStore: LocalAttachmentContextStore,
     private val shareContentProcessor: ShareContentProcessor,
+    private val vCardDescriptorFactory: VCardDescriptorFactory,
     private val userPreferences: UserPreferences,
     private val sendEvent: (ConversationListUiEvent) -> Unit,
     private val dispatch: (ConversationListUiAction) -> Unit,
@@ -980,6 +983,28 @@ internal class MessageActionsHandler(
                     "Shared content resolved to nothing (type=${descriptor.contentType}) — not sending"
                 }
                 sendEvent(ShowErrorMessage(MR.string.chat_error_shared_content_unreadable))
+                return
+            }
+
+            val contactCard = SharedVCardDetector.detect(
+                descriptor = descriptor,
+                fileSize = { fileOperationsProvider.getFileSize(shareContentProcessor.resolveFilePath(it)) },
+                readFileText = {
+                    fileOperationsProvider
+                        .readFileBytes(shareContentProcessor.resolveFilePath(it))
+                        .decodeToString()
+                },
+            )?.let { vCardDescriptorFactory.toDescriptor(it) }
+
+            if (contactCard != null) {
+                val newMessageId = Uuid.random()
+                pendingMessageId = newMessageId
+                chatMessageSenderService.sendNewTypedMessage(
+                    messageUniqueId = newMessageId,
+                    conversationId = conversationId,
+                    content = MessageContent.ContactCard(contactCard),
+                    previousMessageUniqueId = null,
+                )
                 return
             }
 

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/contactcard/SharedVCardDetectorTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/contactcard/SharedVCardDetectorTest.kt
@@ -1,0 +1,301 @@
+package id.homebase.chat.contactcard
+
+import id.homebase.core.share.SharedContentDescriptor
+import id.homebase.core.share.SharedContentType
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Pins the descriptor-driven half of the contact-share path — the one iOS takes. A shared `.vcf`
+ * reaches the app as a generic `FILE` descriptor, and must come out of [SharedVCardDetector] as a
+ * parsed contact so the send path can ship a contact card instead of an opaque attachment.
+ * Anything else, or a vCard that won't parse, must leave the detector null so the existing
+ * file/text send runs unchanged.
+ *
+ * Companion to androidApp's `ShareReceiverVCardIntentTest`, which pins the Intent-driven half.
+ */
+class SharedVCardDetectorTest {
+
+    private val vcard = """
+        BEGIN:VCARD
+        VERSION:3.0
+        N:Vance;Ada;;;
+        FN:Ada Vance
+        ORG:Homebase;Engineering
+        TEL;TYPE=CELL:+14155550123
+        EMAIL;TYPE=INTERNET:ada@example.com
+        END:VCARD
+    """.trimIndent()
+
+    private var readCount = 0
+    private val files = mutableMapOf<String, String>()
+
+    private fun descriptor(
+        contentType: SharedContentType = SharedContentType.FILE,
+        text: String? = null,
+        fileNames: List<String> = emptyList(),
+        mimeTypes: List<String> = emptyList(),
+    ) = SharedContentDescriptor(
+        contentType = contentType,
+        text = text,
+        fileNames = fileNames,
+        mimeTypes = mimeTypes,
+        targetConversationId = "0198cf39-0000-7000-8000-000000000001",
+    )
+
+    private suspend fun detect(
+        descriptor: SharedContentDescriptor,
+        sizeOverride: Long? = null,
+    ): VCardContact? = SharedVCardDetector.detect(
+        descriptor = descriptor,
+        fileSize = { sizeOverride ?: files[it]?.length?.toLong() ?: 0L },
+        readFileText = {
+            readCount++
+            files.getValue(it)
+        },
+    )
+
+    @Test
+    fun `a vcf lands as a generic FILE descriptor and is still recognised`() = runTest {
+        files["Ada Vance.vcf"] = vcard
+
+        val contact = assertNotNull(
+            detect(
+                descriptor(
+                    fileNames = listOf("Ada Vance.vcf"),
+                    // What UTType(filenameExtension:) hands the iOS extension for a .vcf.
+                    mimeTypes = listOf("text/vcard"),
+                )
+            ),
+            "iOS delivers a shared contact as contentType=FILE with a .vcf name.",
+        )
+
+        assertEquals("Ada Vance", contact.displayName)
+        assertEquals(listOf("+14155550123"), contact.phones)
+        assertEquals(listOf("ada@example.com"), contact.emails)
+    }
+
+    @Test
+    fun `a text-vcard mime is recognised even when the file has no vcf extension`() = runTest {
+        files["contact"] = vcard
+
+        assertNotNull(detect(descriptor(fileNames = listOf("contact"), mimeTypes = listOf("text/vcard"))))
+    }
+
+    @Test
+    fun `a charset parameter on the mime type does not defeat detection`() = runTest {
+        files["contact"] = vcard
+
+        assertNotNull(
+            detect(
+                descriptor(
+                    fileNames = listOf("contact"),
+                    mimeTypes = listOf("TEXT/X-VCARD; charset=utf-8"),
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `a vcf filename is recognised even when the mime type is generic`() = runTest {
+        files["Ada Vance.VCF"] = vcard
+
+        assertNotNull(
+            detect(
+                descriptor(
+                    fileNames = listOf("Ada Vance.VCF"),
+                    mimeTypes = listOf("application/octet-stream"),
+                )
+            ),
+            "Senders that declare application/octet-stream still name the file *.vcf.",
+        )
+    }
+
+    @Test
+    fun `a vCard body arriving in the descriptor text is recognised`() = runTest {
+        val contact = assertNotNull(detect(descriptor(contentType = SharedContentType.TEXT, text = vcard)))
+
+        assertEquals("Ada Vance", contact.displayName)
+        assertEquals(0, readCount, "A text-only share reads no file.")
+    }
+
+    @Test
+    fun `a vcf shared alongside other files stays on the file path so nothing is dropped`() = runTest {
+        files["photo.jpg"] = "not a card"
+        files["Ada Vance.vcf"] = vcard
+        files["notes.pdf"] = "%PDF-1.7"
+        val mixed = descriptor(
+            contentType = SharedContentType.MIXED,
+            fileNames = listOf("photo.jpg", "Ada Vance.vcf", "notes.pdf"),
+            mimeTypes = listOf("image/jpeg", "text/vcard", "application/pdf"),
+        )
+
+        assertNull(
+            detect(mixed),
+            "A contact card replaces the whole share — the co-shared files would be lost.",
+        )
+        assertEquals(
+            listOf("photo.jpg", "Ada Vance.vcf", "notes.pdf"),
+            mixed.fileNames,
+            "…so all three still go out through the ordinary multi-file send.",
+        )
+        assertEquals(0, readCount)
+    }
+
+    @Test
+    fun `a vCard body in the text of a file share does not drop the file`() = runTest {
+        files["photo.jpg"] = "not a card"
+
+        assertNull(
+            detect(
+                descriptor(
+                    contentType = SharedContentType.MIXED,
+                    text = vcard,
+                    fileNames = listOf("photo.jpg"),
+                    mimeTypes = listOf("image/jpeg"),
+                )
+            ),
+            "Sending the card here would lose the photo.",
+        )
+    }
+
+    @Test
+    fun `a lone vcf with a caption is still a contact card`() = runTest {
+        files["Ada Vance.vcf"] = vcard
+
+        val contact = assertNotNull(
+            detect(
+                descriptor(
+                    contentType = SharedContentType.MIXED,
+                    text = "here's Ada",
+                    fileNames = listOf("Ada Vance.vcf"),
+                    mimeTypes = listOf("text/vcard"),
+                )
+            ),
+            "The gate is on co-shared FILES; a caption carries nothing that can be dropped.",
+        )
+
+        assertEquals("Ada Vance", contact.displayName)
+    }
+
+    @Test
+    fun `a multi-contact vcf yields the first block`() = runTest {
+        files["two.vcf"] = """
+            BEGIN:VCARD
+            VERSION:3.0
+            FN:First Person
+            TEL:+14155550001
+            END:VCARD
+            BEGIN:VCARD
+            VERSION:3.0
+            FN:Second Person
+            TEL:+14155550002
+            END:VCARD
+        """.trimIndent()
+
+        val contact = assertNotNull(detect(descriptor(fileNames = listOf("two.vcf"), mimeTypes = listOf("text/vcard"))))
+
+        assertEquals("First Person", contact.displayName)
+    }
+
+    @Test
+    fun `an ordinary file share is untouched and never read`() = runTest {
+        files["report.pdf"] = "%PDF-1.7"
+
+        assertNull(detect(descriptor(fileNames = listOf("report.pdf"), mimeTypes = listOf("application/pdf"))))
+        assertEquals(0, readCount, "A non-vCard share must not be read looking for a contact.")
+    }
+
+    @Test
+    fun `an ordinary text share is untouched`() = runTest {
+        assertNull(
+            detect(
+                descriptor(
+                    contentType = SharedContentType.URL,
+                    text = "check out https://homebase.id",
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `an oversize vcf is not read and falls back to the file send`() = runTest {
+        files["huge.vcf"] = vcard
+
+        assertNull(
+            detect(
+                descriptor(fileNames = listOf("huge.vcf"), mimeTypes = listOf("text/vcard")),
+                sizeOverride = SharedVCardDetector.MAX_VCARD_BYTES + 1,
+            )
+        )
+        assertEquals(0, readCount, "A mislabelled huge file must never be slurped into RAM.")
+    }
+
+    @Test
+    fun `a vcf sized exactly at the cap is still read`() = runTest {
+        files["edge.vcf"] = vcard
+
+        assertNotNull(
+            detect(
+                descriptor(fileNames = listOf("edge.vcf"), mimeTypes = listOf("text/vcard")),
+                sizeOverride = SharedVCardDetector.MAX_VCARD_BYTES,
+            )
+        )
+    }
+
+    @Test
+    fun `an unreadable vcf falls back rather than dropping the share`() = runTest {
+        // No entry in `files`, so the read lambda throws — mirrors a file swept before send.
+        assertNull(detect(descriptor(fileNames = listOf("gone.vcf"), mimeTypes = listOf("text/vcard"))))
+    }
+
+    @Test
+    fun `a vcf that is not actually a vCard falls back to the file send`() = runTest {
+        files["fake.vcf"] = "this is not a vCard at all"
+
+        assertNull(detect(descriptor(fileNames = listOf("fake.vcf"), mimeTypes = listOf("text/vcard"))))
+    }
+
+    @Test
+    fun `a vcf whose blocks carry nothing renderable falls back to the file send`() = runTest {
+        files["empty.vcf"] = "BEGIN:VCARD\nVERSION:3.0\nFN:\nTEL:\nEND:VCARD"
+
+        assertNull(detect(descriptor(fileNames = listOf("empty.vcf"), mimeTypes = listOf("text/vcard"))))
+    }
+
+    @Test
+    fun `a broken vcf does not fall through to unrelated descriptor text`() = runTest {
+        files["fake.vcf"] = "this is not a vCard at all"
+
+        assertNull(
+            detect(
+                descriptor(
+                    contentType = SharedContentType.MIXED,
+                    text = vcard,
+                    fileNames = listOf("fake.vcf"),
+                    mimeTypes = listOf("text/vcard"),
+                )
+            ),
+            "The named file is the share; a caption must not be parsed in its place.",
+        )
+    }
+
+    @Test
+    fun `a descriptor carrying no vCard at all leaves every send path unchanged`() = runTest {
+        val plain = descriptor(
+            contentType = SharedContentType.IMAGE,
+            text = "look at this",
+            fileNames = listOf("photo.jpg"),
+            mimeTypes = listOf("image/jpeg"),
+        )
+
+        assertNull(detect(plain))
+        assertTrue(plain.fileNames.isNotEmpty(), "…and the file is still there to send.")
+        assertFalse(plain.text.isNullOrBlank())
+    }
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
@@ -23,6 +23,7 @@ import okio.Path.Companion.toPath
 import id.homebase.auth.login.LoginViewModel
 import id.homebase.chat.addgroupmembers.AddGroupMembersViewModel
 import id.homebase.chat.archivedconversations.ArchivedConversationsViewModel
+import id.homebase.chat.contactcard.VCardDescriptorFactory
 import id.homebase.chat.conversationlist.ConversationListViewModel
 import id.homebase.chat.conversationlist.ExtendPermissionViewModel
 import id.homebase.chat.conversationmedia.ConversationMediaViewModel
@@ -94,6 +95,7 @@ import id.homebase.core.contactbook.EmergencyContactReceiveService
 import id.homebase.core.contactbook.EmergencyContactReconciler
 import id.homebase.core.ui.screens.contactbook.CircleMemberPickerViewModel
 import id.homebase.core.ui.screens.contactbook.ContactBookViewModel
+import id.homebase.core.ui.screens.contactbook.ContactCardImport
 import id.homebase.core.ui.screens.contactbook.add.AddContactViewModel
 import id.homebase.core.ui.screens.contactbook.detail.ContactDetailViewModel
 import id.homebase.core.ui.screens.contactbook.settings.ContactBookSettingsViewModel
@@ -669,6 +671,9 @@ val appModule = module {
 
     singleOf(::ShareConversationCacheWriter)
     singleOf(::ShareContentProcessor)
+    // Lets chat's descriptor share path normalize a vCard through ContactFieldValidation, which
+    // lives here — homebase-chat must not depend on homebase-core.
+    single<VCardDescriptorFactory> { VCardDescriptorFactory(ContactCardImport::toDescriptor) }
     singleOf(::LocalAttachmentContextStore)
 
     singleOf(::ConnectionCacheRepository)
@@ -875,6 +880,7 @@ val appModule = module {
             connectionRequestService = get(),
             driveFileProvider = get<id.homebase.api.client.drives.files.DriveFileProvider>(),
             shareContentProcessor = get(),
+            vCardDescriptorFactory = get(),
             localVideoContextStore = get(),
             pendingNotificationTap = get(),
             cropResultBus = get(),

--- a/homebase-core/src/jvmTest/kotlin/id/homebase/core/ui/screens/contactbook/SharedVCardDescriptorPathTest.kt
+++ b/homebase-core/src/jvmTest/kotlin/id/homebase/core/ui/screens/contactbook/SharedVCardDescriptorPathTest.kt
@@ -1,0 +1,68 @@
+package id.homebase.core.ui.screens.contactbook
+
+import id.homebase.chat.contactcard.SharedVCardDetector
+import id.homebase.chat.contactcard.VCardDescriptorFactory
+import id.homebase.core.share.SharedContentDescriptor
+import id.homebase.core.share.SharedContentType
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+/**
+ * Closes the loop the module boundary splits: chat's [SharedVCardDetector] handed to the real
+ * [VCardDescriptorFactory] this module binds in Koin. Proves that what the descriptor share path
+ * sends is normalized the same way the Android path normalizes it — E.164 phones via
+ * [ContactFieldValidation] — rather than a verbatim copy of the vCard.
+ */
+class SharedVCardDescriptorPathTest {
+
+    private val factory = VCardDescriptorFactory(ContactCardImport::toDescriptor)
+
+    private val files = mutableMapOf<String, String>()
+
+    private suspend fun sentDescriptor(descriptor: SharedContentDescriptor) =
+        SharedVCardDetector.detect(
+            descriptor = descriptor,
+            fileSize = { files[it]?.length?.toLong() ?: 0L },
+            readFileText = { files.getValue(it) },
+        )?.let { factory.toDescriptor(it) }
+
+    private fun fileShare(fileName: String, mimeType: String) = SharedContentDescriptor(
+        contentType = SharedContentType.FILE,
+        fileNames = listOf(fileName),
+        mimeTypes = listOf(mimeType),
+        targetConversationId = "0198cf39-0000-7000-8000-000000000001",
+    )
+
+    @Test
+    fun `a shared vcf becomes a contact card with E164 phones`() = runTest {
+        files["Ada Vance.vcf"] = """
+            BEGIN:VCARD
+            VERSION:3.0
+            N:Vance;Ada;;;
+            FN:Ada Vance
+            ORG:Homebase;Engineering
+            TEL;TYPE=CELL:+1 (415) 555-0123
+            EMAIL;TYPE=INTERNET:ada@example.com
+            END:VCARD
+        """.trimIndent()
+
+        val card = assertNotNull(sentDescriptor(fileShare("Ada Vance.vcf", "text/vcard")))
+
+        assertEquals("Ada Vance", card.displayName)
+        assertEquals("Homebase", card.organization)
+        assertEquals(listOf("+14155550123"), card.phones)
+        assertEquals(listOf("ada@example.com"), card.emails)
+    }
+
+    @Test
+    fun `a card the importer rejects falls back to the file send`() = runTest {
+        // Parses as a vCard (ORG only), but carries no name, phone or email — isValid() fails,
+        // so the share must go out as the raw .vcf rather than as a blank bubble.
+        files["org.vcf"] = "BEGIN:VCARD\nVERSION:3.0\nORG:Homebase\nEND:VCARD"
+
+        assertNull(sentDescriptor(fileShare("org.vcf", "text/vcard")))
+    }
+}


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

> **Stacked on #1260** — review that one first. This layer does not compile without it.

## Why

#1260 made a shared vCard become a contact card instead of an opaque `.vcf` attachment — but only on Android, where the interception lives in `ShareReceiverActivity`. iOS never goes through that code.

iOS shares travel a different route: the share extension writes a `SharedContentDescriptor` into the App Group and the main app picks it up in `MessageActionsHandler.processPendingSharedContent`. A shared `.vcf` misses every specific branch in `SharedContentSaver.swift` and lands in the generic `UTType.data` one, so iOS sends the raw file.

Verified against the system UTI database rather than assumed:

```
public.vcard  conforms to public.text:        true
              conforms to public.plain-text:  false   <- skips the plainText branch
              conforms to public.data:        true    <- lands in the generic data branch
UTType(filenameExtension: "vcf")  ->  public.vcard  ->  text/vcard
```

That last line is what `SharedContentSaver.mimeTypeForExtension` runs, so the descriptor arrives as `fileNames = ["Alice.vcf"]`, `mimeTypes = ["text/vcard"]`.

## What

`SharedVCardDetector` (homebase-chat, commonMain) recognises a vCard on the descriptor path, and `processPendingSharedContent` sends `MessageContent.ContactCard` instead of a file. Detection semantics mirror Android's `ContactShareDetector`: the three vCard mime types with any `;charset=` stripped, or a `.vcf` filename, or a vCard body in the share text; 1 MiB read cap; first block of a multi-contact card.

Because it hooks the descriptor rather than an Android `Intent`, it also covers any other descriptor-driven entry point — `ShareCacheStorage` has a `jvmMain` actual.

**Layering.** `ContactCardImport.toDescriptor` needs `ContactFieldValidation` for E.164, and both live in `:homebase-core`, which `:homebase-chat` does not depend on (`homebase-chat/build.gradle.kts:51-58`). So the conversion is injected: `fun interface VCardDescriptorFactory` declared in homebase-chat, SAM-bound in `AppModule` to `ContactCardImport::toDescriptor`. No new module dependency, no relocated files, nothing duplicated.

## Fallback contract

Anything that isn't a parseable vCard — wrong mime, oversize, unreadable, parses to nothing renderable, or a descriptor the importer rejects — falls through to the existing file/text send completely unchanged. A share is never dropped and never becomes a blank bubble.

One place this deliberately diverges from Android: **a multi-file share is left alone.** The contact card replaces the *whole* share, so anything shared alongside the vcf would vanish. Android's detector picks the first vcf out of the share and discards the sibling files with it — `photo.jpg` + `Alice.vcf` sends only the card. Here the contact-card path requires the vcf to be the share's only file, and the text-vCard path requires there be no files at all; a mixed share goes down the ordinary multi-file send with everything intact.

The Android path has the same defect and is worth a follow-up — this PR does not touch it, since #1260 is device-verified and shouldn't be disturbed.

## Tests

18 in `SharedVCardDetectorTest`, 2 in `SharedVCardDescriptorPathTest`. JVM.

The seam is the detector — the same split #1260 used (it tested `ContactShareDetector`, not the Activity), because `ChatMessageSenderService` is a concrete class and the repo ships no mocking framework. `SharedVCardDescriptorPathTest` crosses the module seam with the *real* `ContactCardImport` factory, so the injected-conversion wiring is covered rather than just the chat-side half.

Both multi-file regression tests were checked against the pre-fix detector and fail there, so they pin behaviour rather than merely passing.

```
homebase-chat: tests=1124 failures=0 errors=0 skipped=6
homebase-core: tests=348  failures=0 errors=0 skipped=2
```

## Not in this PR

- **The sender-side "add to your contacts?" prompt.** On Android that's a Compose surface owned by `ShareReceiverActivity` (`ShareScreenState.ContactSent`). The descriptor path has no equivalent host, so porting it means a new `ConversationListUiDialog` arm — its own change.
- **Any Swift.** `SharedContentSaver.swift:157` handles only `item as? URL` in the data branch, while the image branch above it also handles in-memory `Data` (added for #854). If Contacts.app vends the vCard as `Data`, the extension captures nothing and this layer never fires. I have no evidence either way yet, so no speculative fix — see the verification note below.

## Verification status

JVM tests prove the descriptor path produces a contact card. They do **not** prove iOS populates the descriptor in the first place — that needs a signed-in simulator or device build, sharing a contact from Contacts.app and confirming a card renders. Until that runs, treat the iOS end-to-end as unverified.
