### PR TITLE
feat(chat): add a Contact option to the attachment sheet

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListScreen.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListScreen.kt
@@ -135,6 +135,7 @@ fun ConversationListScreen(
     onNavigateToLiveLocationMap: () -> Unit = {},
     onNavigateToLocationSetup: () -> Unit = {},
     onNavigateToShareLocation: (conversationId: String) -> Unit = {},
+    onNavigateToShareContact: (conversationId: String) -> Unit = {},
     onNavigateToContactInfo: (odinId: String) -> Unit,
     onNavigateToConversationSettings: (conversationId: String) -> Unit,
     onNavigateToGroupSettings: (conversationId: String) -> Unit,
@@ -218,6 +219,11 @@ fun ConversationListScreen(
             is ConversationListUiEvent.NavigateToShareLocation -> {
                 viewModel.eventConsumed()
                 onNavigateToShareLocation(event.conversationId)
+            }
+
+            is ConversationListUiEvent.NavigateToShareContact -> {
+                viewModel.eventConsumed()
+                onNavigateToShareContact(event.conversationId)
             }
 
             is ConversationListUiEvent.NavigateToContactInfo -> {

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiAction.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiAction.kt
@@ -422,6 +422,11 @@ sealed interface ConversationListUiAction {
     /** Open the full-screen share-location screen (attachment sheet → Location). */
     data class OpenShareLocation(val conversationId: Uuid) : ConversationListUiAction
 
+    /** Open the contact book picker that sends a contact card (attachment sheet → Contact). The
+     *  contact book lives in :homebase-core, which this module can't see — hence a navigation
+     *  event rather than an in-place sheet. */
+    data class OpenShareContact(val conversationId: Uuid) : ConversationListUiAction
+
     /** Open the location setup screen — from the "set up location" prompt shown when a live share
      *  can't start because location isn't ready. */
     data object OpenLocationSetup : ConversationListUiAction

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiEvent.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiEvent.kt
@@ -38,6 +38,9 @@ sealed interface ConversationListUiEvent {
     /** Open the full-screen share-location screen for a conversation (attachment sheet → Location). */
     data class NavigateToShareLocation(val conversationId: String) : ConversationListUiEvent
 
+    /** Open the contact book picker for a conversation (attachment sheet → Contact). */
+    data class NavigateToShareContact(val conversationId: String) : ConversationListUiEvent
+
     /** Open the location setup screen (from the "set up location" prompt before a live share). */
     data object NavigateToLocationSetup : ConversationListUiEvent
 }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
@@ -1122,6 +1122,10 @@ class ConversationListViewModel(
                 sendEvent(ConversationListUiEvent.NavigateToShareLocation(action.conversationId.toString()))
             }
 
+            is ConversationListUiAction.OpenShareContact -> {
+                sendEvent(ConversationListUiEvent.NavigateToShareContact(action.conversationId.toString()))
+            }
+
             is ConversationListUiAction.OpenLocationSetup -> {
                 sendEvent(ConversationListUiEvent.NavigateToLocationSetup)
             }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/AttachmentOptions.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/AttachmentOptions.kt
@@ -29,6 +29,7 @@ import androidx.compose.material.icons.automirrored.filled.ArrowForward
 import androidx.compose.material.icons.filled.BarChart
 import androidx.compose.material.icons.filled.CalendarMonth
 import androidx.compose.material.icons.filled.Casino
+import androidx.compose.material.icons.filled.ContactPage
 import androidx.compose.material.icons.filled.Event
 import androidx.compose.material.icons.filled.Image
 import androidx.compose.material.icons.filled.LocationOn
@@ -74,6 +75,7 @@ import id.homebase.core.util.noRippleClickable
 import id.homebase.resources.MR
 import id.homebase.resources.chat_message_attachment_file
 import id.homebase.resources.chat_message_attachment_gallery
+import id.homebase.resources.chat_contact_share
 import id.homebase.resources.chat_dice_share
 import id.homebase.resources.chat_event_share
 import id.homebase.resources.chat_groodle_share
@@ -439,6 +441,14 @@ fun AttachmentOptions(
                     icon = Icons.Default.UploadFile,
                     label = stringResource(MR.string.chat_message_attachment_file),
                     onClick = onFileClick
+                )
+            }
+            item {
+                AttachmentOption(
+                    modifier = Modifier.testTag("attachment_contact"),
+                    icon = Icons.Default.ContactPage,
+                    label = stringResource(MR.string.chat_contact_share),
+                    onClick = onContactClick,
                 )
             }
             if (isMobile()) {

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
@@ -1745,6 +1745,9 @@ fun ConversationContent(
                         fileLauncher.launch()
                     }, onContactClick = {
                         showAttachmentSheet = false
+                        onUiAction(
+                            ConversationListUiAction.OpenShareContact(conversation.conversation.id)
+                        )
                     }, onLocationClick = {
                         Logger.d(tag = "LocationShare") { "share location clicked" }
                         showAttachmentSheet = false

--- a/homebase-chat/src/commonTest/kotlin/id/homebase/chat/widget/AttachmentOptionsTest.kt
+++ b/homebase-chat/src/commonTest/kotlin/id/homebase/chat/widget/AttachmentOptionsTest.kt
@@ -72,4 +72,44 @@ class AttachmentOptionsTest {
         onNodeWithTag("attachment_file").performClick()
         assertTrue(clicked)
     }
+
+    @Test
+    fun displaysContactOption() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                AttachmentOptions(
+                    onGalleryClick = {},
+                    onFileClick = {},
+                    onContactClick = {},
+                    onLocationClick = {},
+                    onEventClick = {},
+                    onGroodleClick = {},
+                    onDicesClick = {},
+                    onPollClick = {},
+                )
+            }
+        }
+        onNodeWithTag("attachment_contact").assertExists()
+    }
+
+    @Test
+    fun contactClickCallbackFires() = runComposeUiTest {
+        var clicked = false
+        setContent {
+            MaterialTheme {
+                AttachmentOptions(
+                    onGalleryClick = {},
+                    onFileClick = {},
+                    onContactClick = { clicked = true },
+                    onLocationClick = {},
+                    onEventClick = {},
+                    onGroodleClick = {},
+                    onDicesClick = {},
+                    onPollClick = {},
+                )
+            }
+        }
+        onNodeWithTag("attachment_contact").performClick()
+        assertTrue(clicked)
+    }
 }

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -927,6 +927,10 @@
 
     <!-- Shared contact card (vCard shared into the app) -->
     <string name="chat_contact_unparseable">Unable to display this contact. Please update the app.</string>
+    <string name="chat_contact_share">Contact</string>
+    <string name="chat_contact_share_title">Send a contact</string>
+    <string name="chat_contact_share_no_contacts">No contacts to send.</string>
+    <string name="chat_contact_share_unshareable">No phone number or email to share</string>
     <string name="contactbook_edit_organization">Organization</string>
     <string name="contact_share_prompt_title">Add to your contacts?</string>
     <string name="contact_share_prompt_body">%1$s was shared to your chat. Save them to your contacts too?</string>

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/ui/navigation/Routes.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/ui/navigation/Routes.kt
@@ -230,6 +230,10 @@ sealed class Route {
     @SerialName("location-share")
     data class LocationShare(val conversationId: String) : Route()
 
+    @Serializable
+    @SerialName("chat-share-contact")
+    data class ShareContact(val conversationId: String) : Route()
+
     /** In-app picker to grant emergency-location-access circle membership to one or more
      *  contacts — replaces the old owner-console browser deep link. */
     @Serializable

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
@@ -96,6 +96,7 @@ import id.homebase.core.contactbook.EmergencyContactReconciler
 import id.homebase.core.ui.screens.contactbook.CircleMemberPickerViewModel
 import id.homebase.core.ui.screens.contactbook.ContactBookViewModel
 import id.homebase.core.ui.screens.contactbook.ContactCardImport
+import id.homebase.core.ui.screens.contactbook.ShareContactPickerViewModel
 import id.homebase.core.ui.screens.contactbook.add.AddContactViewModel
 import id.homebase.core.ui.screens.contactbook.detail.ContactDetailViewModel
 import id.homebase.core.ui.screens.contactbook.settings.ContactBookSettingsViewModel
@@ -994,6 +995,14 @@ val appModule = module {
             circleName = params.get(),
             repo = get(),
             connectionService = get(),
+        )
+    }
+    // Manual block: conversationId arrives as a Koin runtime parameter from the ShareContact route.
+    viewModel { params ->
+        ShareContactPickerViewModel(
+            conversationId = params.get(),
+            repo = get(),
+            chatMessageSenderService = get(),
         )
     }
     viewModelOf(::ContactDetailViewModel)

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
@@ -146,6 +146,7 @@ import id.homebase.core.ui.screens.contactbook.add.AddContactScreen
 import id.homebase.core.ui.screens.contactbook.ContactBookUiAction
 import id.homebase.core.ui.screens.contactbook.ContactBookUiEvent
 import id.homebase.core.ui.screens.contactbook.ContactBookViewModel
+import id.homebase.core.ui.screens.contactbook.ShareContactPickerScreen
 import id.homebase.core.ui.screens.contactbook.detail.ContactDetailScreen
 import id.homebase.core.ui.screens.contactbook.onboarding.ContactBookOnboardingScreen
 import id.homebase.core.ui.screens.contactbook.settings.ContactBookSettingsScreen
@@ -1013,6 +1014,9 @@ fun AppNavHost(
                                     onNavigateToShareLocation = { conversationId ->
                                         navController.navigate(Route.LocationShare(conversationId))
                                     },
+                                    onNavigateToShareContact = { conversationId ->
+                                        navController.navigate(Route.ShareContact(conversationId))
+                                    },
                                     onNavigateToContactInfo = {
                                         // 1:1 contact info is the full contact-detail screen
                                         // (keyed by the contact uniqueId = md5(odinId)).
@@ -1544,6 +1548,23 @@ fun AppNavHost(
                                     // Maps-off / enable-location CTA → location setup (dashboard or
                                     // onboarding), reusing the shared nav lambda.
                                     onOpenSetup = openLocation,
+                                )
+                            }
+                        }
+
+                        composable<Route.ShareContact> { backStackEntry ->
+                            if (isAuthenticated) {
+                                val route = backStackEntry.toRoute<Route.ShareContact>()
+                                ShareContactPickerScreen(
+                                    viewModel = koinViewModel(
+                                        key = route.conversationId,
+                                        parameters = {
+                                            org.koin.core.parameter.parametersOf(
+                                                Uuid.parse(route.conversationId)
+                                            )
+                                        },
+                                    ),
+                                    onNavigateBack = { navController.popBackStack() },
                                 )
                             }
                         }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/ContactCardImport.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/ContactCardImport.kt
@@ -3,6 +3,7 @@ package id.homebase.core.ui.screens.contactbook
 import id.homebase.api.util.truncateToCodePoints
 import id.homebase.chat.contactcard.ContactCardDescriptor
 import id.homebase.chat.contactcard.VCardContact
+import id.homebase.core.ui.screens.contactbook.model.ContactBookEntry
 
 /**
  * Turns a parsed vCard into the two shapes the share flow needs: the wire descriptor for the
@@ -21,8 +22,20 @@ object ContactCardImport {
             givenName = contact.givenName.cap(),
             surname = contact.surname.cap(),
             organization = contact.organization.cap(),
-            phones = contact.normalizedPhones(),
-            emails = contact.normalizedEmails(),
+            phones = contact.phones.normalizedPhones(),
+            emails = contact.emails.normalizedEmails(),
+        )
+        return descriptor.takeIf { it.isValid() }
+    }
+
+    /** [ContactBookEntry] has no organization field, so the descriptor's stays blank. */
+    fun toDescriptor(entry: ContactBookEntry): ContactCardDescriptor? {
+        val descriptor = ContactCardDescriptor(
+            displayName = entry.displayName.cap(),
+            givenName = entry.givenName.orEmpty().cap(),
+            surname = entry.surname.orEmpty().cap(),
+            phones = (listOfNotNull(entry.phone) + entry.additionalPhones).normalizedPhones(),
+            emails = (listOfNotNull(entry.email) + entry.additionalEmails).normalizedEmails(),
         )
         return descriptor.takeIf { it.isValid() }
     }
@@ -36,19 +49,19 @@ object ContactCardImport {
         return ContactDraft(
             givenName = fallbackGiven,
             surname = surname,
-            phone = contact.normalizedPhones().firstOrNull().orEmpty(),
-            email = contact.normalizedEmails().firstOrNull().orEmpty(),
+            phone = contact.phones.normalizedPhones().firstOrNull().orEmpty(),
+            email = contact.emails.normalizedEmails().firstOrNull().orEmpty(),
         )
     }
 
-    private fun VCardContact.normalizedPhones(): List<String> = phones
+    private fun List<String>.normalizedPhones(): List<String> = this
         .map { ContactFieldValidation.normalizePhone(it) }
         .filter { it.isNotBlank() }
         .distinct()
         .take(ContactCardDescriptor.MAX_VALUES_PER_KIND)
         .map { it.truncateToCodePoints(ContactCardDescriptor.MAX_VALUE_CODEPOINTS) }
 
-    private fun VCardContact.normalizedEmails(): List<String> = emails
+    private fun List<String>.normalizedEmails(): List<String> = this
         .map { it.trim() }
         .filter { it.isNotBlank() }
         .distinct()

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/ShareContactPickerScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/ShareContactPickerScreen.kt
@@ -1,0 +1,168 @@
+package id.homebase.core.ui.screens.contactbook
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.Send
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import id.homebase.core.ui.screens.contactbook.components.ContactBookRow
+import id.homebase.core.widget.StyledSearchTextField
+import id.homebase.resources.MR
+import id.homebase.resources.chat_contact_share_no_contacts
+import id.homebase.resources.chat_contact_share_title
+import id.homebase.resources.chat_contact_share_unshareable
+import id.homebase.resources.chat_new_conversation_search_placeholder
+import id.homebase.resources.menu_back
+import id.homebase.resources.send
+import kotlinx.coroutines.launch
+import org.jetbrains.compose.resources.getString
+import org.jetbrains.compose.resources.stringResource
+
+@Composable
+fun ShareContactPickerScreen(
+    viewModel: ShareContactPickerViewModel,
+    onNavigateBack: () -> Unit,
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val snackbarHostState = remember { SnackbarHostState() }
+    val scope = rememberCoroutineScope()
+
+    LaunchedEffect(Unit) {
+        viewModel.events.collect { event ->
+            when (event) {
+                ShareContactPickerUiEvent.Back,
+                ShareContactPickerUiEvent.MessageSent -> onNavigateBack()
+
+                is ShareContactPickerUiEvent.ShowError -> {
+                    val message = getString(event.res)
+                    scope.launch { snackbarHostState.showSnackbar(message) }
+                }
+            }
+        }
+    }
+
+    ShareContactPickerUi(
+        snackbarHostState = snackbarHostState,
+        uiState = uiState,
+        searchTextState = viewModel.searchTextState,
+        onUiAction = viewModel::onUiAction,
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ShareContactPickerUi(
+    snackbarHostState: SnackbarHostState,
+    uiState: ShareContactPickerUiState,
+    searchTextState: TextFieldState,
+    onUiAction: (ShareContactPickerUiAction) -> Unit,
+) {
+    Scaffold(
+        modifier = Modifier.imePadding(),
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(MR.string.chat_contact_share_title)) },
+                navigationIcon = {
+                    IconButton(onClick = { onUiAction(ShareContactPickerUiAction.BackClicked) }) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(MR.string.menu_back),
+                        )
+                    }
+                },
+            )
+        },
+        floatingActionButton = {
+            if (uiState.selectedId != null) {
+                Button(
+                    onClick = { onUiAction(ShareContactPickerUiAction.SendClicked) },
+                    modifier = Modifier.defaultMinSize(minWidth = 56.dp),
+                    enabled = !uiState.isSending,
+                    shape = CircleShape,
+                ) {
+                    if (uiState.isSending) {
+                        CircularProgressIndicator(modifier = Modifier.size(20.dp), strokeWidth = 2.dp)
+                    } else {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.Send,
+                            contentDescription = stringResource(MR.string.send),
+                        )
+                    }
+                }
+            }
+        },
+    ) { paddingValues ->
+        Column(modifier = Modifier.padding(paddingValues)) {
+            StyledSearchTextField(
+                modifier = Modifier.padding(horizontal = 16.dp).fillMaxWidth(),
+                textFieldState = searchTextState,
+                showSearchIcon = false,
+                placeHolderText = stringResource(MR.string.chat_new_conversation_search_placeholder),
+            )
+            if (uiState.candidates.isEmpty()) {
+                Row(
+                    modifier = Modifier.fillMaxWidth().padding(top = 24.dp, start = 16.dp, end = 16.dp),
+                    horizontalArrangement = Arrangement.Center,
+                ) {
+                    Text(text = stringResource(MR.string.chat_contact_share_no_contacts))
+                }
+            } else {
+                val unshareableReason = stringResource(MR.string.chat_contact_share_unshareable)
+                LazyColumn(
+                    modifier = Modifier.weight(1f),
+                    contentPadding = PaddingValues(vertical = 8.dp),
+                ) {
+                    items(uiState.candidates, key = { it.entry.uniqueId.toString() }) { candidate ->
+                        val entry = candidate.entry
+                        ContactBookRow(
+                            entry = entry,
+                            onClick = { onUiAction(ShareContactPickerUiAction.ContactClicked(entry)) },
+                            disabledReason = if (!candidate.shareable) unshareableReason else null,
+                            trailing = if (uiState.selectedId == entry.uniqueId) {
+                                {
+                                    Icon(
+                                        imageVector = Icons.Default.CheckCircle,
+                                        contentDescription = null,
+                                        tint = MaterialTheme.colorScheme.primary,
+                                    )
+                                }
+                            } else null,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/ShareContactPickerUiState.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/ShareContactPickerUiState.kt
@@ -1,0 +1,58 @@
+package id.homebase.core.ui.screens.contactbook
+
+import id.homebase.chat.contactcard.ContactCardDescriptor
+import id.homebase.core.ui.screens.contactbook.model.ContactBookEntry
+import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toPersistentList
+import org.jetbrains.compose.resources.StringResource
+import kotlin.uuid.Uuid
+
+data class ShareContactPickerUiState(
+    val candidates: PersistentList<ShareContactCandidate> = persistentListOf(),
+    val selectedId: Uuid? = null,
+    val isSending: Boolean = false,
+) {
+    val selected: ShareContactCandidate?
+        get() = candidates.firstOrNull { it.entry.uniqueId == selectedId }
+}
+
+/**
+ * A contact book row offered in the send-a-contact picker. [descriptor] is null when the entry
+ * carries nothing a contact card can hold — the row is shown but disabled, so a contact that
+ * can't be shared reads as "needs a phone or email" rather than silently missing from the list.
+ */
+data class ShareContactCandidate(
+    val entry: ContactBookEntry,
+    val descriptor: ContactCardDescriptor?,
+) {
+    val shareable: Boolean get() = descriptor != null
+}
+
+sealed interface ShareContactPickerUiAction {
+    data class ContactClicked(val entry: ContactBookEntry) : ShareContactPickerUiAction
+    data object SendClicked : ShareContactPickerUiAction
+    data object BackClicked : ShareContactPickerUiAction
+}
+
+sealed interface ShareContactPickerUiEvent {
+    data object Back : ShareContactPickerUiEvent
+
+    /** The contact card went out — the screen pops back to the conversation. */
+    data object MessageSent : ShareContactPickerUiEvent
+
+    data class ShowError(val res: StringResource) : ShareContactPickerUiEvent
+}
+
+/**
+ * Builds the picker list: [query]-filtered, name-sorted, each row carrying the descriptor it
+ * would send (null when there is nothing to send).
+ */
+fun shareContactCandidates(
+    entries: List<ContactBookEntry>,
+    query: String,
+): PersistentList<ShareContactCandidate> = entries
+    .filter { it.matches(query) }
+    .sortedBy { it.sortKey }
+    .map { ShareContactCandidate(entry = it, descriptor = ContactCardImport.toDescriptor(it)) }
+    .toPersistentList()

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/ShareContactPickerViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/ShareContactPickerViewModel.kt
@@ -1,0 +1,109 @@
+package id.homebase.core.ui.screens.contactbook
+
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.runtime.snapshotFlow
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import co.touchlab.kermit.Logger
+import id.homebase.api.client.contacts.ContactRepository
+import id.homebase.chat.services.ChatMessageSenderService
+import id.homebase.chat.services.content.MessageContent
+import id.homebase.core.ui.screens.contactbook.model.toContactBookEntry
+import id.homebase.resources.MR
+import id.homebase.resources.chat_contact_share_unshareable
+import id.homebase.resources.error_unknown
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlin.uuid.Uuid
+
+private const val TAG = "ShareContactPickerViewModel"
+
+/**
+ * Picks a Homebase contact book row and sends it into [conversationId] as a
+ * [MessageContent.ContactCard]. Lives in `:homebase-core` because the contact book does — the
+ * chat attachment sheet can't reach it, so it navigates here (the Location share pattern).
+ */
+class ShareContactPickerViewModel(
+    private val conversationId: Uuid,
+    private val repo: ContactRepository,
+    private val chatMessageSenderService: ChatMessageSenderService,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(ShareContactPickerUiState())
+    val uiState: StateFlow<ShareContactPickerUiState> = _uiState.asStateFlow()
+    val searchTextState = TextFieldState()
+
+    private val _events = MutableSharedFlow<ShareContactPickerUiEvent>(extraBufferCapacity = 4)
+    val events: SharedFlow<ShareContactPickerUiEvent> = _events.asSharedFlow()
+
+    init {
+        viewModelScope.launch { repo.ensureLoaded() }
+        viewModelScope.launch {
+            combine(
+                repo.contacts,
+                snapshotFlow { searchTextState.text.toString() },
+            ) { contacts, query ->
+                shareContactCandidates(contacts.mapNotNull { it.toContactBookEntry() }, query)
+            }.collect { candidates ->
+                _uiState.update { it.copy(candidates = candidates) }
+            }
+        }
+    }
+
+    fun onUiAction(action: ShareContactPickerUiAction) {
+        when (action) {
+            is ShareContactPickerUiAction.ContactClicked -> {
+                val candidate = _uiState.value.candidates
+                    .firstOrNull { it.entry.uniqueId == action.entry.uniqueId }
+                if (candidate == null || !candidate.shareable) {
+                    _events.tryEmit(
+                        ShareContactPickerUiEvent.ShowError(MR.string.chat_contact_share_unshareable)
+                    )
+                    return
+                }
+                _uiState.update {
+                    it.copy(selectedId = if (it.selectedId == action.entry.uniqueId) null else action.entry.uniqueId)
+                }
+            }
+
+            ShareContactPickerUiAction.SendClicked -> send()
+            ShareContactPickerUiAction.BackClicked -> _events.tryEmit(ShareContactPickerUiEvent.Back)
+        }
+    }
+
+    private fun send() {
+        val state = _uiState.value
+        if (state.isSending) return
+        val descriptor = state.selected?.descriptor ?: run {
+            _events.tryEmit(
+                ShareContactPickerUiEvent.ShowError(MR.string.chat_contact_share_unshareable)
+            )
+            return
+        }
+        _uiState.update { it.copy(isSending = true) }
+        viewModelScope.launch {
+            try {
+                chatMessageSenderService.sendNewTypedMessage(
+                    messageUniqueId = Uuid.random(),
+                    conversationId = conversationId,
+                    content = MessageContent.ContactCard(descriptor),
+                    previousMessageUniqueId = null,
+                )
+                _events.emit(ShareContactPickerUiEvent.MessageSent)
+            } catch (e: kotlin.coroutines.cancellation.CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Logger.e(throwable = e, tag = TAG) { "contact card send failed" }
+                _uiState.update { it.copy(isSending = false) }
+                _events.emit(ShareContactPickerUiEvent.ShowError(MR.string.error_unknown))
+            }
+        }
+    }
+}

--- a/homebase-core/src/jvmTest/kotlin/id/homebase/core/ui/screens/contactbook/ShareContactPickerTest.kt
+++ b/homebase-core/src/jvmTest/kotlin/id/homebase/core/ui/screens/contactbook/ShareContactPickerTest.kt
@@ -1,0 +1,201 @@
+@file:OptIn(ExperimentalUuidApi::class)
+
+package id.homebase.core.ui.screens.contactbook
+
+import id.homebase.chat.contactcard.ContactCardDescriptor
+import id.homebase.core.ui.screens.contactbook.model.ContactBookEntry
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+/**
+ * The outbound half of the contact card: a contact book row picked inside a chat becomes the
+ * same wire descriptor the inbound vCard share produces.
+ */
+class ShareContactPickerTest {
+
+    private fun entry(
+        displayName: String = "Ada Vance",
+        givenName: String? = "Ada",
+        surname: String? = "Vance",
+        phone: String? = null,
+        additionalPhones: List<String> = emptyList(),
+        email: String? = null,
+        additionalEmails: List<String> = emptyList(),
+        odinId: String? = null,
+    ) = ContactBookEntry(
+        uniqueId = Uuid.random(),
+        fileId = Uuid.random(),
+        versionTag = null,
+        odinId = odinId,
+        displayName = displayName,
+        givenName = givenName,
+        surname = surname,
+        phone = phone,
+        email = email,
+        additionalPhones = additionalPhones,
+        additionalEmails = additionalEmails,
+    )
+
+    @Test
+    fun `collapses the primary and additional slots into one list each`() {
+        val descriptor = assertNotNull(
+            ContactCardImport.toDescriptor(
+                entry(
+                    phone = "+14155550123",
+                    additionalPhones = listOf("+14155550124", "+14155550125"),
+                    email = "ada@example.com",
+                    additionalEmails = listOf("ada.vance@work.example"),
+                )
+            )
+        )
+
+        assertEquals(
+            listOf("+14155550123", "+14155550124", "+14155550125"),
+            descriptor.phones,
+            "Primary first, then the additional slots in order.",
+        )
+        assertEquals(listOf("ada@example.com", "ada.vance@work.example"), descriptor.emails)
+        assertEquals("Ada Vance", descriptor.displayName)
+        assertEquals("Ada", descriptor.givenName)
+        assertEquals("Vance", descriptor.surname)
+    }
+
+    @Test
+    fun `normalizes a formatted number to E164 on the way out`() {
+        val descriptor = assertNotNull(
+            ContactCardImport.toDescriptor(entry(phone = "+1 (415) 555-0123"))
+        )
+
+        assertEquals(listOf("+14155550123"), descriptor.phones)
+        assertTrue(ContactFieldValidation.isValidPhone(descriptor.phones.first()))
+    }
+
+    @Test
+    fun `a legacy non-E164 number is carried verbatim rather than dropped`() {
+        val descriptor = assertNotNull(
+            ContactCardImport.toDescriptor(entry(phone = "0207 946 0018"))
+        )
+
+        assertEquals(listOf("02079460018"), descriptor.phones)
+        assertFalse(ContactFieldValidation.isValidPhone(descriptor.phones.first()))
+    }
+
+    @Test
+    fun `duplicate and blank slots collapse away`() {
+        val descriptor = assertNotNull(
+            ContactCardImport.toDescriptor(
+                entry(
+                    phone = "+14155550123",
+                    additionalPhones = listOf("+1 415 555 0123", "   ", "+14155550124"),
+                    email = "ada@example.com",
+                    additionalEmails = listOf("ada@example.com", ""),
+                )
+            )
+        )
+
+        assertEquals(listOf("+14155550123", "+14155550124"), descriptor.phones)
+        assertEquals(listOf("ada@example.com"), descriptor.emails)
+    }
+
+    @Test
+    fun `values are capped at MAX_VALUES_PER_KIND`() {
+        val many = (1..(ContactCardDescriptor.MAX_VALUES_PER_KIND + 5))
+            .map { "+1415555%04d".format(it) }
+        val descriptor = assertNotNull(
+            ContactCardImport.toDescriptor(
+                entry(
+                    phone = many.first(),
+                    additionalPhones = many.drop(1),
+                    additionalEmails = (1..(ContactCardDescriptor.MAX_VALUES_PER_KIND + 3))
+                        .map { "user$it@example.com" },
+                )
+            )
+        )
+
+        assertEquals(ContactCardDescriptor.MAX_VALUES_PER_KIND, descriptor.phones.size)
+        assertEquals(ContactCardDescriptor.MAX_VALUES_PER_KIND, descriptor.emails.size)
+        assertTrue(descriptor.isValid())
+    }
+
+    @Test
+    fun `an over-long name is truncated rather than rejected`() {
+        val long = "Ada".repeat(ContactCardDescriptor.MAX_NAME_CODEPOINTS)
+        val descriptor = assertNotNull(
+            ContactCardImport.toDescriptor(
+                entry(displayName = long, givenName = long, surname = long, phone = "+14155550123")
+            )
+        )
+
+        assertEquals(ContactCardDescriptor.MAX_NAME_CODEPOINTS, descriptor.displayName.length)
+        assertTrue(descriptor.isValid())
+    }
+
+    @Test
+    fun `an entry with nothing shareable produces no descriptor`() {
+        assertNull(ContactCardImport.toDescriptor(entry(displayName = "", givenName = null, surname = null)))
+    }
+
+    @Test
+    fun `organization stays blank because ContactBookEntry has no such field`() {
+        val descriptor = assertNotNull(ContactCardImport.toDescriptor(entry(phone = "+14155550123")))
+
+        assertEquals("", descriptor.organization)
+    }
+
+    @Test
+    fun `a name-only entry is shareable`() {
+        // displayName alone satisfies isValid() — the receiver still gets someone to save.
+        val descriptor = assertNotNull(ContactCardImport.toDescriptor(entry()))
+
+        assertEquals("Ada Vance", descriptor.displayName)
+        assertTrue(descriptor.phones.isEmpty())
+    }
+
+    @Test
+    fun `candidates are name-sorted and carry the descriptor they would send`() {
+        val candidates = shareContactCandidates(
+            entries = listOf(
+                entry(displayName = "Zoe Nakamura", phone = "+819012345678"),
+                entry(displayName = "ada vance", phone = "+14155550123"),
+            ),
+            query = "",
+        )
+
+        assertEquals(listOf("ada vance", "Zoe Nakamura"), candidates.map { it.entry.displayName })
+        assertTrue(candidates.all { it.shareable })
+        assertEquals(listOf("+14155550123"), candidates.first().descriptor?.phones)
+    }
+
+    @Test
+    fun `an unshareable contact is listed but marked, not hidden`() {
+        val candidates = shareContactCandidates(
+            entries = listOf(entry(displayName = "", givenName = null, surname = null)),
+            query = "",
+        )
+
+        assertEquals(1, candidates.size, "It must stay visible so it doesn't read as missing.")
+        assertFalse(candidates.single().shareable)
+        assertNull(candidates.single().descriptor)
+    }
+
+    @Test
+    fun `the query filters on name, phone, email and odinId`() {
+        val entries = listOf(
+            entry(displayName = "Ada Vance", phone = "+14155550123", odinId = "ada.example.com"),
+            entry(displayName = "Zoe Nakamura", email = "zoe@example.com"),
+        )
+
+        assertEquals(1, shareContactCandidates(entries, "ada").size)
+        assertEquals(1, shareContactCandidates(entries, "zoe@example").size)
+        assertEquals(1, shareContactCandidates(entries, "4155550123").size)
+        assertEquals(1, shareContactCandidates(entries, "ada.example.com").size)
+        assertEquals(2, shareContactCandidates(entries, "").size)
+        assertEquals(0, shareContactCandidates(entries, "nobody").size)
+    }
+}


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

Closes #1264. **Stacked on #1261 → #1260** — review those first; this does not compile without them.

## Why

You could receive a contact card, and (after #1260/#1261) share one *into* a conversation from the OS share sheet. You could not originate one from inside a chat.

`AttachmentOptions` already took an `onContactClick` parameter and `ConversationContent.kt:1746` implemented it as `showAttachmentSheet = false` — no row rendered it, so it was dead. That dead parameter is what #1255 was originally written against ("route it into the existing contact-attachment path"), which is why that issue turned into a whole new message kind instead of a routing change.

## What

A **Contact** row in the attachment sheet → a contact-book picker → sends `MessageContent.ContactCard`, the kind #1260 added. Bubble, parser and receive side already work, so this is purely the outbound affordance.

Routing mirrors the **Location** option hop for hop — each new line sits beside its Location twin:

```
AttachmentOption tap
  -> ConversationListUiAction.OpenShareContact(conversationId)   ConversationContent.kt:1749
  -> ConversationListViewModel.kt:1121
  -> ConversationListUiEvent.NavigateToShareContact(id)
  -> ConversationListScreen.kt:216
  -> AppNavHost.kt:1010 -> Route.ShareContact
```

Same `Uuid`→`String`→`Uuid.parse` threading and the same manual Koin `viewModel { params -> }` block, for the same reason Location has one (`viewModelOf` would try to autowire the runtime parameter).

**Where the picker lives.** `:homebase-chat` does not depend on `:homebase-core` (`homebase-chat/build.gradle.kts:51-58`), so the picker cannot live next to the attachment sheet — the contact book is all in core. It sits beside `CircleMemberPickerScreen`, which it is modelled on. Since core *does* depend on chat, the picker's ViewModel calls `sendNewTypedMessage` directly, copying `ShareReceiverActivity.sendContactCard`'s shape.

**Select-then-send, not tap-to-send.** An accidental tap would otherwise drop a message into someone's chat with no undo.

## Mapping

`ContactBookEntry` has **no organization field** — confirmed, not assumed (`ContactBookEntry.kt:43-90`). `descriptor.organization` is left blank and a test pins that; `shortBio` / `status` were not repurposed into it. `additionalName` likewise has no descriptor slot and is dropped.

`phones` = `phone` + `additionalPhones`, `emails` = `email` + `additionalEmails`, both normalized to E.164 through `ContactFieldValidation` and capped at `MAX_VALUES_PER_KIND`. This is a second `ContactCardImport.toDescriptor` overload — the private normalization helpers were refactored from `VCardContact` extensions to `List<String>` extensions so the vCard path and the picker path share one rule set rather than drifting.

## Tests

`ShareContactPickerTest` (12) and 2 added to `AttachmentOptionsTest` (now 5; the 3 pre-existing cases are untouched, diff is additive only).

Full gate green: **1,966 tests, 0 failures**. Konsist `ArchitectureTest` passes and uses `Konsist.scopeFromProject()`, so it genuinely scans the new core and chat composables rather than only `homebase-common`.

## Known exposure

**This repo has no Koin graph verification test.** The new DI registration is validated only at runtime — the same exposure `ShareLocationViewModel` already carries. Compiling proves the types line up, not that the graph resolves, so opening the attachment sheet is a worthwhile smoke test before merge. The registration deliberately copies the proven Location pattern to minimise the risk.

Not device-verified — the picker needs a populated contact book. The send path is the same `sendNewTypedMessage` call the already-verified share flow uses.

## Not in scope

`odinId` on the card (#1265). The picker doesn't foreclose it: `ShareContactCandidate` holds the whole `ContactBookEntry`, which carries `odinId`, and the descriptor is built in exactly one place, so adding it later is one property plus one line in the mapper. Nothing was pre-built. The open question there is what the *inbound* vCard path puts in that field, since a vCard has no odinId.
