### PR TITLE
fix(chat): stop display-only message previews from consuming taps

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/event/EventBubble.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/event/EventBubble.kt
@@ -134,13 +134,13 @@ fun EventBubble(
         .clip(RoundedCornerShape(16.dp))
         .background(containerColor)
         .let {
-            // combinedClickable (not clickable) so the parent message bubble's
-            // own combinedClickable.onLongClick still fires on mobile —
-            // Modifier.clickable consumes pointer events and otherwise swallows
-            // the long-press, leaving Events with no action menu on mobile.
-            if (canOpenDetail || onLongClick != null) {
+            // Off-stream (action-menu preview, message info, reply quote) the bubble must take no
+            // pointer at all — a handler that can't open the detail still eats the tap the
+            // action-menu scrim needs to dismiss. combinedClickable, not clickable, so the parent
+            // message bubble's long-press survives.
+            if (canOpenDetail) {
                 it.combinedClickable(
-                    onClick = { if (canOpenDetail) showDetail = true },
+                    onClick = { showDetail = true },
                     onLongClick = onLongClick,
                 )
             } else it
@@ -161,8 +161,8 @@ fun EventBubble(
                 imageSize = ImageSize.THUMB_MEDIUM,
                 preserveAspectRatio = true,
                 shape = RoundedCornerShape(0.dp),
-                onClick = { if (canOpenDetail) showDetail = true },
-                onLongPress = onLongClick?.let { lc -> { _ -> lc() } },
+                onClick = if (canOpenDetail) ({ showDetail = true }) else null,
+                onLongPress = onLongClick?.takeIf { canOpenDetail }?.let { lc -> { _ -> lc() } },
                 sharedTransitionScope = null,
                 animatedVisibilityScope = null,
                 modifier = Modifier.fillMaxWidth(),

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/groodle/GroodleBubble.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/groodle/GroodleBubble.kt
@@ -113,9 +113,11 @@ fun GroodleBubble(
         .clip(RoundedCornerShape(16.dp))
         .background(containerColor)
         .let {
-            if (canOpenDetail || onLongClick != null) {
+            // Off-stream the bubble must take no pointer: a handler that can't open the detail
+            // still eats the tap the action-menu scrim needs to dismiss.
+            if (canOpenDetail) {
                 it.combinedClickable(
-                    onClick = { if (canOpenDetail) showDetail = true },
+                    onClick = { showDetail = true },
                     onLongClick = onLongClick,
                 )
             } else it

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/poll/PollBubble.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/poll/PollBubble.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -114,6 +115,10 @@ fun PollBubble(
             messageId to conversationId
         } else null
     val canVote = voteTarget != null
+    // Off-stream (action-menu preview, message info, reply quote) both ids are null: nothing here
+    // may take a pointer, because a handler that can't act still eats the tap the action-menu
+    // scrim needs to dismiss.
+    val canOpenDetail = messageId != null && conversationId != null
     val actionService: ChatMessageActionService = koinInject()
     val scope = rememberCoroutineScope()
 
@@ -124,7 +129,7 @@ fun PollBubble(
         .clip(RoundedCornerShape(16.dp))
         .background(containerColor)
         .let {
-            if (canVote || onLongClick != null) {
+            if (canOpenDetail) {
                 it.combinedClickable(
                     onClick = {},
                     onLongClick = onLongClick,
@@ -214,18 +219,23 @@ fun PollBubble(
             )
         } else {
             val footerLabel = if (descriptor.closed) viewResultsText else viewVotesText
-            TextButton(
-                onClick = { showDetail = true },
-                modifier = Modifier.fillMaxWidth(),
-                colors = ButtonDefaults.textButtonColors(
-                    contentColor = MaterialTheme.colorScheme.primary,
-                ),
-            ) {
-                Text(
-                    text = footerLabel,
-                    style = MaterialTheme.typography.labelLarge,
-                    fontWeight = FontWeight.SemiBold,
-                )
+            if (canOpenDetail) {
+                TextButton(
+                    onClick = { showDetail = true },
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = ButtonDefaults.textButtonColors(
+                        contentColor = MaterialTheme.colorScheme.primary,
+                    ),
+                ) {
+                    PollFooterLabel(footerLabel)
+                }
+            } else {
+                Box(
+                    modifier = Modifier.fillMaxWidth().heightIn(min = 40.dp),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    PollFooterLabel(footerLabel, MaterialTheme.colorScheme.primary)
+                }
             }
         }
     }
@@ -241,6 +251,16 @@ fun PollBubble(
             onDismiss = { showDetail = false },
         )
     }
+}
+
+@Composable
+private fun PollFooterLabel(text: String, color: Color = Color.Unspecified) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.labelLarge,
+        fontWeight = FontWeight.SemiBold,
+        color = color,
+    )
 }
 
 @Composable

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubble.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubble.kt
@@ -443,6 +443,7 @@ fun SentMessageBubbleDisplayOnly(
             downloadingFiles = emptySet(),
             onRequestDecryptedFile = null,
             onLongClick = {},
+            displayOnly = true,
         )
         message.reactionPreview?.let { reactionSummary ->
             ReactionList(
@@ -858,6 +859,7 @@ fun ReceivedMessageBubbleDisplayOnly(
             downloadingFiles = emptySet(),
             onRequestDecryptedFile = null,
             onLongClick = {},
+            displayOnly = true,
         )
         message.reactionPreview?.let { reactionSummary ->
             ReactionList(

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubbleRaw.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubbleRaw.kt
@@ -72,6 +72,7 @@ import id.homebase.chat.data.MessageUiModel
 import id.homebase.chat.dice.DiceRollBubble
 import id.homebase.chat.event.EventBubble
 import id.homebase.chat.groodle.GroodleBubble
+import id.homebase.chat.poll.PollBubble
 import id.homebase.chat.services.ChatProtocol
 import id.homebase.chat.services.content.MessageContent
 import id.homebase.core.config.chatTargetDrive
@@ -164,6 +165,9 @@ fun MessageBubbleRaw(
     searchQuery: String = "",
     isCurrentSearchResult: Boolean = false,
     chainCap: Int? = null,
+    // Rendered as a preview of a message (action-menu header, message info, reply quote) rather
+    // than as the message itself: typed bubbles must not open their full-screen detail from here.
+    displayOnly: Boolean = false,
 ) {
 
     // #814: render the timestamp + delivery footer only on the last bubble of a
@@ -188,8 +192,8 @@ fun MessageBubbleRaw(
             EventBubble(
                 descriptor = content.descriptor,
                 modifier = modifier,
-                messageId = message.id,
-                conversationId = message.conversationId,
+                messageId = message.id.takeIf { !displayOnly },
+                conversationId = message.conversationId.takeIf { !displayOnly },
                 ownReactions = message.ownReactions,
                 reactionSummary = message.reactionPreview,
                 organizer = message.originalAuthor,
@@ -214,8 +218,8 @@ fun MessageBubbleRaw(
             GroodleBubble(
                 descriptor = content.descriptor,
                 modifier = modifier,
-                messageId = message.id,
-                conversationId = message.conversationId,
+                messageId = message.id.takeIf { !displayOnly },
+                conversationId = message.conversationId.takeIf { !displayOnly },
                 ownReactions = message.ownReactions,
                 reactionSummary = message.reactionPreview,
                 organizer = message.originalAuthor,
@@ -238,11 +242,11 @@ fun MessageBubbleRaw(
             return
         }
         is MessageContent.Poll -> {
-            id.homebase.chat.poll.PollBubble(
+            PollBubble(
                 descriptor = content.descriptor,
                 modifier = modifier,
-                messageId = message.id,
-                conversationId = message.conversationId,
+                messageId = message.id.takeIf { !displayOnly },
+                conversationId = message.conversationId.takeIf { !displayOnly },
                 ownReactions = message.ownReactions,
                 reactionSummary = message.reactionPreview,
                 organizer = message.originalAuthor,


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

**Stacked on #1266.** Independent of the contact-card work above it — this is a pre-existing bug in the message-preview surfaces.

## The bug

`SentMessageBubbleDisplayOnly` / `ReceivedMessageBubbleDisplayOnly` render a message inside surfaces where it is a *picture of a message*, not a message: the long-press action menu's own preview (`Menu.kt:377,582`), reply/forward quotes, and `MessageInfoScreen`. In those places the bubble should be inert.

It wasn't. Every typed bubble gated its pointer on `if (canOpenDetail || onLongClick != null)` — and `onLongClick` is **non-nullable** (`MessageBubbleRaw.kt:152`), so that condition is always `true`. The bubbles therefore attached a `combinedClickable` in previews and **consumed the tap**, which the action menu's scrim needs in order to dismiss (`Menu.kt:857-862`).

Worst case: **tapping a poll option in the action-menu preview cast a real vote.** `PollBubble` also opened its detail dialog on top of the menu.

## The fix

A `displayOnly` parameter on `MessageBubbleRaw`, set by the two `…DisplayOnly` wrappers, which nulls `messageId`/`conversationId` so `canOpenDetail` is genuinely false — and each bubble now gates on `canOpenDetail` alone.

Three sites needed it beyond the obvious two:

- **`EventBubble`'s cover photo.** `MediaItem.kt:248` attaches `pointerInput` when *either* `onClick` or `onLongPress` is non-null, so a cover photo ate the tap even with the container fixed. Both are now null off-stream.
- **`PollBubble`'s footer.** Off-stream it renders as a label rather than a `TextButton` — a *disabled* button would not have been enough. `TapGestureDetector.kt:251` is `awaitFirstDown().also { it.consume() }`, unconditional; `enabled` only gates `onPress`/`onTap` (`Clickable.kt:886,892`), and the non-suspending path consumes before checking `enabled` (`:927-929`). A disabled M3 button still eats the down event.
- `PollBubble` was also fully-qualified at its call site; now imported.

## Scope

Deliberately does **not** touch the contact card — that's #1271, which uses the same `displayOnly` gate. Split out so this reads as one concern.

No behavioural change in the message stream itself: `displayOnly` is false there and every gate evaluates exactly as before.
