### PR TITLE
fix(chat,contacts): forward typed messages intact, and harden the save path

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageSenderService.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageSenderService.kt
@@ -846,32 +846,6 @@ class ChatMessageSenderService(
         val content = sourceFile.fileMetadata.appData.content
             ?: throw IllegalArgumentException("source message has no content")
 
-        val messageAppData = try {
-            OdinSystemSerializer.deserialize<MessageAppData>(content)
-        } catch (e: Exception) {
-            throw IllegalArgumentException("Failed to deserialize source message content for $sourceMessageUniqueId: ${content.take(200)}", e)
-        }
-
-        val fullText = chatMessageStream.loadFullMessage(
-            conversationId = sourceFile.fileMetadata.appData.groupId!!,
-            messageId = sourceMessageUniqueId
-        ) ?: messageAppData.getMessage()
-
-        val forwardData = messageAppData.copy(
-            replyPreview = null,
-            message = JsonPrimitive(fullText),
-            deliveryStatus = ChatDeliveryStatus.Sent.value,
-            isEdited = false,
-        )
-
-        val mediaBundle = buildMediaPayloadBundle(sourceFile)
-
-        val built = buildMessageContentAndBundle(
-            preVersionedMessageData = forwardData,
-            payloadBundle = mediaBundle,
-            fileOperationsProvider = fileOperationsProvider
-        )
-
         // Preserve the source's dataType so a forwarded Location stays
         // header-tagged as a Location (and any future payload-bearing kind
         // does the same automatically). Sources that pre-date the kind
@@ -880,12 +854,47 @@ class ChatMessageSenderService(
         // wire-level messages.
         val forwardedDataType = sourceFile.fileMetadata.appData.dataType ?: 0
 
+        val typed = MessageContentParser.parse(forwardedDataType, content)
+        val built = if (MessageContentParser.usesRawHeaderContent(typed)) {
+            // The descriptor IS the header content for these kinds. Round-tripping it through the
+            // MessageAppData envelope drops every field the descriptor requires, so the receiver
+            // parses the forward into a null descriptor and paints the unsupported-format chip.
+            // No size check either: these bytes already passed MaxHeaderContentBytes on the
+            // original send and are forwarded unchanged.
+            MessageBuildResult(
+                headerContent = content,
+                payloadBundle = buildMediaPayloadBundle(sourceFile),
+            )
+        } else {
+            val messageAppData = try {
+                OdinSystemSerializer.deserialize<MessageAppData>(content)
+            } catch (e: Exception) {
+                throw IllegalArgumentException("Failed to deserialize source message content for $sourceMessageUniqueId: ${content.take(200)}", e)
+            }
+
+            val fullText = chatMessageStream.loadFullMessage(
+                conversationId = sourceFile.fileMetadata.appData.groupId!!,
+                messageId = sourceMessageUniqueId
+            ) ?: messageAppData.getMessage()
+
+            buildMessageContentAndBundle(
+                preVersionedMessageData = messageAppData.copy(
+                    replyPreview = null,
+                    message = JsonPrimitive(fullText),
+                    deliveryStatus = ChatDeliveryStatus.Sent.value,
+                    isEdited = false,
+                ),
+                payloadBundle = buildMediaPayloadBundle(sourceFile),
+                fileOperationsProvider = fileOperationsProvider
+            )
+        }
+
         return targetConversationIds.map { conversationId ->
             sendMessageInternal(
                 messageUniqueId = Uuid.random(),
                 conversationId = conversationId,
                 content = built.headerContent,
-                notificationText = "You have a new message",
+                notificationText = typed?.notificationLabel ?: "You have a new message",
                 previousMessageUniqueId = null,
                 payloadBundle = built.payloadBundle,
                 dataType = forwardedDataType,

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageSenderServiceForwardTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageSenderServiceForwardTest.kt
@@ -1,0 +1,139 @@
+package id.homebase.chat.services
+
+import id.homebase.api.client.drives.HomebaseFile
+import id.homebase.api.client.drives.query.QueryBatchCursor
+import id.homebase.api.common.BatchResult
+import id.homebase.api.serialization.OdinSystemSerializer
+import id.homebase.api.sync.database.DatabaseManager
+import id.homebase.chat.contactcard.ContactCardDescriptor
+import id.homebase.chat.data.MessageUiModel
+import id.homebase.chat.services.content.MessageContent
+import id.homebase.chat.services.content.MessageContentParser
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.uuid.Uuid
+
+/**
+ * A contact card is the first typed kind with `allowForward = true`, and a typed kind stores its
+ * descriptor VERBATIM in `appData.content`. `MessageAppData` has a default for every field and the
+ * serializer ignores unknown keys, so re-wrapping the descriptor in that envelope succeeds silently
+ * and lands a card with no `displayName` — which fails `ContactCardDescriptor`'s required-field
+ * decode and paints the receiver's unsupported-format chip instead of the card.
+ */
+class ChatMessageSenderServiceForwardTest {
+
+    private class DbBackedLookup : MessageLookup {
+        var fileLookup: suspend (Uuid) -> HomebaseFile? = { null }
+
+        override suspend fun getMessage(messageId: Uuid): MessageUiModel? = null
+
+        override suspend fun getMessageFile(messageId: Uuid): HomebaseFile? = fileLookup(messageId)
+
+        override suspend fun getMessages(
+            messageIds: List<Uuid>,
+            conversationId: Uuid,
+        ): BatchResult<MessageUiModel> =
+            BatchResult(records = emptyList(), hasMoreRows = false, cursor = QueryBatchCursor())
+
+        override suspend fun loadFullMessage(conversationId: Uuid, messageId: Uuid): String? = null
+
+        override fun findCachedFileId(messageId: Uuid): Uuid? = null
+    }
+
+    private suspend fun ChatMessageSenderServiceTestFixture.headerContentOf(uniqueId: Uuid): String? =
+        dbm.driveMainIndex
+            .selectHomebaseFileByUnique(testIdentityId, chatDriveId, uniqueId)
+            ?.fileMetadata?.appData?.content
+
+    @Test
+    fun `forwarding a contact card carries the descriptor itself, not a MessageAppData envelope`() = runTest {
+        val lookup = DbBackedLookup()
+
+        ChatMessageSenderServiceTestFixture().use { fixture ->
+            val service = fixture.build(messageLookup = { _: DatabaseManager -> lookup })
+            lookup.fileLookup = { uid ->
+                fixture.dbm.driveMainIndex
+                    .selectHomebaseFileByUnique(fixture.testIdentityId, fixture.chatDriveId, uid)
+            }
+
+            val source = fixture.seedConversation(others = listOf("bob.test"))
+            val target = fixture.seedConversation(others = listOf("carol.test"))
+            val messageId = Uuid.random()
+            val descriptor = ContactCardDescriptor(
+                displayName = "Ada Vance",
+                phones = listOf("+14155550123"),
+                emails = listOf("ada@example.com"),
+            )
+
+            service.sendNewTypedMessage(
+                messageUniqueId = messageId,
+                conversationId = source,
+                content = MessageContent.ContactCard(descriptor),
+                previousMessageUniqueId = null,
+            )
+
+            val forwarded = service.forwardMessage(messageId, listOf(target))
+
+            val storedContent = fixture.headerContentOf(forwarded.single().uniqueId)
+            assertNotNull(storedContent, "the forwarded card must have header content")
+
+            val reparsed = MessageContentParser.parse(
+                ChatProtocol.ChatContactCardMessageDataType,
+                storedContent,
+            )
+            assertEquals(
+                descriptor,
+                (reparsed as? MessageContent.ContactCard)?.descriptor,
+                "a forwarded contact card must re-parse to the card that was forwarded",
+            )
+        }
+    }
+
+    /**
+     * The other side of the branch: a text message's content IS a MessageAppData, and forwarding it
+     * has to rebuild that envelope rather than copy it — a forward does not carry the quote of the
+     * message it came from.
+     */
+    @Test
+    fun `forwarding a text reply still rebuilds the envelope, dropping the quote`() =
+        runTest {
+            val lookup = DbBackedLookup()
+
+            ChatMessageSenderServiceTestFixture().use { fixture ->
+                val service = fixture.build(messageLookup = { _: DatabaseManager -> lookup })
+                lookup.fileLookup = { uid ->
+                    fixture.dbm.driveMainIndex
+                        .selectHomebaseFileByUnique(fixture.testIdentityId, fixture.chatDriveId, uid)
+                }
+
+                val source = fixture.seedConversation(others = listOf("bob.test"))
+                val target = fixture.seedConversation(others = listOf("carol.test"))
+                val messageId = Uuid.random()
+
+                service.replyToMessage(
+                    messageUniqueId = messageId,
+                    conversationId = source,
+                    replyTo = ReplyPreview(
+                        replyUniqueId = Uuid.random(),
+                        authorOdinId = "bob.test",
+                        message = "what is her number?",
+                    ),
+                    messageText = "here is the number",
+                    previousMessageUniqueId = null,
+                    payloadBundle = null,
+                )
+
+                val forwarded = service.forwardMessage(messageId, listOf(target))
+
+                val storedContent = fixture.headerContentOf(forwarded.single().uniqueId)
+                assertNotNull(storedContent, "the forwarded text must have header content")
+
+                val envelope = OdinSystemSerializer.deserialize<MessageAppData>(storedContent)
+                assertEquals("here is the number", envelope.getMessage())
+                assertNull(envelope.replyPreview, "a forward is not a reply to the original's parent")
+            }
+        }
+}

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -1661,6 +1661,7 @@
     <string name="contactbook_edit_birthday">Birthday</string>
     <string name="contactbook_edit_change_photo">Add photo</string>
     <string name="contactbook_edit_save">Save</string>
+    <string name="contactbook_edit_saving">Saving…</string>
     <string name="contactbook_edit_cancel">Cancel</string>
     <string name="contactbook_error_email">Enter a valid email address</string>
     <string name="contactbook_error_phone">Use international format, e.g. +14155550123</string>

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/contactbook/ContactOverrideStore.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/contactbook/ContactOverrideStore.kt
@@ -2,6 +2,7 @@
 
 package id.homebase.core.contactbook
 
+import co.touchlab.kermit.Logger
 import id.homebase.api.client.contacts.Contact
 import id.homebase.api.client.contacts.ContactRepository
 import id.homebase.api.client.contacts.ContactsProvider
@@ -9,7 +10,11 @@ import id.homebase.api.client.eventbus.BackendEvent
 import id.homebase.api.client.eventbus.EventBus
 import id.homebase.core.config.AppConfig
 import id.homebase.core.ui.screens.contactbook.model.ContactFieldOverlay
+import kotlin.coroutines.cancellation.CancellationException
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -17,7 +22,9 @@ import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.sync.withPermit
 import kotlinx.serialization.json.Json
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
@@ -33,11 +40,23 @@ import kotlin.uuid.Uuid
  *
  * Registered as a singleton.
  */
-class ContactOverrideStore(
-    private val repo: ContactRepository,
+class ContactOverrideStore internal constructor(
     eventBus: EventBus,
     private val scope: CoroutineScope,
+    private val readOverride: suspend (Contact) -> String?,
+    private val writeOverride: suspend (Uuid, Uuid, String?) -> Uuid?,
 ) {
+    constructor(repo: ContactRepository, eventBus: EventBus, scope: CoroutineScope) : this(
+        eventBus = eventBus,
+        scope = scope,
+        readOverride = { repo.loadAppExtData(it, AppConfig.APP_ID) },
+        writeOverride = { uniqueId, versionTag, content ->
+            val response = if (content == null) repo.deleteAppExtData(uniqueId, versionTag)
+            else repo.setAppExtData(uniqueId, content, versionTag)
+            response?.versionTag
+        },
+    )
+
     private val json = Json { encodeDefaults = false; ignoreUnknownKeys = true; isLenient = true }
 
     private val _overrides = MutableStateFlow<Map<Uuid, ContactFieldOverlay>>(emptyMap())
@@ -48,6 +67,11 @@ class ContactOverrideStore(
     // re-fetch when the tag advances (the override payload may have changed under us).
     private val hydratedVersion = MutableStateFlow<Map<Uuid, Uuid?>>(emptyMap())
     private val mutex = Mutex()
+    private val fetchLimit = Semaphore(MAX_CONCURRENT_FETCHES)
+
+    private class Fetch(val versionTag: Uuid?, val job: Deferred<Unit>)
+
+    private val inFlight = mutableMapOf<Uuid, Fetch>()
 
     init {
         scope.launch {
@@ -58,9 +82,13 @@ class ContactOverrideStore(
         }
     }
 
-    private fun reset() {
+    // Test seam: the registry is pruned on completion, and nothing else can observe that.
+    internal suspend fun inFlightFetchCount(): Int = mutex.withLock { inFlight.size }
+
+    private suspend fun reset() {
         _overrides.value = emptyMap()
         hydratedVersion.value = emptyMap()
+        mutex.withLock { inFlight.clear() }
     }
 
     /**
@@ -69,20 +97,76 @@ class ContactOverrideStore(
      * contact whenever the list changes.
      */
     fun hydrate(contact: Contact) {
+        if (forgetIfPayloadGone(contact) || isUpToDate(contact)) return
+        scope.launch { hydrateJoining(contact) }
+    }
+
+    /**
+     * [hydrate] for a whole list, suspending until every fetch has landed — for a caller that reads
+     * [overrides] on the next line, which the fire-and-forget [hydrate] would leave empty.
+     */
+    suspend fun hydrateAll(contacts: List<Contact>): Unit = coroutineScope {
+        contacts.forEach { contact -> launch { hydrateJoining(contact) } }
+    }
+
+    // Awaits a running fetch rather than skipping it — [hydrateAll]'s caller reads `overrides` the
+    // line after it returns. Only a fetch for the SAME versionTag: one parked under an older tag
+    // would answer with an overlay already known to be stale.
+    private suspend fun hydrateJoining(contact: Contact) {
         val id = contact.uniqueId
-        if (ContactsProvider.CONTACT_APP_EXT_DATA_PAYLOAD_KEY !in contact.payloadKeys) {
-            // No bulk payload: forget any stale override cached for this id.
-            if (id in _overrides.value) _overrides.update { it - id }
-            hydratedVersion.update { it + (id to contact.versionTag) }
-            return
-        }
-        if (hydratedVersion.value[id] == contact.versionTag) return
-        scope.launch {
-            mutex.withLock {
-                if (hydratedVersion.value[id] == contact.versionTag) return@launch
-                hydratedVersion.update { it + (id to contact.versionTag) }
+        val load = mutex.withLock {
+            val running = inFlight[id]
+                ?.takeIf { it.job.isActive && it.versionTag == contact.versionTag }
+            when {
+                running != null -> running.job
+                forgetIfPayloadGone(contact) || isUpToDate(contact) -> null
+                else -> scope.async { fetch(contact) }.also { job ->
+                    val entry = Fetch(contact.versionTag, job)
+                    inFlight[id] = entry
+                    // Or a settled Deferred pins its Contact until SessionEnded.
+                    job.invokeOnCompletion {
+                        scope.launch {
+                            mutex.withLock { if (inFlight[id] === entry) inFlight.remove(id) }
+                        }
+                    }
+                }
             }
-            val overlay = loadOverlay(contact)
+        }
+        load?.await()
+    }
+
+    // On the store's own scope, so a caller that stops waiting (hydrateAll under a timeout) still
+    // gets the result cached.
+    private suspend fun fetch(contact: Contact) = fetchLimit.withPermit {
+        try {
+            loadInto(contact)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Throwable) {
+            Logger.w(tag = TAG, throwable = e) { "override hydrate failed for ${contact.uniqueId}" }
+        }
+    }
+
+    /** Drops the cached override of a contact that no longer advertises the payload. */
+    private fun forgetIfPayloadGone(contact: Contact): Boolean {
+        if (ContactsProvider.CONTACT_APP_EXT_DATA_PAYLOAD_KEY in contact.payloadKeys) return false
+        val id = contact.uniqueId
+        if (id in _overrides.value) _overrides.update { it - id }
+        hydratedVersion.update { it + (id to contact.versionTag) }
+        return true
+    }
+
+    private fun isUpToDate(contact: Contact): Boolean =
+        hydratedVersion.value[contact.uniqueId] == contact.versionTag
+
+    private suspend fun loadInto(contact: Contact) {
+        val id = contact.uniqueId
+        // Claim after the payload lands: claiming first marks an abandoned fetch hydrated for good.
+        val overlay = loadOverlay(contact)
+        mutex.withLock {
+            // Not our contact any more — a newer tag took it, or reset() dropped the session.
+            if (inFlight[id]?.versionTag != contact.versionTag) return
+            hydratedVersion.update { it + (id to contact.versionTag) }
             _overrides.update {
                 if (overlay == null || overlay.isEmpty) it - id else it + (id to overlay)
             }
@@ -90,7 +174,7 @@ class ContactOverrideStore(
     }
 
     private suspend fun loadOverlay(contact: Contact): ContactFieldOverlay? {
-        val raw = repo.loadAppExtData(contact, AppConfig.APP_ID) ?: return null
+        val raw = readOverride(contact) ?: return null
         return runCatching { json.decodeFromString<ContactFieldOverlay>(raw) }.getOrNull()
     }
 
@@ -101,14 +185,16 @@ class ContactOverrideStore(
      * Rethrows [id.homebase.api.client.ForbiddenException] (403).
      */
     suspend fun save(uniqueId: Uuid, versionTag: Uuid, overlay: ContactFieldOverlay): Uuid? {
-        val response = if (overlay.isEmpty) {
-            repo.deleteAppExtData(uniqueId, versionTag)
-        } else {
-            repo.setAppExtData(uniqueId, json.encodeToString(overlay), versionTag)
-        } ?: return null
+        val content = if (overlay.isEmpty) null else json.encodeToString(overlay)
+        val newTag = writeOverride(uniqueId, versionTag, content) ?: return null
 
-        hydratedVersion.update { it + (uniqueId to response.versionTag) }
+        hydratedVersion.update { it + (uniqueId to newTag) }
         _overrides.update { if (overlay.isEmpty) it - uniqueId else it + (uniqueId to overlay) }
-        return response.versionTag
+        return newTag
     }
 }
+
+private const val TAG = "ContactOverrideStore"
+
+/** Each fetch is a header read plus a decrypt; a cold contact book must not open them all at once. */
+private const val MAX_CONCURRENT_FETCHES = 4

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
@@ -265,7 +265,7 @@ val appModule = module {
     // Read+write contact source of truth lives in homebase-api (ContactRepository); the contact
     // book consumes it directly. No core-side stream/service wrapper.
     // User overrides of profile-synced fields (bulk app-data tier), shared by list + detail.
-    singleOf(::ContactOverrideStore)
+    single { ContactOverrideStore(get(), get(), get()) }
 
     // region Location add-on
     single { LocationPreferences(get()) }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/ContactSaveHelper.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/ContactSaveHelper.kt
@@ -2,6 +2,7 @@
 
 package id.homebase.core.ui.screens.contactbook
 
+import co.touchlab.kermit.Logger
 import id.homebase.api.client.ForbiddenException
 import id.homebase.api.client.contacts.ContactBirthday
 import id.homebase.api.client.contacts.ContactContent
@@ -17,20 +18,29 @@ import id.homebase.core.ui.screens.contactbook.model.ContactFieldOverlay
 import id.homebase.core.util.contentType
 import io.github.vinceglb.filekit.PlatformFile
 import io.github.vinceglb.filekit.readBytes
+import kotlin.coroutines.cancellation.CancellationException
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
+
+private const val TAG = "ContactSaveHelper"
 
 /** Outcome of [saveContactDraft]. */
 sealed interface ContactSaveResult {
     /**
-     * Saved. [photoFailed] = contact saved but avatar upload failed. [clearedFieldsIgnored] = the
+     * Saved. [photoFailed] = contact saved but avatar upload failed. [additionsFailed] = contact
+     * saved but its extra phones/emails could not be attached. [clearedFieldsIgnored] = the
      * edit blanked a previously-set field, which the V2 server merge can't express (empty = "leave
      * existing alone"), so that field was kept — the UI should tell the user clearing isn't
      * supported yet. The repository already applied the optimistic update, so callers push nothing.
+     * [uniqueId]/[versionTag] let a caller layer a follow-up write without value-matching the
+     * contact back out of the list.
      */
     data class Success(
         val photoFailed: Boolean,
         val clearedFieldsIgnored: Boolean = false,
+        val additionsFailed: Boolean = false,
+        val uniqueId: Uuid? = null,
+        val versionTag: Uuid? = null,
     ) : ContactSaveResult
 
     /** Server rejected the write with 403 — the app token lacks the manage-contacts permission. */
@@ -80,8 +90,91 @@ suspend fun saveContactDraft(
     val photoFailed = photo != null &&
         !uploadContactPhoto(repo, response.uniqueId, response.versionTag, photo)
 
-    return ContactSaveResult.Success(photoFailed, clearedFieldsIgnored)
+    return ContactSaveResult.Success(
+        photoFailed = photoFailed,
+        clearedFieldsIgnored = clearedFieldsIgnored,
+        uniqueId = response.uniqueId,
+        versionTag = response.versionTag,
+    )
 }
+
+/**
+ * Creates a contact from [draft] *with* its extra phones/emails. The contact schema has a single
+ * phone/email slot, so the extras can only live in this app's override blob — which needs the new
+ * contact's id, hence the two writes. Ordered create → overlay → photo so each write carries the
+ * versionTag the one before it produced.
+ */
+suspend fun saveNewContact(
+    store: ContactOverrideStore,
+    repo: ContactRepository,
+    draft: ContactDraft,
+    additionalPhones: List<String>,
+    additionalEmails: List<String>,
+    photo: PlatformFile?,
+): ContactSaveResult = saveNewContact(
+    draft = draft,
+    additionalPhones = additionalPhones,
+    additionalEmails = additionalEmails,
+    photo = photo,
+    createContact = { d, p -> saveContactDraft(repo, d, null, p) },
+    saveOverlay = store::save,
+    uploadPhoto = { uniqueId, versionTag, file -> uploadContactPhoto(repo, uniqueId, versionTag, file) },
+)
+
+// Same ordering with the three writes injected, so the contract is assertable without a
+// ContactRepository.
+internal suspend fun saveNewContact(
+    draft: ContactDraft,
+    additionalPhones: List<String>,
+    additionalEmails: List<String>,
+    photo: PlatformFile?,
+    createContact: suspend (ContactDraft, PlatformFile?) -> ContactSaveResult,
+    saveOverlay: suspend (Uuid, Uuid, ContactFieldOverlay) -> Uuid?,
+    uploadPhoto: suspend (Uuid, Uuid, PlatformFile) -> Boolean,
+): ContactSaveResult {
+    val overlay = additionsOverlay(additionalPhones, additionalEmails)
+    if (overlay.isEmpty) return createContact(draft, photo)
+
+    val created = createContact(draft, null)
+    if (created !is ContactSaveResult.Success) return created
+    val uniqueId = created.uniqueId
+    val versionTag = created.versionTag
+    if (uniqueId == null || versionTag == null) return created.copy(additionsFailed = true)
+
+    // Every failure past this point is partial, never retryable: the contact is already written, so
+    // Failed would invite a retry that creates it twice. Hence nothing narrower than Exception.
+    val overlayTag = try {
+        saveOverlay(uniqueId, versionTag, overlay)
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        Logger.w(e, TAG) { "contact $uniqueId created but its extra values could not be attached" }
+        null
+    }
+    val tag = overlayTag ?: versionTag
+    val photoFailed = photo != null && !uploadPhoto(uniqueId, tag, photo)
+    return ContactSaveResult.Success(
+        photoFailed = photoFailed,
+        additionsFailed = overlayTag == null,
+        uniqueId = uniqueId,
+        versionTag = tag,
+    )
+}
+
+/** The extras the contact schema can't hold, cleaned to the same rules the editor validates on. */
+fun additionsOverlay(
+    additionalPhones: List<String>,
+    additionalEmails: List<String>,
+): ContactFieldOverlay = ContactFieldOverlay(
+    additionalPhones = additionalPhones
+        .map { ContactFieldValidation.normalizePhone(it) }
+        .filter { it.isNotBlank() && ContactFieldValidation.isValidPhone(it) }
+        .distinct(),
+    additionalEmails = additionalEmails
+        .map { it.trim() }
+        .filter { it.isNotBlank() && ContactFieldValidation.isValidEmail(it) }
+        .distinct(),
+)
 
 /**
  * Persists an edit, routing each piece to the store that survives:
@@ -108,13 +201,11 @@ suspend fun saveContactEdit(
     additionalEmails: List<String>,
     photo: PlatformFile?,
 ): ContactSaveResult {
-    val cleanPhones = additionalPhones
-        .mapNotNull { p -> p.ifBlank { null }?.let { ContactFieldValidation.normalizePhone(it) } }
-        .distinct()
-    val cleanEmails = additionalEmails
-        .map { it.trim() }
-        .filter { it.isNotBlank() && ContactFieldValidation.isValidEmail(it) }
-        .distinct()
+    // Silently drops an invalid extra. Safe only while ContactEditSheet gates Save on the same
+    // ContactFieldValidation predicates — otherwise a legacy non-E.164 extra is lost on edit.
+    val additions = additionsOverlay(additionalPhones, additionalEmails)
+    val cleanPhones = additions.additionalPhones
+    val cleanEmails = additions.additionalEmails
     val hadOverride = editing.syncedOverlay != null ||
         editing.additionalPhones.isNotEmpty() || editing.additionalEmails.isNotEmpty()
 
@@ -140,12 +231,11 @@ suspend fun saveContactEdit(
     val result = saveContactDraft(repo, draft, synced, photo)
     if (result !is ContactSaveResult.Success) return result
 
-    val addOverlay = ContactFieldOverlay(additionalPhones = cleanPhones, additionalEmails = cleanEmails)
-    if (!addOverlay.isEmpty || hadOverride) {
+    if (!additions.isEmpty || hadOverride) {
         val tag = repo.contacts.value.firstOrNull { it.uniqueId == editing.uniqueId }?.versionTag
         if (tag != null) {
             try {
-                store.save(editing.uniqueId, tag, addOverlay)
+                store.save(editing.uniqueId, tag, additions)
             } catch (e: ForbiddenException) {
                 return ContactSaveResult.Forbidden
             }
@@ -162,7 +252,7 @@ private suspend fun uploadContactPhoto(
 ): Boolean {
     val bytes = try {
         photo.readBytes()
-    } catch (e: kotlin.coroutines.cancellation.CancellationException) {
+    } catch (e: CancellationException) {
         throw e
     } catch (_: Exception) {
         return false

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/components/AdaptiveSheet.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/components/AdaptiveSheet.kt
@@ -6,9 +6,14 @@ import androidx.compose.foundation.layout.widthIn
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.ModalBottomSheetProperties
+import androidx.compose.material3.SheetValue
 import androidx.compose.material3.Surface
 import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
@@ -20,11 +25,16 @@ import androidx.window.core.layout.WindowSizeClass
  * a centered constrained dialog on medium+ widths (tablet / desktop), where a
  * full-width bottom sheet looks wrong. Callers supply the same inner content for
  * both — typically a scrollable Column with its own padding.
+ *
+ * @param dismissible false pins the sheet open while the caller has work in flight. Gating
+ *   [onDismiss] would not: `ModalBottomSheet` runs `hide()` *before* consulting `onDismissRequest`,
+ *   so a refused dismissal leaves an invisible sheet mounted with no way to bring it back.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AdaptiveSheet(
     onDismiss: () -> Unit,
+    dismissible: Boolean = true,
     content: @Composable () -> Unit,
 ) {
     val wide = currentWindowAdaptiveInfo().windowSizeClass
@@ -33,7 +43,11 @@ fun AdaptiveSheet(
     if (wide) {
         Dialog(
             onDismissRequest = onDismiss,
-            properties = DialogProperties(usePlatformDefaultWidth = false),
+            properties = DialogProperties(
+                dismissOnBackPress = dismissible,
+                dismissOnClickOutside = dismissible,
+                usePlatformDefaultWidth = false,
+            ),
         ) {
             Surface(
                 shape = MaterialTheme.shapes.extraLarge,
@@ -47,7 +61,21 @@ fun AdaptiveSheet(
             }
         }
     } else {
-        ModalBottomSheet(onDismissRequest = onDismiss) {
+        // The drag handle's *tap* survives sheetGesturesEnabled = false; confirmValueChange is the
+        // only thing that stops it. Kept identity-stable — the sheet state is keyed on this lambda.
+        val canDismiss = rememberUpdatedState(dismissible)
+        val sheetState = rememberModalBottomSheetState(
+            confirmValueChange = remember { { it != SheetValue.Hidden || canDismiss.value } },
+        )
+        ModalBottomSheet(
+            onDismissRequest = onDismiss,
+            sheetState = sheetState,
+            sheetGesturesEnabled = dismissible,
+            properties = ModalBottomSheetProperties(
+                shouldDismissOnBackPress = dismissible,
+                shouldDismissOnClickOutside = dismissible,
+            ),
+        ) {
             content()
         }
     }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/components/ContactEditSheet.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/components/ContactEditSheet.kt
@@ -24,6 +24,7 @@ import androidx.compose.material.icons.outlined.Lock
 import androidx.compose.material.icons.outlined.Person
 import androidx.compose.material.icons.outlined.Restore
 import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Surface
@@ -41,6 +42,10 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.liveRegion
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.TextFieldValue
@@ -72,6 +77,7 @@ import id.homebase.resources.contactbook_edit_phone
 import id.homebase.resources.contactbook_edit_remove
 import id.homebase.resources.contactbook_edit_reset
 import id.homebase.resources.contactbook_edit_save
+import id.homebase.resources.contactbook_edit_saving
 import id.homebase.resources.contactbook_edit_synced_banner
 import id.homebase.resources.contactbook_edit_synced_from_profile
 import id.homebase.resources.contactbook_edit_surname
@@ -88,9 +94,10 @@ import io.github.vinceglb.filekit.readBytes
 import org.jetbrains.compose.resources.stringResource
 
 /**
- * [seed] pre-fills a NEW contact (it is ignored when [editing] is non-null) — used by the
- * share-a-vCard flow so the user reviews imported fields before saving. A seeded phone that
- * isn't E.164 stays visible and flagged; Save is gated on it being corrected.
+ * [seed], [seedAdditionalPhones] and [seedAdditionalEmails] pre-fill a NEW contact (all ignored
+ * when [editing] is non-null). A seeded phone that isn't E.164 stays visible and flagged; Save is
+ * gated on it being corrected. [saving] keeps the sheet mounted and inert while the caller's write
+ * is in flight, so a failure can be reported over a sheet that still holds the user's edits.
  */
 @Composable
 fun ContactEditSheet(
@@ -99,16 +106,21 @@ fun ContactEditSheet(
     onDismiss: () -> Unit,
     odinIdLocked: Boolean = false,
     seed: ContactDraft? = null,
+    seedAdditionalPhones: List<String> = emptyList(),
+    seedAdditionalEmails: List<String> = emptyList(),
+    saving: Boolean = false,
 ) {
     var draft by remember { mutableStateOf(editing?.toDraft() ?: seed ?: ContactDraft()) }
     // Extra phones/emails beyond the single canonical slot — app-local additions (see overlay).
     // Phones carry a stable id so the stateful PhoneNumberField rows keep their seeded country/
     // national state when a row above them is removed (index-keying would shuffle that state).
+    val seededPhones = if (editing != null) editing.additionalPhones else seedAdditionalPhones
+    val seededEmails = if (editing != null) editing.additionalEmails else seedAdditionalEmails
     var addPhones by remember {
-        mutableStateOf(editing?.additionalPhones.orEmpty().mapIndexed { i, v -> DraftPhone(i, v) })
+        mutableStateOf(seededPhones.mapIndexed { i, v -> DraftPhone(i, v) })
     }
-    var nextPhoneId by remember { mutableStateOf(editing?.additionalPhones.orEmpty().size) }
-    var addEmails by remember { mutableStateOf(editing?.additionalEmails.orEmpty()) }
+    var nextPhoneId by remember { mutableStateOf(seededPhones.size) }
+    var addEmails by remember { mutableStateOf(seededEmails) }
     // Identity contact (has odinId): fields are synced from the profile and edits become private
     // overrides. `synced` is the pre-override baseline used for the per-field affordance.
     val isIdentity = editing != null && !editing.odinId.isNullOrBlank()
@@ -124,7 +136,8 @@ fun ContactEditSheet(
         type = FileKitType.Image,
     ) { file -> if (file != null) photo = file }
 
-    AdaptiveSheet(onDismiss = onDismiss) {
+    // Pinned open mid-write: a dismissal there strands the result with nowhere to report to.
+    AdaptiveSheet(onDismiss = onDismiss, dismissible = !saving) {
         Column(
             modifier = Modifier
                 .fillMaxWidth()
@@ -310,8 +323,21 @@ fun ContactEditSheet(
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.End),
+                verticalAlignment = Alignment.CenterVertically,
             ) {
-                TextButton(onClick = onDismiss) {
+                if (saving) {
+                    val savingLabel = stringResource(MR.string.contactbook_edit_saving)
+                    CircularProgressIndicator(
+                        modifier = Modifier
+                            .size(20.dp)
+                            .semantics {
+                                liveRegion = LiveRegionMode.Polite
+                                contentDescription = savingLabel
+                            },
+                        strokeWidth = 2.dp,
+                    )
+                }
+                TextButton(onClick = onDismiss, enabled = !saving) {
                     Text(stringResource(MR.string.contactbook_edit_cancel))
                 }
                 // Save requires at least one meaningful field AND every phone/email — primary and
@@ -326,7 +352,7 @@ fun ContactEditSheet(
                     addEmails.all { ContactFieldValidation.isValidEmail(it) }
                 Button(
                     onClick = { onSave(draft, addPhones.map { it.value }, addEmails, photo) },
-                    enabled = hasContent && primaryValid && additionsValid,
+                    enabled = hasContent && primaryValid && additionsValid && !saving,
                 ) {
                     Text(stringResource(MR.string.contactbook_edit_save))
                 }

--- a/homebase-core/src/jvmTest/kotlin/id/homebase/core/contactbook/ContactOverrideStoreTest.kt
+++ b/homebase-core/src/jvmTest/kotlin/id/homebase/core/contactbook/ContactOverrideStoreTest.kt
@@ -1,0 +1,235 @@
+@file:OptIn(ExperimentalUuidApi::class, ExperimentalCoroutinesApi::class)
+
+package id.homebase.core.contactbook
+
+import id.homebase.api.client.contacts.Contact
+import id.homebase.api.client.contacts.ContactContent
+import id.homebase.api.client.contacts.ContactsProvider
+import id.homebase.api.client.eventbus.EventBus
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+/**
+ * [ContactOverrideStore.hydrateAll] is the only hydrator the received-contact-card save flow has:
+ * it runs the duplicate check's override load, and its caller reads `overrides` on the very next
+ * line. Returning before the payloads land silently blinds the check to every value that lives in
+ * an override — which is most of what a contact card collides on.
+ */
+class ContactOverrideStoreTest {
+
+    private val payloadKey = ContactsProvider.CONTACT_APP_EXT_DATA_PAYLOAD_KEY
+    private val storeScopes = mutableListOf<CoroutineScope>()
+
+    @AfterTest
+    fun cancelStoreScopes() = storeScopes.forEach { it.cancel() }
+
+    private fun contact(
+        id: Uuid = Uuid.random(),
+        versionTag: Uuid? = Uuid.random(),
+        advertisesPayload: Boolean = true,
+    ) = Contact(
+        uniqueId = id,
+        versionTag = versionTag,
+        content = ContactContent(),
+        fileId = Uuid.random(),
+        payloadKeys = if (advertisesPayload) setOf(payloadKey) else emptySet(),
+    )
+
+    // Not backgroundScope: advanceUntilIdle does not run background work, so a store hosted there
+    // would make no progress between assertions.
+    private fun TestScope.store(read: suspend (Contact) -> String?): ContactOverrideStore {
+        val scope = CoroutineScope(StandardTestDispatcher(testScheduler))
+        storeScopes += scope
+        return ContactOverrideStore(
+            eventBus = EventBus(),
+            scope = scope,
+            readOverride = read,
+            writeOverride = { _, _, _ -> null },
+        )
+    }
+
+    private fun overlayJson(givenName: String) = """{"givenName":"$givenName"}"""
+
+    @Test
+    fun `every override is readable the moment hydrateAll returns`() = runTest {
+        val ada = contact()
+        val grace = contact()
+        val store = store { c ->
+            when (c.uniqueId) {
+                ada.uniqueId -> overlayJson("Ada")
+                grace.uniqueId -> overlayJson("Grace")
+                else -> null
+            }
+        }
+
+        store.hydrateAll(listOf(ada, grace))
+
+        assertEquals("Ada", store.overrides.value[ada.uniqueId]?.givenName)
+        assertEquals("Grace", store.overrides.value[grace.uniqueId]?.givenName)
+    }
+
+    @Test
+    fun `a contact that no longer advertises the payload is not fetched and loses its cached override`() =
+        runTest {
+            val id = Uuid.random()
+            val withOverride = contact(id = id)
+            val reads = mutableListOf<Uuid>()
+            val store = store { c ->
+                reads += c.uniqueId
+                overlayJson("Ada")
+            }
+
+            store.hydrateAll(listOf(withOverride))
+            assertEquals(listOf(id), reads)
+            assertEquals("Ada", store.overrides.value[id]?.givenName)
+
+            val payloadGone = withOverride.copy(versionTag = Uuid.random(), payloadKeys = emptySet())
+            store.hydrateAll(listOf(payloadGone))
+
+            assertEquals(listOf(id), reads, "a contact with no payload must not be fetched")
+            assertNull(store.overrides.value[id], "the stale override must be evicted")
+        }
+
+    @Test
+    fun `hydrateAll waits for a fetch hydrate already started rather than returning empty`() = runTest {
+        val ada = contact()
+        val gate = CompletableDeferred<Unit>()
+        val store = store {
+            gate.await()
+            overlayJson("Ada")
+        }
+
+        store.hydrate(ada)
+        advanceUntilIdle()
+
+        var returned = false
+        launch {
+            store.hydrateAll(listOf(ada))
+            returned = true
+        }
+        advanceUntilIdle()
+
+        assertFalse(returned, "hydrateAll returned while the in-flight fetch was still parked")
+        assertTrue(store.overrides.value.isEmpty())
+
+        gate.complete(Unit)
+        advanceUntilIdle()
+
+        assertTrue(returned)
+        assertEquals("Ada", store.overrides.value[ada.uniqueId]?.givenName)
+    }
+
+    @Test
+    fun `a fetch parked under an older versionTag does not answer a caller holding the new one`() =
+        runTest {
+            val id = Uuid.random()
+            val v1 = contact(id = id)
+            val v2 = v1.copy(versionTag = Uuid.random())
+            val gates = mutableMapOf<Uuid?, CompletableDeferred<Unit>>()
+            val asked = mutableListOf<Uuid?>()
+            val store = store { c ->
+                asked += c.versionTag
+                gates.getOrPut(c.versionTag) { CompletableDeferred() }.await()
+                overlayJson(if (c.versionTag == v1.versionTag) "Stale" else "Fresh")
+            }
+
+            store.hydrate(v1)
+            advanceUntilIdle()
+            assertEquals(listOf(v1.versionTag), asked)
+
+            var returned = false
+            launch {
+                store.hydrateAll(listOf(v2))
+                returned = true
+            }
+            advanceUntilIdle()
+
+            assertFalse(returned, "hydrateAll joined the fetch parked under the older versionTag")
+            assertEquals(
+                listOf(v1.versionTag, v2.versionTag),
+                asked,
+                "the advanced versionTag must get a read of its own",
+            )
+
+            gates.getValue(v2.versionTag).complete(Unit)
+            advanceUntilIdle()
+
+            assertTrue(returned)
+            assertEquals("Fresh", store.overrides.value[id]?.givenName)
+        }
+
+    @Test
+    fun `a stale fetch landing after a newer one does not overwrite it`() = runTest {
+        val id = Uuid.random()
+        val v1 = contact(id = id)
+        val v2 = v1.copy(versionTag = Uuid.random())
+        val gates = mutableMapOf<Uuid?, CompletableDeferred<Unit>>()
+        val store = store { c ->
+            gates.getOrPut(c.versionTag) { CompletableDeferred() }.await()
+            overlayJson(if (c.versionTag == v1.versionTag) "Stale" else "Fresh")
+        }
+
+        store.hydrate(v1)
+        advanceUntilIdle()
+        store.hydrate(v2)
+        advanceUntilIdle()
+
+        gates.getValue(v2.versionTag).complete(Unit)
+        advanceUntilIdle()
+        assertEquals("Fresh", store.overrides.value[id]?.givenName)
+
+        gates.getValue(v1.versionTag).complete(Unit)
+        advanceUntilIdle()
+
+        assertEquals(
+            "Fresh",
+            store.overrides.value[id]?.givenName,
+            "the abandoned fetch must not resurrect the overlay of a version that has moved on",
+        )
+    }
+
+    @Test
+    fun `a completed fetch is dropped rather than retained for the whole session`() = runTest {
+        val ada = contact()
+        val store = store { overlayJson("Ada") }
+
+        store.hydrateAll(listOf(ada))
+        advanceUntilIdle()
+
+        assertEquals(0, store.inFlightFetchCount(), "a settled fetch pins its Contact until reset")
+    }
+
+    @Test
+    fun `a failed fetch leaves the version unclaimed so the next pass retries it`() = runTest {
+        val ada = contact()
+        var attempts = 0
+        val store = store {
+            attempts++
+            if (attempts == 1) error("payload fetch blew up") else overlayJson("Ada")
+        }
+
+        store.hydrateAll(listOf(ada))
+        assertEquals(1, attempts)
+        assertTrue(store.overrides.value.isEmpty())
+
+        store.hydrateAll(listOf(ada))
+
+        assertEquals(2, attempts)
+        assertEquals("Ada", store.overrides.value[ada.uniqueId]?.givenName)
+    }
+}

--- a/homebase-core/src/jvmTest/kotlin/id/homebase/core/ui/screens/contactbook/SaveNewContactTest.kt
+++ b/homebase-core/src/jvmTest/kotlin/id/homebase/core/ui/screens/contactbook/SaveNewContactTest.kt
@@ -1,0 +1,180 @@
+@file:OptIn(ExperimentalUuidApi::class)
+
+package id.homebase.core.ui.screens.contactbook
+
+import id.homebase.core.ui.screens.contactbook.model.ContactFieldOverlay
+import io.github.vinceglb.filekit.PlatformFile
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+/**
+ * [saveNewContact]'s write ordering. Three writes have to chain — create, then the override
+ * carrying the extras under the tag the create returned, then the photo under the tag the override
+ * returned — and the second and third must never be able to make the caller retry the first: the
+ * contact exists by then, and a retried create is a duplicate contact the user has to clean up.
+ */
+class SaveNewContactTest {
+
+    private sealed interface Write {
+        data class Create(val draft: ContactDraft, val withPhoto: Boolean) : Write
+        data class Overlay(val id: Uuid, val tag: Uuid, val overlay: ContactFieldOverlay) : Write
+        data class Photo(val id: Uuid, val tag: Uuid) : Write
+    }
+
+    private val draft = ContactDraft(givenName = "Ada", surname = "Vance", phone = "+14155550123")
+    private val photo = PlatformFile("/tmp/contact-avatar.png")
+    private val createdId = Uuid.random()
+    private val createdTag = Uuid.random()
+    private val overlayTag = Uuid.random()
+
+    private class Recorder {
+        val writes = mutableListOf<Write>()
+    }
+
+    private suspend fun save(
+        recorder: Recorder,
+        additionalPhones: List<String> = listOf("+14155550999"),
+        additionalEmails: List<String> = emptyList(),
+        photo: PlatformFile? = null,
+        create: suspend (ContactDraft, PlatformFile?) -> ContactSaveResult = { _, _ ->
+            ContactSaveResult.Success(
+                photoFailed = false,
+                uniqueId = createdId,
+                versionTag = createdTag,
+            )
+        },
+        overlay: suspend (Uuid, Uuid, ContactFieldOverlay) -> Uuid? = { _, _, _ -> overlayTag },
+        upload: suspend (Uuid, Uuid, PlatformFile) -> Boolean = { _, _, _ -> true },
+    ): ContactSaveResult = saveNewContact(
+        draft = draft,
+        additionalPhones = additionalPhones,
+        additionalEmails = additionalEmails,
+        photo = photo,
+        createContact = { d, p ->
+            recorder.writes += Write.Create(d, withPhoto = p != null)
+            create(d, p)
+        },
+        saveOverlay = { id, tag, o ->
+            recorder.writes += Write.Overlay(id, tag, o)
+            overlay(id, tag, o)
+        },
+        uploadPhoto = { id, tag, file ->
+            recorder.writes += Write.Photo(id, tag)
+            upload(id, tag, file)
+        },
+    )
+
+    @Test
+    fun `each write carries the tag the one before it produced`() = runTest {
+        val recorder = Recorder()
+
+        val result = save(recorder, photo = photo)
+
+        assertContentEquals(
+            listOf(
+                Write.Create(draft, withPhoto = false),
+                Write.Overlay(
+                    createdId,
+                    createdTag,
+                    ContactFieldOverlay(additionalPhones = listOf("+14155550999")),
+                ),
+                Write.Photo(createdId, overlayTag),
+            ),
+            recorder.writes,
+        )
+        assertEquals(
+            ContactSaveResult.Success(
+                photoFailed = false,
+                additionsFailed = false,
+                uniqueId = createdId,
+                versionTag = overlayTag,
+            ),
+            result,
+        )
+    }
+
+    @Test
+    fun `a card with nothing extra is one write that carries the photo itself`() = runTest {
+        val recorder = Recorder()
+
+        save(recorder, additionalPhones = emptyList(), photo = photo)
+
+        assertContentEquals(listOf(Write.Create(draft, withPhoto = true)), recorder.writes)
+    }
+
+    @Test
+    fun `a failed overlay is partial, never a retry that creates the contact twice`() = runTest {
+        val recorder = Recorder()
+
+        val result = save(
+            recorder,
+            photo = photo,
+            overlay = { _, _, _ -> error("app-data blob exceeds the tier size cap") },
+        )
+
+        assertEquals(1, recorder.writes.count { it is Write.Create }, "The create must not repeat.")
+        assertTrue(result is ContactSaveResult.Success, "Failed/Forbidden here would invite a retry.")
+        assertTrue(result.additionsFailed)
+        assertFalse(result.photoFailed)
+        assertEquals(
+            Write.Photo(createdId, createdTag),
+            recorder.writes.last(),
+            "With no new tag from the overlay, the photo falls back to the create's.",
+        )
+    }
+
+    @Test
+    fun `an overlay that reports failure without throwing is partial too`() = runTest {
+        val recorder = Recorder()
+
+        val result = save(recorder, overlay = { _, _, _ -> null })
+
+        assertTrue(result is ContactSaveResult.Success)
+        assertTrue(result.additionsFailed)
+    }
+
+    @Test
+    fun `a failed create writes nothing else`() = runTest {
+        val recorder = Recorder()
+
+        val result = save(recorder, photo = photo, create = { _, _ -> ContactSaveResult.Forbidden })
+
+        assertEquals(ContactSaveResult.Forbidden, result)
+        assertContentEquals(listOf(Write.Create(draft, withPhoto = false)), recorder.writes)
+    }
+
+    @Test
+    fun `a create that returns no id cannot be layered on`() = runTest {
+        val recorder = Recorder()
+
+        val result = save(
+            recorder,
+            photo = photo,
+            create = { _, _ -> ContactSaveResult.Success(photoFailed = false) },
+        )
+
+        assertTrue(result is ContactSaveResult.Success)
+        assertTrue(result.additionsFailed)
+        assertNull(result.uniqueId)
+        assertContentEquals(listOf(Write.Create(draft, withPhoto = false)), recorder.writes)
+    }
+
+    @Test
+    fun `a failed photo upload is reported without touching the contact again`() = runTest {
+        val recorder = Recorder()
+
+        val result = save(recorder, photo = photo, upload = { _, _, _ -> false })
+
+        assertTrue(result is ContactSaveResult.Success)
+        assertTrue(result.photoFailed)
+        assertFalse(result.additionsFailed)
+        assertEquals(1, recorder.writes.count { it is Write.Create })
+    }
+}


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

**Stacked on #1269 → #1266.** Four independent fixes to shared infrastructure. #1271 consumes all of them; each stands on its own.

## 1. `forwardMessage` corrupted any typed message kind

A typed kind stores its descriptor **verbatim** in `appData.content` (`MessageContentParser.kt:45`). `forwardMessage` deserialized that as `MessageAppData` — which **succeeds silently**, because every field has a default and `OdinSystemSerializer` sets `ignoreUnknownKeys = true` — then rebuilt the header from the resulting empty envelope.

The receiver would then parse a header with no `displayName` (no default, `ContactCardDescriptor.kt:16`) and paint the unsupported-format chip.

Latent until now only because every typed kind had `allowForward = false`. #1271 turns it on for contact cards, so this has to land first. Fixed by routing raw-header kinds through `MessageContentParser.usesRawHeaderContent` — the same predicate `updateMessage` already uses.

Both branches are pinned by tests. The negative test is a forwarded **reply** rather than a plain text message: a text message's header content already *is* a `MessageAppData`, so it passes under the broken version too and proves nothing. A reply must lose its `replyPreview` in the envelope rebuild, which does discriminate.

## 2. A modal sheet could be dismissed mid-write

`AdaptiveSheet` gains `dismissible`. Guarding `onDismiss` is not enough: M3 calls `sheetState.hide()` **before** consulting `onDismissRequest` (`ModalBottomSheet.kt:151-166,181`), so a swipe/scrim/back during a write hid the sheet permanently while leaving it mounted — no visible UI, and nothing re-shows it.

`sheetGesturesEnabled` + `ModalBottomSheetProperties` still leave a hole: the **drag handle** carries an unconditional `Modifier.clickable { … animateToDismiss() }` (`ModalBottomSheet.kt:386`) with only its semantics guarded. Closed with a `confirmValueChange` refusing `Hidden`, which `animateToDismiss` (`:151`) and `SheetState.hide()` both consult.

The lambda is identity-stable via `remember` + `rememberUpdatedState` because `rememberSheetState` uses it as a `rememberSaveable` **key** (`SheetDefaults.kt:519-521`) — an unstable one recreates the state and re-animates the sheet mid-write.

`EmergencyLocateSheet` has the identical latent bug and is now a one-argument fix; tracked in #1267 rather than widened into this PR.

## 3. `ContactOverrideStore` hydration races

- `hydrateAll` awaited an in-flight `hydrate()` incorrectly and could return with `overrides` still empty — `hydrate` claimed its version *before* fetching, and `hydrateAll` read that claim. Replaced with an `inFlight` registry; the claim now lands after the payload, so a failed fetch isn't marked hydrated forever.
- The join is keyed on `versionTag`, so a parked fetch for a stale version isn't awaited — and `loadInto` refuses to write when its tag is no longer current, so the older of two concurrent fetches can't clobber the newer or roll the version back.
- Bounded by `Semaphore(4)`; the caller time-boxes it.
- `isUpToDate()` was a predicate that mutated; split into `forgetIfPayloadGone()` and a pure read.

## 4. `saveNewContact`

Creating a contact and attaching its extra phones/emails needs the `uniqueId`/`versionTag` the write produces, so `ContactSaveResult.Success` now carries them (defaulted — no caller churn). Recovering them by *value matching* would be unsafe: the user may have edited the seeded number, so the match can land on a **different** contact and overwrite their extras.

The ordering contract — create, overlay with the tag the create returned, photo with the tag the overlay returned, and **never retry a create after a partial failure** — is enforced and tested through an injected-writes seam.

## Note

`hydrateAll` and `saveNewContact` have no production caller until #1271. Both are directly exercised by this PR's own tests.
