### PR TITLE
fix(ios): consume the update banner's status-bar inset through the node channel

### DIFF
--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
@@ -12,13 +12,15 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.outlined.Lock
@@ -666,9 +668,14 @@ fun AppNavHost(
 
                 val showUpdateBanner = isOnTopLevelScreen && uiState.updateAvailable
                 Column(
-                    // statusBarsPadding consumes the inset, so screens in the NavHost
-                    // below don't re-pad while the banner occupies the top edge.
-                    modifier = if (showUpdateBanner) Modifier.statusBarsPadding() else Modifier,
+                    // Not statusBarsPadding(): outside Android it consumes into a legacy
+                    // modifier-local channel the NavHost's TopAppBars cannot see, so they
+                    // re-pad the top inset and the header drops a safe-area below the banner.
+                    modifier = if (showUpdateBanner) {
+                        Modifier.windowInsetsPadding(WindowInsets.statusBars)
+                    } else {
+                        Modifier
+                    },
                 ) {
                     if (isOnTopLevelScreen) {
                         if (showUpdateBanner) {


### PR DESCRIPTION
Fixes #1274.

## Root cause (proven, not inferred)

The issue offered two candidates. **Candidate (b) is false and candidate (a) is true**, and the reason is platform-specific in a way that is invisible from our source.

`Modifier.statusBarsPadding()` and `Modifier.windowInsetsPadding(...)` consume window insets through **two different, non-interoperating channels**, and which channel `statusBarsPadding()` uses depends on the target:

- **Android** — `foundation-layout-android/androidMain/.../WindowInsetsPadding.android.kt:126`
  ```kotlin
  actual fun Modifier.statusBarsPadding() =
      windowInsetsPadding(debugInspectorInfo { name = "statusBarsPadding" }) { statusBars }
  ```
  backed by `SystemInsetsPaddingModifierNode : InsetsPaddingModifierNode` — i.e. the **node** channel (`InsetsConsumingModifierNode`, traverse key `androidx.compose.foundation.layout.ConsumedInsetsProvider`).

- **iOS / desktop / web (skiko)** — `foundation-layout/skikoMain/.../WindowInsetsPadding.skiko.kt:67`
  ```kotlin
  actual fun Modifier.statusBarsPadding(): Modifier =
      windowInsetsPadding(debugInspectorInfo { name = "statusBarsPadding" }) { WindowInsets.statusBars }
  ```
  where that *private* helper is `composed { _InsetsPaddingModifier(insets) }`, and `_InsetsPaddingModifier` publishes its consumption into a **file-private** modifier local:
  ```kotlin
  private val ModifierLocalConsumedWindowInsets = modifierLocalOf { WindowInsets(0, 0, 0, 0) }
  ```
  The same file carries the upstream marker: `// FIXME: Should be replaced with non-composed InsetsPaddingModifierElement — CMP-8998`.

`TopAppBar` pads with `Modifier.windowInsetsPadding(windowInsets)` (`material3/.../AppBar.kt:1577`), which is the commonMain `InsetsPaddingModifierElement` and reads the **node** channel via `traverseAncestors`. It never sees the skiko modifier-local. So on iOS the `Column` at `AppNavHost.kt:667-675` padded the banner correctly but consumed nothing as far as the `TopAppBar` was concerned, and every top-level screen's `TopAppBar` re-applied the whole safe-area top.

`statusBars` vs `systemBars` — issue candidate (b) — is **not** the cause: on iOS `UIKitWindowInsetsManager` defines both tops as `safeAreaInsets.top`, and the device probe below confirms they are equal.

### Device evidence (iPhone 17 Pro simulator, iOS 26.5)

A temporary `Modifier.onConsumedWindowInsetsChanged {}` probe (node channel — the same one `TopAppBar` reads) placed as a direct child of that `Column`, and again at `ConversationListPane`:

```
before  banner-Column           statusBars=186 systemBars=186 safeDrawing=186   (px @3x = 62dp)
before  inside-banner-Column    consumedTop=0
before  ConversationListPane    consumedTop=0
after   banner-Column           statusBars=186 systemBars=186 safeDrawing=186
after   inside-banner-Column    consumedTop=186
after   ConversationListPane    consumedTop=186
```

`consumedTop=0` directly under a `Column` that is padding 62dp of status bar is the bug. Nothing else was changed between the two runs.

## The change

One line (plus imports) in `homebase-core/.../ui/navigation/AppNavHost.kt:671`:

```kotlin
-modifier = if (showUpdateBanner) Modifier.statusBarsPadding() else Modifier,
+modifier = if (showUpdateBanner) {
+    Modifier.windowInsetsPadding(WindowInsets.statusBars)
+} else {
+    Modifier
+},
```

Same insets, same padding, but consumed on the channel `TopAppBar` actually reads — on every target. On Android this is a no-op by construction: Android's `statusBarsPadding()` *is* `windowInsetsPadding` over `WindowInsetsHolder.statusBars`, the same `InsetsPaddingModifierNode` with the same values.

The `else Modifier` branch (banner hidden) is untouched, so #1005 is structurally unaffected.

## Measurements

iPhone 17 Pro simulator, 402 x 874 pt, safe-area top 62 pt. Frames from `describe` (normalized), converted to pt.

| | banner bottom | header row top | gap |
|---|---|---|---|
| before | 122.4 pt | 201.0 pt | **78.6 pt** |
| after | 122.4 pt | 139.0 pt | **16.6 pt** |

The header moved up by `0.230 - 0.159 = 0.071` → **62.1 pt**, exactly the safe-area top that was being applied twice. The remaining 16.6 pt is `UpdateAvailableBanner`'s own `.padding(16.dp)` — the expected value, matching Android.

The banner's own frame `(0.040, 0.085, 0.920, 0.055)` is **byte-identical before and after** — it did not move.

## Verified

- **iOS, banner shown** — gap 78.6 pt → 16.6 pt (numbers above). Screenshots captured before and after.
- **iOS, #1010 (no regression)** — banner frame unchanged; its top edge sits at 74.3 pt, below the 62 pt safe-area top, so it clears the Dynamic Island. Tapping its centre (0.50, 0.1125) fired `onUpdateClick` and the banner responded — it is hit-testable at its rendered position.
- **iOS, banner hidden, #1005 (no regression)** — header content top at 67.3 pt (just below the 62 pt safe area) with the `TopAppBar` container drawing behind the status bar; no gap or band above it.
- **Android, banner shown** — Pixel 9 emulator (1080x2424, density 420): banner bottom 114.5 dp, `TopAppBar` title top 144.0 dp → bar top ≈ 126 dp. Tight under the banner, no status-bar-sized gap, and the banner clears the status bar. Layout matches the pre-existing Android behaviour.
- `:homebase-core:compileKotlinIosSimulatorArm64`, `:homebase-core:compileAndroidMain`, `:homebase-core:compileKotlinJvm` — all green.
- `:homebase-core:jvmTest`, `:homebase-common:jvmTest` — green.

### How the banner was forced

`IOSUpdateAppManager` compares the bundle version against an App Store lookup, and `id.homebase.feed.dev` has **no App Store listing** (`resultCount: 0`), so the banner can never appear naturally on a dev build. For the device runs only, `AppViewModel.checkForUpdate()` was temporarily patched to set `updateAvailable = true, updateAvailableVersion = "9.9.9"`, and `triggerUpdate()` to clear the flag so a tap visibly proved hit-testability. **All of that instrumentation, and the two inset probes, were removed before committing** — the diff on this branch is the one modifier change and its imports, nothing else.

## NOT verified — please read

- **The Android measurement is from a synthetic screen, not the real Chats screen.** No Android device available to me has a signed-in Homebase session for a build I can install: the only signed-in app is the `dev` variant, whose signing config needs `SIGNING_STORE_PASSWORD` / `SIGNING_KEY_PASSWORD` that I do not have, so a locally built APK cannot replace it without an uninstall (which would destroy the session). I did not sign in with a real account. So on Android I forced the banner plus a stock `TopAppBar` into the same consuming `Column` on the pre-auth screen and measured that instead. It exercises the exact mechanism (banner → `TopAppBar.windowInsetsPadding` under a consuming parent) but not the full `NavHost → Scaffold → ListDetailPaneScaffold → AnimatedPane → Scaffold` chain that the iOS run covered.
- **No Android before/after A/B.** Android was measured post-fix only; "unchanged" rests on the post-fix geometry being correct plus the source-level equivalence argued above, not on a captured pre-fix Android baseline.
- **The final committed code was not re-run on device.** The iOS device runs carried the temporary forced-banner instrumentation; with it removed the banner cannot appear on a dev build at all, so re-running would only re-show the banner-hidden state, which is already covered above. The layout-affecting line is identical in both.
- **Desktop and web were not exercised.** They are skiko targets and share the same defect, so they should improve identically, but neither was run.
- Only this one call site was changed. `MediaAttachmentEditor.kt:189`, `TimezonePicker.kt:189` and `InAppNotificationBanner.kt:45` still use `statusBarsPadding()`; they pad their own content and nothing downstream depends on their consumption reaching a sibling `TopAppBar`, so they are out of scope here.
