### PR TITLE
fix(contacts): post a saved contact's phone and email as number and email (#1280)

### DIFF
--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/ContactSaveHelper.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/ContactSaveHelper.kt
@@ -56,25 +56,7 @@ suspend fun saveContactDraft(
 
     val normalizedPhone = draft.phone.ifBlank { null }
         ?.let { ContactFieldValidation.normalizePhone(it) }
-    // An odinId may be set on a new contact, or kept from the edited one.
-    val odinId = draft.odinId.trim().ifBlank { null } ?: editing?.odinId?.ifBlank { null }
-
-    // The V2 server merges per-leaf with Coalesce(incoming, existing): a blanked field is "leave
-    // alone", never cleared. Mirror that here — keep the old value when an edit blanked a
-    // previously-set field — so the saved/optimistic content matches what the drive will sync back
-    // (no "cleared" field flashing empty then reappearing). `didClear` drives the user warning.
-    fun coalesce(new: String?, old: String?): String? = new?.ifBlank { null } ?: old?.ifBlank { null }
-    fun didClear(new: String?, old: String?): Boolean = !old.isNullOrBlank() && new.isNullOrBlank()
-
-    val mergedDisplay = coalesce(draft.displayName, editing?.displayName)
-    val mergedGiven = coalesce(draft.givenName, editing?.givenName)
-    val mergedSurname = coalesce(draft.surname, editing?.surname)
-    val mergedPhone = coalesce(normalizedPhone, editing?.phone)
-    val mergedEmail = coalesce(draft.email, editing?.email)
-    val mergedCity = coalesce(draft.city, editing?.city)
-    val mergedCountry = coalesce(draft.country, editing?.country)
-    val mergedBirthday = coalesce(draft.birthday, editing?.birthday)
-
+    val content = buildContactContent(draft, editing, normalizedPhone)
     val clearedFieldsIgnored = editing != null && (
         didClear(draft.givenName, editing.givenName) ||
             didClear(draft.surname, editing.surname) ||
@@ -84,35 +66,6 @@ suspend fun saveContactDraft(
             didClear(draft.country, editing.country) ||
             didClear(draft.birthday, editing.birthday)
         )
-
-    val content = ContactContent(
-        odinId = odinId,
-        name = ContactName(
-            displayName = mergedDisplay,
-            givenName = mergedGiven,
-            surname = mergedSurname,
-        ),
-        source = editing?.source ?: ContactBookSource.MANUAL,
-        // The edit form only touches city/country; carry the rest of the address from the edited
-        // contact so the optimistic content matches what the per-leaf server merge syncs back (the
-        // omitted street/postcode/label fields are "leave alone", not "clear").
-        location = if (mergedCity != null || mergedCountry != null ||
-            !editing?.addressLine1.isNullOrBlank() || !editing?.addressLine2.isNullOrBlank() ||
-            !editing?.postcode.isNullOrBlank() || !editing?.locationLabel.isNullOrBlank()
-        ) {
-            ContactLocation(
-                label = editing?.locationLabel?.ifBlank { null },
-                addressLine1 = editing?.addressLine1?.ifBlank { null },
-                addressLine2 = editing?.addressLine2?.ifBlank { null },
-                postcode = editing?.postcode?.ifBlank { null },
-                city = mergedCity,
-                country = mergedCountry,
-            )
-        } else null,
-        phone = mergedPhone?.let { ContactPhone(it) },
-        email = mergedEmail?.let { ContactEmail(it) },
-        birthday = mergedBirthday?.let { ContactBirthday(it) },
-    )
 
     val response = try {
         repo.save(
@@ -221,5 +174,61 @@ private suspend fun uploadContactPhoto(
         bytes = bytes,
         contentType = contentType,
         versionTag = versionTag,
+    )
+}
+
+// The V2 server merges per-leaf with Coalesce(incoming, existing): a blanked field is "leave
+// alone", never cleared. Mirror that here so the optimistic content matches what the drive syncs
+// back, instead of a cleared field flashing empty and reappearing.
+private fun coalesce(new: String?, old: String?): String? =
+    new?.ifBlank { null } ?: old?.ifBlank { null }
+
+private fun didClear(new: String?, old: String?): Boolean = !old.isNullOrBlank() && new.isNullOrBlank()
+
+/** Extracted so a test can assert the JSON that actually goes on the wire. */
+internal fun buildContactContent(
+    draft: ContactDraft,
+    editing: ContactBookEntry?,
+    normalizedPhone: String?,
+): ContactContent {
+    val odinId = draft.odinId.trim().ifBlank { null } ?: editing?.odinId?.ifBlank { null }
+    val mergedDisplay = coalesce(draft.displayName, editing?.displayName)
+    val mergedGiven = coalesce(draft.givenName, editing?.givenName)
+    val mergedSurname = coalesce(draft.surname, editing?.surname)
+    val mergedPhone = coalesce(normalizedPhone, editing?.phone)
+    val mergedEmail = coalesce(draft.email, editing?.email)
+    val mergedCity = coalesce(draft.city, editing?.city)
+    val mergedCountry = coalesce(draft.country, editing?.country)
+    val mergedBirthday = coalesce(draft.birthday, editing?.birthday)
+
+    return ContactContent(
+        odinId = odinId,
+        name = ContactName(
+            displayName = mergedDisplay,
+            givenName = mergedGiven,
+            surname = mergedSurname,
+        ),
+        source = editing?.source ?: ContactBookSource.MANUAL,
+        // The edit form only touches city/country; carry the rest of the address from the edited
+        // contact so the optimistic content matches what the per-leaf server merge syncs back (the
+        // omitted street/postcode/label fields are "leave alone", not "clear").
+        location = if (mergedCity != null || mergedCountry != null ||
+            !editing?.addressLine1.isNullOrBlank() || !editing?.addressLine2.isNullOrBlank() ||
+            !editing?.postcode.isNullOrBlank() || !editing?.locationLabel.isNullOrBlank()
+        ) {
+            ContactLocation(
+                label = editing?.locationLabel?.ifBlank { null },
+                addressLine1 = editing?.addressLine1?.ifBlank { null },
+                addressLine2 = editing?.addressLine2?.ifBlank { null },
+                postcode = editing?.postcode?.ifBlank { null },
+                city = mergedCity,
+                country = mergedCountry,
+            )
+        } else null,
+        // Named, not positional: `label` sits first on all three, so a positional argument files
+        // the number under the label and posts no number at all.
+        phone = mergedPhone?.let { ContactPhone(number = it) },
+        email = mergedEmail?.let { ContactEmail(email = it) },
+        birthday = mergedBirthday?.let { ContactBirthday(date = it) },
     )
 }

--- a/homebase-core/src/jvmTest/kotlin/id/homebase/core/ui/screens/contactbook/BuildContactContentTest.kt
+++ b/homebase-core/src/jvmTest/kotlin/id/homebase/core/ui/screens/contactbook/BuildContactContentTest.kt
@@ -1,0 +1,61 @@
+package id.homebase.core.ui.screens.contactbook
+
+import id.homebase.api.serialization.OdinSystemSerializer
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Asserts the JSON, not the object. `ContactPhone`/`ContactEmail` both take `label` first, so a
+ * positional `ContactPhone(it)` files the number under the label and posts no number at all — the
+ * object still looks populated, the request still returns 200, and the contact saves without a
+ * phone or an email. Only the wire form shows it.
+ */
+class BuildContactContentTest {
+
+    private fun json(draft: ContactDraft) = OdinSystemSerializer.serialize(
+        buildContactContent(draft, editing = null, normalizedPhone = draft.phone.ifBlank { null }),
+    )
+
+    @Test
+    fun `a phone is posted as a number, not as a label`() {
+        val body = json(ContactDraft(givenName = "Ada", phone = "+14155550123"))
+
+        assertTrue(body.contains(""""number":"+14155550123""""), body)
+        assertTrue(body.contains(""""phone":{"number""""), "phone must not lead with label: $body")
+    }
+
+    @Test
+    fun `an email is posted as an email, not as a label`() {
+        val body = json(ContactDraft(givenName = "Ada", email = "ada@example.com"))
+
+        assertTrue(body.contains(""""email":{"email":"ada@example.com"}"""), body)
+    }
+
+    @Test
+    fun `a birthday is posted as a date`() {
+        val body = json(ContactDraft(givenName = "Ada", birthday = "1815-12-10"))
+
+        assertTrue(body.contains(""""birthday":{"date":"1815-12-10"}"""), body)
+    }
+
+    @Test
+    fun `a draft with every simple field round-trips onto the wire`() {
+        val body = json(
+            ContactDraft(
+                givenName = "Ada",
+                surname = "Lovelace",
+                phone = "+14155550123",
+                email = "ada@example.com",
+                odinId = "ada.demo.rocks",
+            ),
+        )
+
+        val parsed = OdinSystemSerializer.deserialize<
+            id.homebase.api.client.contacts.ContactContent,
+            >(body)
+        assertEquals("+14155550123", parsed.phone?.number)
+        assertEquals("ada@example.com", parsed.email?.email)
+        assertEquals("ada.demo.rocks", parsed.odinId)
+    }
+}


### PR DESCRIPTION
Closes #1280.

Saving a contact reported success but the phone number and email address never landed on it — blank in the list, blank in the edit sheet, still blank after a restart.

## Cause

`ContactPhone` and `ContactEmail` both take `label` as their **first** parameter:

```kotlin
data class ContactPhone(val label: String? = null, val number: String? = null)
```

and `ContactSaveHelper` built them positionally:

```kotlin
phone = mergedPhone?.let { ContactPhone(it) },   // -> label = "+1415…", number = null
email = mergedEmail?.let { ContactEmail(it) },   // -> label = "ada@…",  email  = null
```

`OdinSystemSerializer` has `explicitNulls = false`, so the POST body carried `{"phone":{"label":"+1415…"}}` with no `number` key at all. The server accepted it (200) and stored it verbatim; the read side looks for `content.phone?.number` and got `null`.

The call sites predate `450baf425` (2026-06-23), which inserted `label` above `number`/`email`. Both parameters are `String?`, so the rebinding compiled without a warning. These were the **only** positional constructions of these types in the repo — every other call site, including both existing test files, already uses named arguments.

## Scope

Not a contact-card bug. All three creation paths funnel through `saveContactDraft`:

- `AddContactViewModel` (plain Add contact)
- `ContactBookViewModel` (list sheet)
- `ContactDetailViewModel` (detail save)

So **every manually created contact since 2026-06-23** lost its phone and email, as did edits to pure manual contacts. Identity contacts (with an `odinId`) were spared — their edits route through `ContactOverrideStore`, which stores plain strings. That is why some contacts show a phone and hand-created ones never do.

## Why the existing test missed it

`ContactContentSerializationTest` constructs `ContactPhone(number = …)` with **named** arguments. It pins the serializer — which was never broken — and structurally cannot observe a call-site mis-binding.

So the `ContactContent` build is extracted into a pure `internal fun buildContactContent(...)` (it was previously unreachable from tests, since `saveContactDraft` takes a concrete `ContactRepository`), and `BuildContactContentTest` asserts the **serialized JSON**. Asserting the object would be vacuous — it looks fully populated either way.

Verified by negative control: with the positional binding restored, the new tests fail; with the fix, they pass.

## Existing data: no backfill

Because CREATE stores the posted content verbatim, contacts created since 2026-06-23 still hold the number on the server under `phone.label` (and the email under `email.label`), so a one-off migration was possible. **Decided against** — affected users re-enter the phone and email by hand. No compatibility shim in the read path, and nothing to schedule server-side.

Contacts that went through an UPDATE had already lost it outright regardless: the server's `MergePhone` keys off `Number`, got null, and dropped the object. Those rows also carry the phone number in `label` as a junk label, which this fix does not clear.