### PR TITLE
feat(chat): carry a shared contact's photo on its card (#1281)

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/contactcard/ContactCardBubble.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/contactcard/ContactCardBubble.kt
@@ -261,8 +261,8 @@ internal fun ContactCardAvatar(
     val fontScale = LocalDensity.current.fontScale
     val diameter = size * fontScale.coerceIn(1f, 1.5f)
 
-    // Needs no provenance gate, unlike the identity avatar below: these bytes already arrived on the
-    // message, so rendering them dials nobody.
+    // No provenance gate, unlike the identity avatar below: these bytes are already on the message,
+    // so drawing them dials nobody.
     if (photo != null) {
         HomebaseImage(
             imageData = photo,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/contactcard/ContactCardBubble.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/contactcard/ContactCardBubble.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.semantics
@@ -45,6 +46,8 @@ import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import id.homebase.core.avatars.AvatarOptions
+import id.homebase.core.image.HomebaseImage
+import id.homebase.core.image.HomebaseImageData
 import id.homebase.core.avatars.PublicAvatar
 import id.homebase.resources.MR
 import id.homebase.resources.chat_contact_card_actions
@@ -78,6 +81,7 @@ fun ContactCardBubble(
     canOpenDetail: Boolean = true,
     authorOdinId: String? = null,
     sentByYou: Boolean = false,
+    photo: HomebaseImageData? = null,
     footer: (@Composable () -> Unit)? = null,
 ) {
     if (descriptor == null || !descriptor.isValid()) {
@@ -137,6 +141,7 @@ fun ContactCardBubble(
                     size = 44.dp,
                     authorOdinId = authorOdinId,
                     sentByYou = sentByYou,
+                    photo = photo,
                 )
                 Spacer(Modifier.width(12.dp))
                 Column(
@@ -223,6 +228,7 @@ fun ContactCardBubble(
             descriptor = descriptor,
             authorOdinId = authorOdinId,
             sentByYou = sentByYou,
+            photo = photo,
             onDismiss = { showDetail = false },
             // Close first: the editor is hosted above the nav graph and this dialog would outlive it.
             onSaveToContacts = onSaveToContacts?.let { save ->
@@ -248,11 +254,26 @@ internal fun ContactCardAvatar(
     size: Dp,
     authorOdinId: String?,
     sentByYou: Boolean,
+    photo: HomebaseImageData? = null,
 ) {
     val initials = remember(descriptor) { descriptor.avatarInitials() }
     // Holds sp text, so a fixed dp clips it at a large font scale; capped so 2x doesn't eat the row.
     val fontScale = LocalDensity.current.fontScale
     val diameter = size * fontScale.coerceIn(1f, 1.5f)
+
+    // Needs no provenance gate, unlike the identity avatar below: these bytes already arrived on the
+    // message, so rendering them dials nobody.
+    if (photo != null) {
+        HomebaseImage(
+            imageData = photo,
+            contentDescription = null,
+            contentScale = ContentScale.Crop,
+            placeholder = { ContactCardInitials(initials, diameter, fontScale) },
+            error = { ContactCardInitials(initials, diameter, fontScale) },
+            modifier = Modifier.size(diameter).clip(CircleShape).clearAndSetSemantics {},
+        )
+        return
+    }
 
     // An identity publishes its avatar at a URL derived from the odinId, so the card shows a real
     // picture without the descriptor carrying one — nothing would fit in the 7 KB header anyway.
@@ -276,6 +297,11 @@ internal fun ContactCardAvatar(
         return
     }
 
+    ContactCardInitials(initials, diameter, fontScale)
+}
+
+@Composable
+private fun ContactCardInitials(initials: String, diameter: Dp, fontScale: Float) {
     Box(
         // Decoration: the initials only re-render the name that follows.
         modifier = Modifier

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/contactcard/ContactCardDetailDialog.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/contactcard/ContactCardDetailDialog.kt
@@ -51,6 +51,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import id.homebase.core.clipboard.clipEntryOf
+import id.homebase.core.image.HomebaseImageData
 import id.homebase.resources.MR
 import id.homebase.resources.chat_contact_card_action_unavailable
 import id.homebase.resources.chat_contact_card_call
@@ -89,6 +90,7 @@ fun ContactCardDetailDialog(
     onMessageIdentity: ((String) -> Unit)? = null,
     authorOdinId: String? = null,
     sentByYou: Boolean = false,
+    photo: HomebaseImageData? = null,
 ) {
     Dialog(
         onDismissRequest = onDismiss,
@@ -101,6 +103,7 @@ fun ContactCardDetailDialog(
             onMessageIdentity = onMessageIdentity,
             authorOdinId = authorOdinId,
             sentByYou = sentByYou,
+            photo = photo,
         )
     }
 }
@@ -114,6 +117,7 @@ private fun ContactCardDetailContent(
     onMessageIdentity: ((String) -> Unit)?,
     authorOdinId: String?,
     sentByYou: Boolean,
+    photo: HomebaseImageData?,
 ) {
     val uriHandler = LocalUriHandler.current
     val clipboard = LocalClipboard.current
@@ -194,6 +198,7 @@ private fun ContactCardDetailContent(
                     size = 72.dp,
                     authorOdinId = authorOdinId,
                     sentByYou = sentByYou,
+                    photo = photo,
                 )
                 Spacer(Modifier.width(16.dp))
                 Column(modifier = Modifier.weight(1f)) {

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/contactcard/ContactCardPhoto.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/contactcard/ContactCardPhoto.kt
@@ -1,0 +1,54 @@
+package id.homebase.chat.contactcard
+
+import id.homebase.api.client.KeyHeader
+import id.homebase.api.client.drives.files.PayloadDescriptor
+import id.homebase.api.client.drives.upload.EmbeddedThumb
+import id.homebase.chat.services.ChatProtocol
+import id.homebase.core.image.HomebaseImageData
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+/**
+ * A contact card's photo rides as an ordinary encrypted image payload on the message, never in the
+ * descriptor — a picture cannot fit the 7 KB header budget that lets the card render on scroll with
+ * no fetch. Presence is therefore *inferred* from the payload list rather than declared, so a card
+ * from a sender that never attached one simply has none, and an older client is unaffected.
+ *
+ * It reuses the Event cover's `chat_web` key, which every generic media surface already filters out
+ * — a bespoke key would have to be added to each of those filters to stop the photo turning up as a
+ * loose image in the conversation's shared-media tab.
+ */
+internal fun contactCardPhotoPayload(payloads: List<PayloadDescriptor>?): PayloadDescriptor? =
+    payloads?.firstOrNull {
+        it.contentType?.startsWith("image/") == true &&
+            it.key.startsWith(ChatProtocol.PAYLOAD_KEY_MESSAGE_WEB)
+    }
+
+/**
+ * The [HomebaseImageData] for a card's photo, or null when there is no usable one. The AES key is
+ * the message's and the IV is the payload's, the same split every other chat image uses.
+ */
+@OptIn(ExperimentalEncodingApi::class, ExperimentalUuidApi::class)
+internal fun contactCardPhotoData(
+    payloads: List<PayloadDescriptor>?,
+    driveId: Uuid,
+    fileId: Uuid,
+    keyHeader: KeyHeader,
+    previewThumbnail: EmbeddedThumb?,
+): HomebaseImageData? {
+    val payload = contactCardPhotoPayload(payloads) ?: return null
+    val iv = payload.iv?.let { runCatching { Base64.decode(it) }.getOrNull() } ?: return null
+    return HomebaseImageData(
+        driveId = driveId,
+        fileId = fileId,
+        payloadKey = payload.key,
+        previewThumbnail = payload.previewThumbnail?.toEmbeddedThumb() ?: previewThumbnail,
+        loadFullPayload = false,
+        isEncrypted = true,
+        lastModified = payload.lastModified,
+        payloadContentType = payload.contentType,
+        keyHeader = KeyHeader(iv = iv, aesKey = keyHeader.aesKey),
+    )
+}

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/contactcard/ContactCardPhoto.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/contactcard/ContactCardPhoto.kt
@@ -5,6 +5,8 @@ import id.homebase.api.client.drives.files.PayloadDescriptor
 import id.homebase.api.client.drives.upload.EmbeddedThumb
 import id.homebase.chat.services.ChatProtocol
 import id.homebase.core.image.HomebaseImageData
+import id.homebase.core.image.ImageSize
+import id.homebase.core.image.thumbSizesFrom
 import kotlin.io.encoding.Base64
 import kotlin.io.encoding.ExperimentalEncodingApi
 import kotlin.uuid.ExperimentalUuidApi
@@ -45,6 +47,11 @@ internal fun contactCardPhotoData(
         fileId = fileId,
         payloadKey = payload.key,
         previewThumbnail = payload.previewThumbnail?.toEmbeddedThumb() ?: previewThumbnail,
+        // An avatar is 44–72dp, so the smallest stored thumbnail is always enough. Both are
+        // needed: without the available sizes the loader guesses one the server never stored and
+        // takes a 404 before falling back.
+        requestedSize = ImageSize.THUMB_SMALL,
+        availableThumbSizes = thumbSizesFrom(payload.thumbnails),
         loadFullPayload = false,
         isEncrypted = true,
         lastModified = payload.lastModified,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/contactcard/ContactCardPhoto.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/contactcard/ContactCardPhoto.kt
@@ -12,26 +12,14 @@ import kotlin.io.encoding.ExperimentalEncodingApi
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 
-/**
- * A contact card's photo rides as an ordinary encrypted image payload on the message, never in the
- * descriptor — a picture cannot fit the 7 KB header budget that lets the card render on scroll with
- * no fetch. Presence is therefore *inferred* from the payload list rather than declared, so a card
- * from a sender that never attached one simply has none, and an older client is unaffected.
- *
- * It reuses the Event cover's `chat_web` key, which every generic media surface already filters out
- * — a bespoke key would have to be added to each of those filters to stop the photo turning up as a
- * loose image in the conversation's shared-media tab.
- */
+// Shares the Event cover's key because every generic media surface already filters `chat_web*`; a
+// new key would have to be added to each of those filters.
 internal fun contactCardPhotoPayload(payloads: List<PayloadDescriptor>?): PayloadDescriptor? =
     payloads?.firstOrNull {
         it.contentType?.startsWith("image/") == true &&
             it.key.startsWith(ChatProtocol.PAYLOAD_KEY_MESSAGE_WEB)
     }
 
-/**
- * The [HomebaseImageData] for a card's photo, or null when there is no usable one. The AES key is
- * the message's and the IV is the payload's, the same split every other chat image uses.
- */
 @OptIn(ExperimentalEncodingApi::class, ExperimentalUuidApi::class)
 internal fun contactCardPhotoData(
     payloads: List<PayloadDescriptor>?,
@@ -47,9 +35,7 @@ internal fun contactCardPhotoData(
         fileId = fileId,
         payloadKey = payload.key,
         previewThumbnail = payload.previewThumbnail?.toEmbeddedThumb() ?: previewThumbnail,
-        // An avatar is 44–72dp, so the smallest stored thumbnail is always enough. Both are
-        // needed: without the available sizes the loader guesses one the server never stored and
-        // takes a 404 before falling back.
+        // Left empty, the loader guesses a size the server never stored and takes a 404.
         requestedSize = ImageSize.THUMB_SMALL,
         availableThumbSizes = thumbSizesFrom(payload.thumbnails),
         loadFullPayload = false,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationsettings/ConversationOverview.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationsettings/ConversationOverview.kt
@@ -90,8 +90,7 @@ fun collectConversationOverview(
             else -> Unit
         }
 
-        // A contact card's photo is the subject's avatar, not a picture shared into the
-        // conversation, so it does not belong in the Media tab.
+        // A card's photo is the subject's avatar, not a picture shared into the conversation.
         if (message.messageContent is MessageContent.ContactCard) continue
 
         val payloads = message.payloads?.filter {

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationsettings/ConversationOverview.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationsettings/ConversationOverview.kt
@@ -90,6 +90,10 @@ fun collectConversationOverview(
             else -> Unit
         }
 
+        // A contact card's photo is the subject's avatar, not a picture shared into the
+        // conversation, so it does not belong in the Media tab.
+        if (message.messageContent is MessageContent.ContactCard) continue
+
         val payloads = message.payloads?.filter {
             it.key != ChatProtocol.DefaultPayloadKey &&
                     !it.key.startsWith(ChatProtocol.DEFAULT_PAYLOAD_DESCRIPTOR_KEY)

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubbleRaw.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubbleRaw.kt
@@ -66,6 +66,7 @@ import id.homebase.api.client.drives.files.DescriptorContent
 import id.homebase.api.client.drives.files.PayloadDescriptor
 import id.homebase.api.util.markdownHasBlockElements
 import id.homebase.chat.contactcard.ContactCardBubble
+import id.homebase.chat.contactcard.contactCardPhotoData
 import id.homebase.chat.contactcard.ContactCardDescriptor
 import id.homebase.chat.conversationlist.DecryptedFileKey
 import id.homebase.chat.conversationlist.MessageClusterPosition
@@ -243,6 +244,15 @@ fun MessageBubbleRaw(
                     { card: ContactCardDescriptor -> save(card.forSaving(cardAuthor, sentByYou)) }
                 }
             }
+            val cardPhoto = remember(message.fileId, message.payloads, message.keyHeader) {
+                contactCardPhotoData(
+                    payloads = message.payloads,
+                    driveId = chatTargetDrive.alias,
+                    fileId = message.fileId,
+                    keyHeader = message.keyHeader,
+                    previewThumbnail = message.previewThumbnail,
+                )
+            }
             ContactCardBubble(
                 descriptor = content.descriptor,
                 modifier = modifier,
@@ -255,6 +265,7 @@ fun MessageBubbleRaw(
                 // From the envelope, not the card: the card's own odinId is attacker-controlled.
                 authorOdinId = message.originalAuthor?.domainName,
                 sentByYou = sentByYou,
+                photo = cardPhoto,
                 footer = {
                     MessageTimestampFooter(
                         visible = showMessageFooter,

--- a/homebase-chat/src/commonTest/kotlin/id/homebase/chat/contactcard/ContactCardPhotoTest.kt
+++ b/homebase-chat/src/commonTest/kotlin/id/homebase/chat/contactcard/ContactCardPhotoTest.kt
@@ -1,0 +1,90 @@
+package id.homebase.chat.contactcard
+
+import id.homebase.api.client.KeyHeader
+import id.homebase.api.common.SecureByteArray
+import id.homebase.api.client.drives.files.PayloadDescriptor
+import id.homebase.chat.services.ChatProtocol
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+@OptIn(ExperimentalEncodingApi::class, ExperimentalUuidApi::class)
+class ContactCardPhotoTest {
+
+    private val key = ChatProtocol.PAYLOAD_KEY_MESSAGE_WEB + "0"
+    private val iv = Base64.encode(ByteArray(16) { it.toByte() })
+
+    private fun photo(
+        key: String = this.key,
+        contentType: String? = "image/jpeg",
+        iv: String? = this.iv,
+    ) = PayloadDescriptor(key = key, contentType = contentType, iv = iv)
+
+    private fun data(payloads: List<PayloadDescriptor>?) = contactCardPhotoData(
+        payloads = payloads,
+        driveId = Uuid.random(),
+        fileId = Uuid.random(),
+        keyHeader = KeyHeader(iv = ByteArray(16), aesKey = SecureByteArray(ByteArray(16) { 7 })),
+        previewThumbnail = null,
+    )
+
+    @Test
+    fun `a card with no payloads has no photo`() {
+        assertNull(contactCardPhotoPayload(null))
+        assertNull(contactCardPhotoPayload(emptyList()))
+    }
+
+    @Test
+    fun `the chat_web image payload is the photo`() {
+        val found = contactCardPhotoPayload(listOf(photo()))
+        assertEquals(key, assertNotNull(found).key)
+    }
+
+    @Test
+    fun `a non-image payload under the same key is not a photo`() {
+        // The key is shared with other web-ish payloads; only an image is an avatar.
+        assertNull(contactCardPhotoPayload(listOf(photo(contentType = "application/json"))))
+        assertNull(contactCardPhotoPayload(listOf(photo(contentType = null))))
+    }
+
+    @Test
+    fun `an image under an unrelated key is not a photo`() {
+        assertNull(contactCardPhotoPayload(listOf(photo(key = "otherpay"))))
+    }
+
+    @Test
+    fun `the photo is found among other payloads`() {
+        val payloads = listOf(photo(key = "otherpay"), photo(contentType = "text/plain"), photo())
+        assertEquals(key, assertNotNull(contactCardPhotoPayload(payloads)).key)
+    }
+
+    @Test
+    fun `image data takes the AES key from the message and the IV from the payload`() {
+        val built = assertNotNull(data(listOf(photo())))
+
+        assertEquals(key, built.payloadKey)
+        assertContentEqualsHex(Base64.decode(iv), built.keyHeader?.iv)
+        assertContentEqualsHex(ByteArray(16) { 7 }, built.keyHeader?.aesKey?.toByteArray())
+    }
+
+    @Test
+    fun `a payload with no IV yields no image data`() {
+        // Undecryptable: rendering it would spin forever rather than fall back to initials.
+        assertNull(data(listOf(photo(iv = null))))
+        assertNull(data(listOf(photo(iv = "not base64 @@@"))))
+    }
+
+    @Test
+    fun `chat payloads are always treated as encrypted`() {
+        assertEquals(true, assertNotNull(data(listOf(photo()))).isEncrypted)
+    }
+
+    private fun assertContentEqualsHex(expected: ByteArray, actual: ByteArray?) {
+        assertEquals(expected.toList(), assertNotNull(actual).toList())
+    }
+}

--- a/homebase-chat/src/commonTest/kotlin/id/homebase/chat/contactcard/ContactCardPhotoTest.kt
+++ b/homebase-chat/src/commonTest/kotlin/id/homebase/chat/contactcard/ContactCardPhotoTest.kt
@@ -3,7 +3,9 @@ package id.homebase.chat.contactcard
 import id.homebase.api.client.KeyHeader
 import id.homebase.api.common.SecureByteArray
 import id.homebase.api.client.drives.files.PayloadDescriptor
+import id.homebase.api.client.drives.files.ThumbnailDescriptor
 import id.homebase.chat.services.ChatProtocol
+import id.homebase.core.image.ImageSize
 import kotlin.io.encoding.Base64
 import kotlin.io.encoding.ExperimentalEncodingApi
 import kotlin.test.Test
@@ -82,6 +84,23 @@ class ContactCardPhotoTest {
     @Test
     fun `chat payloads are always treated as encrypted`() {
         assertEquals(true, assertNotNull(data(listOf(photo()))).isEncrypted)
+    }
+
+    @Test
+    fun `the loader is told which thumbnail sizes actually exist`() {
+        // Device log, build of 2026-08-18: with this empty the loader guessed 121x121, which the
+        // server never stored, and logged a non-retriable 404 before falling back.
+        val withThumbs = photo().copy(
+            thumbnails = listOf(
+                ThumbnailDescriptor(pixelWidth = 300, pixelHeight = 300, contentType = "image/jpeg"),
+                ThumbnailDescriptor(pixelWidth = 600, pixelHeight = 600, contentType = "image/jpeg"),
+            ),
+        )
+
+        val built = assertNotNull(data(listOf(withThumbs)))
+
+        assertEquals(listOf(ImageSize(300, 300), ImageSize(600, 600)), built.availableThumbSizes)
+        assertEquals(ImageSize.THUMB_SMALL, built.requestedSize)
     }
 
     private fun assertContentEqualsHex(expected: ByteArray, actual: ByteArray?) {

--- a/homebase-chat/src/commonTest/kotlin/id/homebase/chat/contactcard/ContactCardPhotoTest.kt
+++ b/homebase-chat/src/commonTest/kotlin/id/homebase/chat/contactcard/ContactCardPhotoTest.kt
@@ -49,7 +49,6 @@ class ContactCardPhotoTest {
 
     @Test
     fun `a non-image payload under the same key is not a photo`() {
-        // The key is shared with other web-ish payloads; only an image is an avatar.
         assertNull(contactCardPhotoPayload(listOf(photo(contentType = "application/json"))))
         assertNull(contactCardPhotoPayload(listOf(photo(contentType = null))))
     }
@@ -76,7 +75,6 @@ class ContactCardPhotoTest {
 
     @Test
     fun `a payload with no IV yields no image data`() {
-        // Undecryptable: rendering it would spin forever rather than fall back to initials.
         assertNull(data(listOf(photo(iv = null))))
         assertNull(data(listOf(photo(iv = "not base64 @@@"))))
     }
@@ -88,8 +86,6 @@ class ContactCardPhotoTest {
 
     @Test
     fun `the loader is told which thumbnail sizes actually exist`() {
-        // Device log, build of 2026-08-18: with this empty the loader guessed 121x121, which the
-        // server never stored, and logged a non-retriable 404 before falling back.
         val withThumbs = photo().copy(
             thumbnails = listOf(
                 ThumbnailDescriptor(pixelWidth = 300, pixelHeight = 300, contentType = "image/jpeg"),

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
@@ -1004,6 +1004,7 @@ val appModule = module {
             repo = get(),
             overrideStore = get(),
             chatMessageSenderService = get(),
+            fileOperationsProvider = get(),
         )
     }
     viewModelOf(::ContactDetailViewModel)

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/ShareContactPickerViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/ShareContactPickerViewModel.kt
@@ -6,6 +6,12 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import co.touchlab.kermit.Logger
 import id.homebase.api.client.contacts.ContactRepository
+import id.homebase.api.client.contacts.ContactsProvider
+import id.homebase.api.file.FileOperationsProvider
+import id.homebase.chat.services.ChatProtocol
+import id.homebase.chat.services.builder.AttachmentInput
+import id.homebase.chat.services.builder.MessageAttachmentBuilder
+import id.homebase.upload.PayloadBundle
 import id.homebase.chat.services.ChatMessageSenderService
 import id.homebase.chat.contactcard.ContactCardDescriptor
 import id.homebase.chat.services.content.MessageContent
@@ -37,6 +43,7 @@ class ShareContactPickerViewModel(
     private val repo: ContactRepository,
     private val overrideStore: ContactOverrideStore,
     private val chatMessageSenderService: ChatMessageSenderService,
+    private val fileOperationsProvider: FileOperationsProvider,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(ShareContactPickerUiState())
@@ -107,6 +114,33 @@ class ShareContactPickerViewModel(
         return entry?.let { ContactCardImport.toDescriptor(it) } ?: fallback
     }
 
+    /**
+     * The contact's stored photo, re-uploaded as a payload on the message. It cannot be referenced
+     * in place — it lives on the sender's own contacts drive, which the recipient can't read — and
+     * it cannot ride in the descriptor, which is capped at 7 KB. Best-effort by design: a card that
+     * reaches the conversation without its picture is far better than one that never sends.
+     */
+    private suspend fun photoBundle(uniqueId: Uuid?): PayloadBundle? = runCatching {
+        val contact = repo.contacts.value.firstOrNull { it.uniqueId == uniqueId } ?: return null
+        val image = contact.image ?: return null
+        val bytes = repo.loadPayloadBytes(contact, ContactsProvider.CONTACT_IMAGE_PAYLOAD_KEY)
+        if (bytes == null || bytes.isEmpty()) return null
+        val contentType = image.payload.contentType?.takeIf { it.startsWith("image/") } ?: "image/jpeg"
+        val path = fileOperationsProvider.writeBytesToTempFile(
+            bytes = bytes,
+            prefix = "contact-card-photo",
+            suffix = if (contentType == "image/png") ".png" else ".jpg",
+        )
+        MessageAttachmentBuilder.buildSingle(
+            attachment = AttachmentInput(filePath = path, contentType = contentType),
+            fileOperationsProvider = fileOperationsProvider,
+            payloadKey = ChatProtocol.PAYLOAD_KEY_MESSAGE_WEB + "0",
+        )
+    }.onFailure {
+        if (it is kotlin.coroutines.cancellation.CancellationException) throw it
+        Logger.w(throwable = it, tag = TAG) { "contact card photo skipped" }
+    }.getOrNull()
+
     private fun send() {
         val state = _uiState.value
         if (state.isSending) return
@@ -125,6 +159,7 @@ class ShareContactPickerViewModel(
                     conversationId = conversationId,
                     content = MessageContent.ContactCard(resolvedDescriptor(selectedId, descriptor)),
                     previousMessageUniqueId = null,
+                    payloadBundle = photoBundle(selectedId),
                 )
                 _events.emit(ShareContactPickerUiEvent.MessageSent)
             } catch (e: kotlin.coroutines.cancellation.CancellationException) {

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/ShareContactPickerViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/ShareContactPickerViewModel.kt
@@ -114,12 +114,8 @@ class ShareContactPickerViewModel(
         return entry?.let { ContactCardImport.toDescriptor(it) } ?: fallback
     }
 
-    /**
-     * The contact's stored photo, re-uploaded as a payload on the message. It cannot be referenced
-     * in place — it lives on the sender's own contacts drive, which the recipient can't read — and
-     * it cannot ride in the descriptor, which is capped at 7 KB. Best-effort by design: a card that
-     * reaches the conversation without its picture is far better than one that never sends.
-     */
+    // Re-uploaded rather than referenced: it lives on our own contacts drive, which the recipient
+    // cannot read. Best-effort — a photo failure must never block the card itself.
     private suspend fun photoBundle(uniqueId: Uuid?): PayloadBundle? = runCatching {
         val contact = repo.contacts.value.firstOrNull { it.uniqueId == uniqueId } ?: return null
         val image = contact.image ?: return null


### PR DESCRIPTION
Closes #1281 (the payload half — see below).

## What was already done

#1281 has two halves. **Half 1 — identity contacts — shipped in #1282**: the descriptor carries `odinId`, and `ContactCardAvatar` resolves `https://<odinId>/pub/image` behind the `avatarIdentity` provenance gate. This PR is half 2: the contacts that are *not* Homebase identities, whose photo is an uploaded drive payload and therefore has to travel.

## Where the photo lives

Not in the descriptor. The descriptor is capped at `MaxHeaderContentBytes` = 7 KB, and that cap is the whole reason a card renders on scroll with no payload fetch — a base64 avatar would either blow it or eat it. So the photo rides as an ordinary encrypted image payload on the message, exactly like an Event cover, and **presence is inferred from the payload list rather than declared**.

That inference is what makes it backward-compatible in both directions: a card from a sender that never attached a photo simply has no matching payload, and a client that predates this change ignores a payload it does not look for. No schema version, no descriptor field, no migration.

It reuses the Event cover's `chat_web` key deliberately. Every generic media surface (`MessageBubble`'s `filteredPayloads`, `MediaDownloadHandler`) already filters that prefix, so the photo cannot leak out as a loose attachment. A bespoke key would have meant adding it to each of those filters and getting all of them right.

## Send side

`ShareContactPickerViewModel` reads the selected contact's stored `prfl_pic` bytes via `ContactRepository.loadPayloadBytes`, writes them to an upload temp, and builds the bundle with `MessageAttachmentBuilder.buildSingle`. Thumbnails, the embedded preview thumb, encryption, per-payload IVs and the optimistic cache seed all come free from that builder.

The photo cannot be referenced in place — it lives on the sender's own contacts drive, which the recipient has no route to read — so re-uploading is not an optimisation choice, it is the only option.

**Best-effort by design.** The whole thing is wrapped so that any failure — the bytes are gone, the temp write fails, thumbnailing throws — logs and sends the card *without* the picture. A card that arrives without its photo is strictly better than one that never sends, and the photo is the one part of a contact card that is pure decoration.

## Receive side

`MessageBubbleRaw` finds the payload and builds a `HomebaseImageData` whose **AES key comes from the message and IV from the payload** — the split every other chat image uses. `ContactCardAvatar` gains it as a third, highest-priority branch:

1. attached photo (new)
2. identity avatar via `/pub/image`, behind the existing provenance gate
3. initials, else the generic icon

Unlike branch 2, branch 1 needs **no privacy gate**: those bytes are already on the message, so drawing them dials nobody. The gate on branch 2 exists because rendering it makes a live request to a host the card's author chose.

The initials block is extracted to `ContactCardInitials` so it serves as the photo's placeholder *and* error state — an undecodable photo lands back on initials rather than an empty circle, and there is no second copy of that layout to drift.

## One behaviour change beyond the feature

`collectConversationOverview` buckets **any** `image/*` payload into the conversation's Media tab, and does not filter `chat_web`. Left alone, a contact's profile picture would show up there as a photo someone shared into the chat. It is not — it is the subject's avatar — so contact-card messages are now skipped when collecting shared media.

Scoped to contact cards on purpose. An Event cover has the same issue today and I have **not** changed it: an event's cover is at least arguably a picture shared into the conversation, and that call belongs to whoever owns Events, not to this PR.

## Tests

`ContactCardPhotoTest`, 8 tests: no payloads / empty list yields nothing; the `chat_web` image is found; a non-image (and a null content-type) under the same key is rejected; an image under an unrelated key is rejected; the photo is found among decoys; the built image data takes the AES key from the message and the IV from the payload; a missing or malformed IV yields no image data rather than an undecryptable one that would spin forever; chat payloads are always treated as encrypted.

Full JVM suite green; `compileKotlinIosSimulatorArm64` green for both touched modules.

**Not device-verified yet** — needs a real send between two identities to confirm the round trip end to end.

## Still open on #1281

The **vCard** path is untouched: `VCardParser` deliberately skips `PHOTO`/`BASE64`, so a contact shared as a `.vcf` (the Android share sheet and the shared-vCard route) still arrives without a picture even when the file contains one. That is independent of this change and wants its own PR.
