### PR TITLE
fix(chat,contacts): stop a card's identity vanishing when you save it (#1265)

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/contactcard/ContactCardDescriptor.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/contactcard/ContactCardDescriptor.kt
@@ -65,9 +65,7 @@ data class ContactCardDescriptor(
      * its original sender. Gating on "is already one of my contacts" would close that too, at the
      * cost of a contact lookup per bubble.
      *
-     * Saving deliberately has no equivalent gate: this one exists because the bubble fetches
-     * without being asked, whereas a save is an explicit act on a form that shows the identity,
-     * lets you edit it, and says what saving it means.
+     * Saving has no equivalent gate: this one exists because the bubble fetches without being asked.
      */
     fun avatarIdentity(author: String?, sentByYou: Boolean = false): OdinId? =
         identity()?.takeIf {

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/contactcard/ContactCardDescriptor.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/contactcard/ContactCardDescriptor.kt
@@ -64,21 +64,15 @@ data class ContactCardDescriptor(
      * Ceiling: a card you *forwarded* rather than composed counts as [sentByYou] but was named by
      * its original sender. Gating on "is already one of my contacts" would close that too, at the
      * cost of a contact lookup per bubble.
+     *
+     * Saving deliberately has no equivalent gate: this one exists because the bubble fetches
+     * without being asked, whereas a save is an explicit act on a form that shows the identity,
+     * lets you edit it, and says what saving it means.
      */
     fun avatarIdentity(author: String?, sentByYou: Boolean = false): OdinId? =
         identity()?.takeIf {
             sentByYou || it.domainName.equals(author?.trim(), ignoreCase = true)
         }
-
-    /**
-     * The card as it may be *saved*. A stored contact's odinId drives an unconditional
-     * `https://<odinId>/pub/image` on every render of its row, so an identity bound from a card
-     * outlives — and goes around — the bubble's own avatar gate, from one tap. Same test as
-     * [avatarIdentity]; the field stays editable in the sheet, so a user who means to link the
-     * contact still can.
-     */
-    fun forSaving(author: String?, sentByYou: Boolean): ContactCardDescriptor =
-        if (avatarIdentity(author, sentByYou) != null) this else copy(odinId = "")
 
     fun isValid(): Boolean {
         if (displayName.codePointCount() > MAX_NAME_CODEPOINTS) return false

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubbleRaw.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubbleRaw.kt
@@ -235,13 +235,8 @@ fun MessageBubbleRaw(
         is MessageContent.ContactCard -> {
             // No edited marker: MessageMapper hard-codes isEdited = false for every typed kind.
             val cardInfoText = formatMessageTimestamp(message.userDate)
-            val cardAuthor = message.originalAuthor?.domainName
-            // Saving is where an attacker-chosen identity would outlive the avatar gate, so the
-            // same provenance test runs on the way out.
-            val onSaveCard = remember(onSaveContactCard, cardAuthor, sentByYou, displayOnly) {
-                onSaveContactCard?.takeIf { !displayOnly }?.let { save ->
-                    { card: ContactCardDescriptor -> save(card.forSaving(cardAuthor, sentByYou)) }
-                }
+            val onSaveCard = remember(onSaveContactCard, displayOnly) {
+                onSaveContactCard?.takeIf { !displayOnly }
             }
             ContactCardBubble(
                 descriptor = content.descriptor,

--- a/homebase-chat/src/commonTest/kotlin/id/homebase/chat/contactcard/ContactCardValuesTest.kt
+++ b/homebase-chat/src/commonTest/kotlin/id/homebase/chat/contactcard/ContactCardValuesTest.kt
@@ -516,37 +516,44 @@ class ContactCardValuesTest {
         assertEquals("Ada Lovelace \u00C9amonn \uD83C\uDF89", "Ada Lovelace \u00C9amonn \uD83C\uDF89".scrubbed())
     }
 
-    // Saving is the path that outlives the bubble: a stored contact's odinId is fetched on every
-    // render of its row, with no author to check against any more.
+    // The bubble's avatar gate stays. Saving is not gated: the strip that used to run here emptied
+    // the identity field the bubble had just shown, with nothing said — the #1280 defect again.
     @Test
-    fun `saving a card someone else sent does not bind its identity`() {
+    fun `the avatar of a card someone else sent is not fetched`() {
         val hostile = card().copy(odinId = "tracker.evil.tld")
 
-        assertEquals("", hostile.forSaving(author = "friend.demo.rocks", sentByYou = false).odinId)
-        assertEquals("", hostile.forSaving(author = null, sentByYou = false).odinId)
+        assertNull(hostile.avatarIdentity(author = "friend.demo.rocks", sentByYou = false))
+        assertNull(hostile.avatarIdentity(author = null, sentByYou = false))
     }
 
     @Test
-    fun `saving keeps an identity the envelope vouches for`() {
+    fun `the avatar is fetched for an identity the envelope vouches for`() {
         val own = card().copy(odinId = "samwise.gamgee.demo.rocks")
 
         assertEquals(
             "samwise.gamgee.demo.rocks",
-            own.forSaving(author = "samwise.gamgee.demo.rocks", sentByYou = false).odinId,
+            own.avatarIdentity(author = "samwise.gamgee.demo.rocks", sentByYou = false)?.domainName,
         )
         assertEquals(
             "samwise.gamgee.demo.rocks",
-            own.forSaving(author = null, sentByYou = true).odinId,
+            own.avatarIdentity(author = null, sentByYou = true)?.domainName,
         )
     }
 
     @Test
-    fun `gating the identity leaves the rest of the card intact`() {
+    fun `an unattested identity still reaches the editor, so nothing is dropped silently`() {
         val hostile = card(phones = listOf("+14155550123"), emails = listOf("ada@example.com"))
             .copy(odinId = "tracker.evil.tld")
 
-        val saved = hostile.forSaving(author = "friend.demo.rocks", sentByYou = false)
+        // Ungated on purpose: the sheet shows this, lets the user clear it, and says what
+        // saving it means. What must not happen is the field arriving blank.
+        assertEquals("tracker.evil.tld", hostile.identity()?.domainName)
+    }
 
-        assertEquals(hostile.copy(odinId = ""), saved)
+    @Test
+    fun `a garbage identity never reaches the editor claiming to be one`() {
+        // The gate on the way in is parseability, not provenance.
+        assertNull(card().copy(odinId = "not a host!!").identity())
+        assertNull(card().copy(odinId = "   ").identity())
     }
 }

--- a/homebase-chat/src/commonTest/kotlin/id/homebase/chat/contactcard/ContactCardValuesTest.kt
+++ b/homebase-chat/src/commonTest/kotlin/id/homebase/chat/contactcard/ContactCardValuesTest.kt
@@ -516,8 +516,7 @@ class ContactCardValuesTest {
         assertEquals("Ada Lovelace \u00C9amonn \uD83C\uDF89", "Ada Lovelace \u00C9amonn \uD83C\uDF89".scrubbed())
     }
 
-    // The bubble's avatar gate stays. Saving is not gated: the strip that used to run here emptied
-    // the identity field the bubble had just shown, with nothing said — the #1280 defect again.
+    // The bubble's avatar gate stays; saving is deliberately not gated.
     @Test
     fun `the avatar of a card someone else sent is not fetched`() {
         val hostile = card().copy(odinId = "tracker.evil.tld")
@@ -545,14 +544,11 @@ class ContactCardValuesTest {
         val hostile = card(phones = listOf("+14155550123"), emails = listOf("ada@example.com"))
             .copy(odinId = "tracker.evil.tld")
 
-        // Ungated on purpose: the sheet shows this, lets the user clear it, and says what
-        // saving it means. What must not happen is the field arriving blank.
         assertEquals("tracker.evil.tld", hostile.identity()?.domainName)
     }
 
     @Test
     fun `a garbage identity never reaches the editor claiming to be one`() {
-        // The gate on the way in is parseability, not provenance.
         assertNull(card().copy(odinId = "not a host!!").identity())
         assertNull(card().copy(odinId = "   ").identity())
     }

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -1678,6 +1678,7 @@
     <string name="contactbook_edit_surname">Last name</string>
     <string name="contactbook_edit_odinid">Homebase ID</string>
     <string name="contactbook_edit_odinid_locked">Homebase ID can't be changed for a connected contact.</string>
+    <string name="contactbook_edit_odinid_from_card">From the card. Saving it lets this Homebase ID see when you open the contact — clear the field if you don't want that.</string>
     <string name="contactbook_edit_synced_banner">Synced from their Homebase profile. Changes you make are saved only for you and won't change their profile.</string>
     <string name="contactbook_edit_synced_from_profile">From their Homebase profile</string>
     <string name="contactbook_edit_overrides">Overrides their profile value (%1$s) · only you see this</string>

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/components/ContactCardSaveHost.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/components/ContactCardSaveHost.kt
@@ -49,6 +49,7 @@ import id.homebase.core.ui.screens.contactbook.saveContactEdit
 import id.homebase.core.ui.screens.contactbook.saveNewContact
 import id.homebase.resources.MR
 import id.homebase.resources.cancel
+import id.homebase.resources.contactbook_edit_odinid_from_card
 import id.homebase.resources.chat_contact_card_exists_body
 import id.homebase.resources.chat_contact_card_exists_identity_body
 import id.homebase.resources.chat_contact_card_exists_open
@@ -209,6 +210,8 @@ fun ContactCardSaveHost(
         // Switching to the merge editor re-seeds every field, so the sheet has to start over. Keyed
         // on the descriptor too: ContactEditSheet seeds with an unkeyed remember, so a new card
         // arriving under a mounted sheet would otherwise keep the previous card's draft.
+        val odinIdNote = stringResource(MR.string.contactbook_edit_odinid_from_card)
+            .takeIf { descriptor.identity() != null && target?.odinId.isNullOrBlank() }
         key(descriptor, target?.uniqueId) {
             ContactEditSheet(
                 // The unfilled target: it decides whether the sheet calls itself profile-synced,
@@ -226,6 +229,11 @@ fun ContactCardSaveHost(
                 },
                 saving = current is SaveStage.Saving,
                 banner = banner,
+                // The card names an identity we could not attest (any client can put any host in
+                // that field), and a saved odinId is fetched on every render of the contact's row.
+                // Shown rather than stripped: silently emptying a field the bubble just displayed
+                // is the same defect as #1280.
+                odinIdNote = odinIdNote,
                 onSave = { draft, extraPhones, extraEmails, photo ->
                     val savedName = target?.displayName ?: cardName
                     val attempt: () -> Unit = {

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/components/ContactCardSaveHost.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/components/ContactCardSaveHost.kt
@@ -210,6 +210,8 @@ fun ContactCardSaveHost(
         // Switching to the merge editor re-seeds every field, so the sheet has to start over. Keyed
         // on the descriptor too: ContactEditSheet seeds with an unkeyed remember, so a new card
         // arriving under a mounted sheet would otherwise keep the previous card's draft.
+        // A saved odinId is fetched on every render of the contact's row, and any client can put
+        // any host in that field — so say what saving it costs rather than silently dropping it.
         val odinIdNote = stringResource(MR.string.contactbook_edit_odinid_from_card)
             .takeIf { descriptor.identity() != null && target?.odinId.isNullOrBlank() }
         key(descriptor, target?.uniqueId) {
@@ -229,10 +231,6 @@ fun ContactCardSaveHost(
                 },
                 saving = current is SaveStage.Saving,
                 banner = banner,
-                // The card names an identity we could not attest (any client can put any host in
-                // that field), and a saved odinId is fetched on every render of the contact's row.
-                // Shown rather than stripped: silently emptying a field the bubble just displayed
-                // is the same defect as #1280.
                 odinIdNote = odinIdNote,
                 onSave = { draft, extraPhones, extraEmails, photo ->
                     val savedName = target?.displayName ?: cardName

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/components/ContactEditSheet.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/components/ContactEditSheet.kt
@@ -116,6 +116,8 @@ fun ContactEditSheet(
     onSave: (ContactDraft, List<String>, List<String>, PlatformFile?) -> Unit,
     onDismiss: () -> Unit,
     odinIdLocked: Boolean = false,
+    /** Shown under the identity field when it isn't locked and isn't in error. */
+    odinIdNote: String? = null,
     seed: ContactDraft? = null,
     seedAdditionalPhones: List<String> = emptyList(),
     seedAdditionalEmails: List<String> = emptyList(),
@@ -261,6 +263,7 @@ fun ContactEditSheet(
                         supportingText = when {
                             odinIdShowError -> { { Text(odinIdErrorText) } }
                             odinIdLockNote != null -> { { Text(odinIdLockNote) } }
+                            odinIdNote != null -> { { Text(odinIdNote) } }
                             else -> null
                         },
                         trailingIcon = if (odinIdLocked) {

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/components/ContactEditSheet.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/components/ContactEditSheet.kt
@@ -116,7 +116,6 @@ fun ContactEditSheet(
     onSave: (ContactDraft, List<String>, List<String>, PlatformFile?) -> Unit,
     onDismiss: () -> Unit,
     odinIdLocked: Boolean = false,
-    /** Shown under the identity field when it isn't locked and isn't in error. */
     odinIdNote: String? = null,
     seed: ContactDraft? = null,
     seedAdditionalPhones: List<String> = emptyList(),


### PR DESCRIPTION
Closes #1265.

## The question in the issue

"Can a contact card carry a Homebase identity, not just vCard fields?" — and the answer turned out to be that it already does, everywhere except the one place it matters. `odinId` is on `ContactCardDescriptor`, ships on the wire, is validated at the point of use, is on `ContactDraft`, has a real input in `ContactEditSheet` with its own error text and lock state, and persists via `ContactContent.odinId`.

What did not work was **saving** one.

## What was wrong

`forSaving(author, sentByYou)` re-ran the bubble's avatar gate and returned `copy(odinId = "")` when it failed. So: the bubble shows a card with a Homebase identity, you tap Save, and the editor opens with the identity field **empty**. Save it and the stored contact has no identity. Nothing anywhere said a field had been removed.

That is the same defect as #1280 and #1289 — what you were shown and what got saved disagree, silently — and it is worse here, because the field is visible in the form and simply blank, which reads as "this card had no identity" rather than "we dropped it".

## What changed

`forSaving` is gone. The descriptor reaches `ContactCardImport.toDraft` intact, which already seeds `odinId` through its own parse-only `identityOrBlank()`, so the field arrives filled.

`avatarIdentity` is **untouched**. That gate is the one doing real work and it stays exactly as it was.

The two are not the same situation, which is the whole argument for keeping one and dropping the other:

- **The bubble fetches without being asked.** Scrolling past a card draws `https://<odinId>/pub/image`, and any client can author a card naming any host. Ungated, that is a tracking pixel: open the chat and the named host learns your IP and the moment you read it. The user never opted into anything.
- **A save is an explicit act.** It happens on a form that shows the identity, lets you edit or clear it, and now states the consequence. That is consent in the ordinary sense, and it is how every contact app on the phone behaves.

Stripping was defending against the real risk that a *stored* contact's row fetches its odinId unconditionally forever. That risk is genuine — it is just not addressed by making the field disappear without telling anyone.

## The note

The identity field now carries, when the card named an identity and the merge target has none:

> From the card. Saving it lets this Homebase ID see when you open the contact — clear the field if you don't want that.

Deliberately **not** conditional on whether the identity is attested. Two reasons. The consequence of saving is identical either way — the row fetches that host on every render regardless of who sent the card. And "attested" here means only "the envelope's `originalAuthor` matches", which is a weak signal to hand a user as a trust verdict they cannot check; the honest thing is to state what happens and let them clear the field.

It also needs no plumbing. Threading an `attested` flag from `MessageBubbleRaw` to the sheet would have meant editing the UI action, the UI event, the screen parameter, the nav-host state and both hosts — nine files for a supporting line.

## Tests

The three `forSaving` tests are replaced by four in `ContactCardValuesTest` that pin the contract that actually holds now:

- the avatar of a card someone else sent is **not** fetched (unchanged gate, both the wrong-author and no-author cases)
- the avatar **is** fetched for an identity the envelope vouches for, and for one you sent yourself
- an unattested identity still reaches the editor — the regression this PR fixes
- a garbage identity never reaches the editor claiming to be one; the gate on the way in is parseability, not provenance

Full JVM suite green.

**Not device-verified yet.**

## Related

#1284 (gate the fetch on "already a contact" rather than on who sent it) is unaffected and still open — it would tighten `avatarIdentity`, which this PR does not touch.
