### PR TITLE
chore: trim the comments on the contact-card path

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/contactcard/ContactCardValues.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/contactcard/ContactCardValues.kt
@@ -22,8 +22,7 @@ internal fun ContactCardDescriptor.renderableEmails(): List<String> =
 
 internal fun ContactCardDescriptor.renderableIdentity(): String? = identity()?.domainName
 
-// Identity first: it is the only globally unique value here, so it is what a nameless card is
-// titled by and the first thing worth showing under a name.
+// Identity first: it is the only globally unique value here.
 internal fun ContactCardDescriptor.allValues(): List<ContactCardValue> =
     listOfNotNull(renderableIdentity()?.let { ContactCardValue(ContactValueKind.Identity, it) }) +
         renderablePhones().map { ContactCardValue(ContactValueKind.Phone, it) } +
@@ -33,9 +32,7 @@ internal fun ContactCardDescriptor.bubbleValues(
     limit: Int = ContactCardBubbleRowLimit,
 ): ContactCardBubbleValues {
     val all = allValues()
-    // By value, at any position: displayName is arbitrary text that can equal any of these — a
-    // connection has it resolved from the odinId, and a vCard can put the email in FN — and the
-    // value it matches is not necessarily the first.
+    // By value, at any position: a vCard can put the email in FN, and the match need not be first.
     val title = summaryLine()
     val candidates = all.filterNot { it.value.equals(title, ignoreCase = true) }
     return ContactCardBubbleValues(
@@ -60,11 +57,8 @@ internal fun ContactCardDescriptor.avatarInitials(): String =
 // dialer can parse.
 internal fun String.dialable(): String = filter { it in '0'..'9' || it in "+*#," }
 
-/**
- * MMI/USSD control codes (`*21*<number>#` sets up call forwarding) start with `*` or `#`, and a
- * phone number never does. The card is authored remotely, so a value of that shape is not offered
- * as callable — `#` mid-number is still a legitimate extension terminator and survives.
- */
+// MMI/USSD codes (`*21*<number>#` sets up call forwarding) start with `*` or `#` and a phone number
+// never does, so a remotely-authored value of that shape is not offered as callable.
 internal fun String.isControlCode(): Boolean =
     // After the separators a dialer skips: ",*21*…#" would otherwise pass on its leading pause.
     dialable().dropWhile { it == ',' || it == '+' }.firstOrNull()
@@ -105,8 +99,7 @@ internal fun String.mailtoTarget(): String {
     }
 }
 
-// ',' and ';' are deliberately absent: RFC 6068 makes ',' a recipient separator (and
-// Outlook-family clients treat ';' the same), so leaving them addresses the compose window to
-// whoever the card names after the real recipient.
+// ',' and ';' deliberately absent: RFC 6068 makes ',' a recipient separator (Outlook treats ';'
+// the same), so leaving them in addresses whoever the card names after the real recipient.
 private const val MAILTO_SAFE = "-._~!$'()*+:@"
 private const val HEX = "0123456789ABCDEF"

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/MergeSeed.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/MergeSeed.kt
@@ -2,28 +2,15 @@ package id.homebase.core.ui.screens.contactbook
 
 import id.homebase.core.ui.screens.contactbook.model.ContactBookEntry
 
-/**
- * What a seeded [ContactEditSheet] starts with. Computed in one place because the primary slots and
- * the additional rows are drawn from the same source: deciding them separately let the same phone
- * number land in both, and the sheet is the only code that knows which value the primary took.
- */
+// Primary slots and additional rows are decided together: separately, the same number lands in both.
 data class MergeSeed(
     val draft: ContactDraft,
     val additionalPhones: List<String>,
     val additionalEmails: List<String>,
 )
 
-/**
- * [seed] fills only what [editing] leaves blank — the contact being merged into always wins — and
- * an additional row is dropped when the primary slot has just taken that same value.
- *
- * The identity is deliberately **not** filled from [seed]. Merging is the one place a remote card
- * could bind an odinId onto a contact that had none, and every render of that contact then fetches
- * `https://<odinId>/pub/image`, which is the beacon the card's own avatar gate exists to prevent.
- * It costs nothing to refuse: when the match was made *on* the identity the target already has it,
- * so filling it only ever changes the phone/email-matched case — exactly the hostile one. The field
- * stays editable, so a user who means to link the contact still can.
- */
+// The identity is deliberately never filled from [seed]: merging is the one place a remote card
+// could bind an odinId onto a contact that had none, which every later render would then fetch.
 fun mergeSeed(
     editing: ContactBookEntry?,
     seed: ContactDraft?,
@@ -35,8 +22,7 @@ fun mergeSeed(
         base == null -> seed ?: ContactDraft()
         seed == null -> base
         else -> base.copy(
-            // A card with no structured name puts the whole formatted name in givenName, so a
-            // target already holding either part must not gain a second copy of it.
+            // A card with no structured name puts the whole formatted name in givenName.
             givenName = if (base.givenName.isBlank() && base.surname.isBlank()) {
                 seed.givenName
             } else {

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/components/Countries.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/components/Countries.kt
@@ -31,11 +31,8 @@ fun splitE164(value: String): Pair<Country?, String> {
     return country to national.filter { it.isDigit() }
 }
 
-/**
- * The E.164 that a non-E.164 [value] is already being displayed as, or `null` when there is
- * nothing to publish. A seed like `4155553695` renders as 🇺🇸 +1 | 4155553695 while the caller
- * still holds the raw digits, so the field looks right and Save stays disabled.
- */
+// A seed like `4155553695` renders as 🇺🇸 +1 | 4155553695 while the caller still holds the raw
+// digits — the field looks right and Save stays disabled until this is published.
 fun seededE164(value: String, fallback: Country): String? {
     val (country, national) = splitE164(value)
     if (country != null || national.isBlank()) return null

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/components/PhoneNumberField.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/components/PhoneNumberField.kt
@@ -61,8 +61,7 @@ fun PhoneNumberField(
 
     fun emit(c: Country, n: String) = onValueChange(composeE164(c, n))
 
-    // Once per row lifetime — rows are rendered under a stable key(id), so this neither re-emits
-    // on recomposition nor reseeds a sibling.
+    // Once per row lifetime: rows are keyed, so this never re-emits or reseeds a sibling.
     LaunchedEffect(Unit) { seededE164(e164Value, country)?.let(onValueChange) }
 
     OutlinedTextField(


### PR DESCRIPTION
Comment cleanup on the contact-card work already merged to `main`. No behaviour change — comments only, and the JVM suite is green.

## Why

CLAUDE.md is explicit, and I had been ignoring parts of it:

> Default to none. This codebase is over-commented; do not add to it.
> Don't write: what the code already says · KDoc restating parameter names, or a header block on every function · narrative about how the code got here, alternatives considered, or how it was tested · issue and PR numbers.
> Do write, as one terse line: a **why** that isn't derivable from the code.
> If the comment is longer than the code it explains, delete it.

Three of those I broke repeatedly: alternatives-considered narrative, KDoc headers that restate the signature, and issue numbers in source. That reasoning belongs in the PR description, which is where it already was — the source copy was pure duplication.

## What changed

- **`MergeSeed.kt`** — a 4-line KDoc on a 5-line data class and a 10-line KDoc on `mergeSeed` become one and two lines. The kept part is the non-derivable why: primaries and additional rows are decided together because separately the same number lands in both, and the identity is never filled from the seed because merging is the one place a remote card could bind an odinId onto a contact that had none.
- **`ContactCardValues.kt`** — trimmed the verbose ones. **Deliberately kept** the RFC landmines (`,` as a recipient separator in `mailto:`/`sms:`, `#` as the `tel:` fragment delimiter, `Char.isDigit()` letting Arabic-Indic digits through, MMI/USSD codes) — those are exactly the "workaround for someone else's bug" case CLAUDE.md says to keep, and they are already one-liners.
- **`Countries.kt`** — `seededE164`'s KDoc block becomes two lines.
- **`PhoneNumberField.kt`** — the `LaunchedEffect` note becomes one line.

Net: **38 lines removed, 13 added.**

## Scope

Only comments **I** wrote. `ContactOverlay.kt` has three long KDoc blocks in the same area that are equally restate-y, but `git log` shows they are @toddmitchell's from the original override work — not mine to delete in a drive-by.

The same trim is applied in place on my two open PRs (#1292, #1296) rather than here, so this PR does not conflict with them.
