### PR TITLE
fix(avatars): build initials from code points, not UTF-16 chars

### DIFF
--- a/androidApp/src/main/kotlin/id/homebase/feed/share/ShareShortcutAvatarLoader.kt
+++ b/androidApp/src/main/kotlin/id/homebase/feed/share/ShareShortcutAvatarLoader.kt
@@ -10,6 +10,7 @@ import android.graphics.Rect
 import androidx.core.graphics.createBitmap
 import androidx.core.graphics.drawable.IconCompat
 import co.touchlab.kermit.Logger
+import id.homebase.api.util.truncateToCodePoints
 import id.homebase.chat.services.convo.ConversationStream
 import id.homebase.core.avatars.ConversationAvatarModel
 import id.homebase.core.image.HomebaseImageLoader
@@ -137,7 +138,7 @@ class ShareShortcutAvatarLoader(
             typeface = android.graphics.Typeface.DEFAULT_BOLD
         }
         val textBounds = Rect()
-        val displayInitials = initials.take(2).uppercase()
+        val displayInitials = initials.truncateToCodePoints(2).uppercase()
         textPaint.getTextBounds(displayInitials, 0, displayInitials.length, textBounds)
         val y = size / 2f + textBounds.height() / 2f
         canvas.drawText(displayInitials, size / 2f, y, textPaint)

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/auth/OwnerSession.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/auth/OwnerSession.kt
@@ -2,6 +2,7 @@ package id.homebase.api.client.auth
 
 import androidx.compose.runtime.Immutable
 import id.homebase.api.common.OdinId
+import id.homebase.api.util.truncateToCodePoints
 
 @Immutable
 data class OwnerSession(
@@ -21,13 +22,13 @@ fun OwnerSession.initials(): String {
         firstName
             ?.trim()
             ?.takeIf { it.isNotEmpty() }
-            ?.firstOrNull()
+            ?.truncateToCodePoints(1)
 
     val last =
         surName
             ?.trim()
             ?.takeIf { it.isNotEmpty() }
-            ?.firstOrNull()
+            ?.truncateToCodePoints(1)
 
     if (first != null && last != null) {
         return "${first}${last}".uppercase()
@@ -42,10 +43,11 @@ fun OwnerSession.initials(): String {
 
     return when {
         tokens.size >= 2 ->
-            "${tokens.first().first()}${tokens.last().first()}".uppercase()
+            "${tokens.first().truncateToCodePoints(1)}${tokens.last().truncateToCodePoints(1)}"
+                .uppercase()
 
         tokens.size == 1 ->
-            tokens.first().first().uppercaseChar().toString()
+            tokens.first().truncateToCodePoints(1).uppercase()
 
         else ->
             "?"

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/contacts/ContactNameExtensions.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/contacts/ContactNameExtensions.kt
@@ -1,5 +1,7 @@
 package id.homebase.api.client.contacts
 
+import id.homebase.api.util.truncateToCodePoints
+
 /**
  * Single source of truth for turning a contact's [ContactName] into the values UIs render, shared
  * by every consumer of [ContactRepository] so display-name/initials logic can't drift.
@@ -34,15 +36,18 @@ fun ContactName?.resolveDisplayName(
  * first/last whitespace tokens of `displayName`, else `"?"`.
  */
 fun ContactName?.initials(): String {
-    val first = this?.givenName?.trim()?.takeIf { it.isNotEmpty() }?.firstOrNull()
-    val last = this?.surname?.trim()?.takeIf { it.isNotEmpty() }?.firstOrNull()
+    val first = this?.givenName?.trim()?.takeIf { it.isNotEmpty() }?.truncateToCodePoints(1)
+    val last = this?.surname?.trim()?.takeIf { it.isNotEmpty() }?.truncateToCodePoints(1)
     if (first != null && last != null) return "$first$last".uppercase()
 
     val display = this?.displayName ?: return "?"
     val tokens = display.trim().split("\\s+".toRegex()).filter { it.isNotEmpty() }
     return when {
-        tokens.size >= 2 -> "${tokens.first().first()}${tokens.last().first()}".uppercase()
-        tokens.size == 1 -> tokens.first().first().uppercaseChar().toString()
+        tokens.size >= 2 ->
+            "${tokens.first().truncateToCodePoints(1)}${tokens.last().truncateToCodePoints(1)}"
+                .uppercase()
+
+        tokens.size == 1 -> tokens.first().truncateToCodePoints(1).uppercase()
         else -> "?"
     }
 }

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/identity/PublicIdentity.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/identity/PublicIdentity.kt
@@ -2,6 +2,7 @@ package id.homebase.api.client.identity
 
 import androidx.compose.runtime.Immutable
 import id.homebase.api.common.OdinId
+import id.homebase.api.util.truncateToCodePoints
 
 @Immutable
 data class PublicIdentity(
@@ -16,8 +17,8 @@ data class PublicIdentity(
 )
 
 fun PublicIdentity.initials(): String {
-    val first = firstName?.trim()?.takeIf { it.isNotEmpty() }?.firstOrNull()
-    val last = surName?.trim()?.takeIf { it.isNotEmpty() }?.firstOrNull()
+    val first = firstName?.trim()?.takeIf { it.isNotEmpty() }?.truncateToCodePoints(1)
+    val last = surName?.trim()?.takeIf { it.isNotEmpty() }?.truncateToCodePoints(1)
 
     if (first != null && last != null) {
         return "${first}${last}".uppercase()
@@ -30,9 +31,12 @@ fun PublicIdentity.initials(): String {
         ?: emptyList()
 
     return when {
-        tokens.size >= 2 -> "${tokens.first().first()}${tokens.last().first()}".uppercase()
-        tokens.size == 1 -> tokens.first().first().uppercaseChar().toString()
-        else -> odinId.domainName.firstOrNull()?.uppercaseChar()?.toString() ?: "?"
+        tokens.size >= 2 ->
+            "${tokens.first().truncateToCodePoints(1)}${tokens.last().truncateToCodePoints(1)}"
+                .uppercase()
+
+        tokens.size == 1 -> tokens.first().truncateToCodePoints(1).uppercase()
+        else -> odinId.domainName.truncateToCodePoints(1).uppercase().ifEmpty { "?" }
     }
 }
 

--- a/homebase-api/src/jvmTest/kotlin/id/homebase/api/client/auth/OwnerSessionInitialsTest.kt
+++ b/homebase-api/src/jvmTest/kotlin/id/homebase/api/client/auth/OwnerSessionInitialsTest.kt
@@ -1,0 +1,90 @@
+package id.homebase.api.client.auth
+
+import id.homebase.api.common.OdinId
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+private const val PARTY = "🎉" // U+1F389 party popper
+
+private fun String.hasLoneSurrogate(): Boolean {
+    var i = 0
+    while (i < length) {
+        val c = this[i]
+        when {
+            c.isHighSurrogate() -> {
+                if (i + 1 >= length || !this[i + 1].isLowSurrogate()) return true
+                i += 2
+            }
+
+            c.isLowSurrogate() -> return true
+            else -> i += 1
+        }
+    }
+    return false
+}
+
+class OwnerSessionInitialsTest {
+
+    private fun session(
+        displayName: String? = null,
+        firstName: String? = null,
+        surName: String? = null,
+    ) = OwnerSession(
+        odinId = OdinId("test.homebase.id"),
+        displayName = displayName,
+        firstName = firstName,
+        surName = surName,
+        profileImageFileId = null,
+        profileImageFileKey = null,
+        profileImagePreviewThumbnail = null,
+        profileImageLastModified = null,
+        status = null,
+    )
+
+    @Test
+    fun emoji_led_first_and_sur_name() {
+        val result = session(firstName = "${PARTY}Ada", surName = "Lovelace").initials()
+        assertEquals("${PARTY}L", result)
+        assertFalse(result.hasLoneSurrogate())
+    }
+
+    @Test
+    fun emoji_led_display_name() {
+        val result = session(displayName = "$PARTY Ada").initials()
+        assertEquals("${PARTY}A", result)
+        assertFalse(result.hasLoneSurrogate())
+    }
+
+    @Test
+    fun emoji_led_single_word_display_name() {
+        val result = session(displayName = "${PARTY}Party").initials()
+        assertEquals(PARTY, result)
+        assertFalse(result.hasLoneSurrogate())
+    }
+
+    @Test
+    fun plain_ascii_name_parts() {
+        assertEquals("AL", session(firstName = "Ada", surName = "Lovelace").initials())
+    }
+
+    @Test
+    fun plain_ascii_display_name() {
+        assertEquals("AL", session(displayName = "Ada Lovelace").initials())
+    }
+
+    @Test
+    fun single_word_display_name() {
+        assertEquals("A", session(displayName = "Ada").initials())
+    }
+
+    @Test
+    fun no_name_falls_back_to_question_mark() {
+        assertEquals("?", session().initials())
+    }
+
+    @Test
+    fun blank_display_name_falls_back_to_question_mark() {
+        assertEquals("?", session(displayName = "   ").initials())
+    }
+}

--- a/homebase-api/src/jvmTest/kotlin/id/homebase/api/client/contacts/ContactNameInitialsTest.kt
+++ b/homebase-api/src/jvmTest/kotlin/id/homebase/api/client/contacts/ContactNameInitialsTest.kt
@@ -1,0 +1,80 @@
+package id.homebase.api.client.contacts
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+private const val PARTY = "🎉" // U+1F389 party popper
+
+private fun String.hasLoneSurrogate(): Boolean {
+    var i = 0
+    while (i < length) {
+        val c = this[i]
+        when {
+            c.isHighSurrogate() -> {
+                if (i + 1 >= length || !this[i + 1].isLowSurrogate()) return true
+                i += 2
+            }
+
+            c.isLowSurrogate() -> return true
+            else -> i += 1
+        }
+    }
+    return false
+}
+
+class ContactNameInitialsTest {
+
+    @Test
+    fun emoji_led_given_and_surname() {
+        val result = ContactName(givenName = "${PARTY}Ada", surname = "Lovelace").initials()
+        assertEquals("${PARTY}L", result)
+        assertFalse(result.hasLoneSurrogate())
+    }
+
+    @Test
+    fun emoji_led_display_name() {
+        val result = ContactName(displayName = "$PARTY Ada").initials()
+        assertEquals("${PARTY}A", result)
+        assertFalse(result.hasLoneSurrogate())
+    }
+
+    @Test
+    fun last_word_starting_with_emoji() {
+        val result = ContactName(displayName = "Ada ${PARTY}Lovelace").initials()
+        assertEquals("A$PARTY", result)
+        assertFalse(result.hasLoneSurrogate())
+    }
+
+    @Test
+    fun emoji_led_single_word_display_name() {
+        val result = ContactName(displayName = "${PARTY}Party").initials()
+        assertEquals(PARTY, result)
+        assertFalse(result.hasLoneSurrogate())
+    }
+
+    @Test
+    fun plain_ascii_name_parts() {
+        assertEquals("AL", ContactName(givenName = "Ada", surname = "Lovelace").initials())
+    }
+
+    @Test
+    fun plain_ascii_display_name() {
+        assertEquals("AL", ContactName(displayName = "Ada Lovelace").initials())
+    }
+
+    @Test
+    fun single_word_display_name() {
+        assertEquals("A", ContactName(displayName = "Ada").initials())
+    }
+
+    @Test
+    fun null_name_falls_back_to_question_mark() {
+        assertEquals("?", (null as ContactName?).initials())
+    }
+
+    @Test
+    fun blank_display_name_falls_back_to_question_mark() {
+        assertEquals("?", ContactName(displayName = "   ").initials())
+    }
+}

--- a/homebase-api/src/jvmTest/kotlin/id/homebase/api/client/identity/PublicIdentityInitialsTest.kt
+++ b/homebase-api/src/jvmTest/kotlin/id/homebase/api/client/identity/PublicIdentityInitialsTest.kt
@@ -1,0 +1,82 @@
+package id.homebase.api.client.identity
+
+import id.homebase.api.common.OdinId
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+private const val PARTY = "🎉" // U+1F389 party popper
+
+private fun String.hasLoneSurrogate(): Boolean {
+    var i = 0
+    while (i < length) {
+        val c = this[i]
+        when {
+            c.isHighSurrogate() -> {
+                if (i + 1 >= length || !this[i + 1].isLowSurrogate()) return true
+                i += 2
+            }
+
+            c.isLowSurrogate() -> return true
+            else -> i += 1
+        }
+    }
+    return false
+}
+
+class PublicIdentityInitialsTest {
+
+    private fun identity(
+        displayName: String? = null,
+        firstName: String? = null,
+        surName: String? = null,
+        domain: String = "test.homebase.id",
+    ) = PublicIdentity(
+        odinId = OdinId(domain),
+        displayName = displayName,
+        firstName = firstName,
+        surName = surName,
+        status = null,
+    )
+
+    @Test
+    fun emoji_led_first_and_sur_name() {
+        val result = identity(firstName = "${PARTY}Ada", surName = "Lovelace").initials()
+        assertEquals("${PARTY}L", result)
+        assertFalse(result.hasLoneSurrogate())
+    }
+
+    @Test
+    fun emoji_led_display_name() {
+        val result = identity(displayName = "$PARTY Ada").initials()
+        assertEquals("${PARTY}A", result)
+        assertFalse(result.hasLoneSurrogate())
+    }
+
+    @Test
+    fun emoji_led_single_word_display_name() {
+        val result = identity(displayName = "${PARTY}Party").initials()
+        assertEquals(PARTY, result)
+        assertFalse(result.hasLoneSurrogate())
+    }
+
+    @Test
+    fun plain_ascii_name_parts() {
+        assertEquals("AL", identity(firstName = "Ada", surName = "Lovelace").initials())
+    }
+
+    @Test
+    fun plain_ascii_display_name() {
+        assertEquals("AL", identity(displayName = "Ada Lovelace").initials())
+    }
+
+    @Test
+    fun single_word_display_name() {
+        assertEquals("A", identity(displayName = "Ada").initials())
+    }
+
+    @Test
+    fun no_name_falls_back_to_domain_initial() {
+        assertEquals("S", identity(domain = "samwise.homebase.id").initials())
+    }
+}

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/util/StringExtensions.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/util/StringExtensions.kt
@@ -2,6 +2,8 @@
 
 package id.homebase.core.util
 
+import id.homebase.api.util.truncateToCodePoints
+
 fun String.isEmojiContentOnly(): Boolean {
     if (this.isBlank()) return false
     if (this.lines().all { it.isBlank() }) return false
@@ -159,10 +161,12 @@ fun String.initials(): String {
 
     return when {
         tokens.size >= 2 ->
-            "${tokens.first().first()}${tokens.last().first()}".uppercase().trim()
+            "${tokens.first().truncateToCodePoints(1)}${tokens.last().truncateToCodePoints(1)}"
+                .uppercase()
+                .trim()
 
         tokens.size == 1 ->
-            tokens.first().first().uppercaseChar().toString().trim()
+            tokens.first().truncateToCodePoints(1).uppercase().trim()
 
         else -> ""
     }

--- a/homebase-common/src/jvmTest/kotlin/id/homebase/core/util/StringInitialsTest.kt
+++ b/homebase-common/src/jvmTest/kotlin/id/homebase/core/util/StringInitialsTest.kt
@@ -1,0 +1,110 @@
+package id.homebase.core.util
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+private const val PARTY = "🎉" // U+1F389 party popper
+private const val CJK_EXT_B = "𠀀" // U+20000 CJK extension B ideograph
+
+private fun String.hasLoneSurrogate(): Boolean {
+    var i = 0
+    while (i < length) {
+        val c = this[i]
+        when {
+            c.isHighSurrogate() -> {
+                if (i + 1 >= length || !this[i + 1].isLowSurrogate()) return true
+                i += 2
+            }
+
+            c.isLowSurrogate() -> return true
+            else -> i += 1
+        }
+    }
+    return false
+}
+
+class StringInitialsTest {
+
+    @Test
+    fun emoji_led_single_word() {
+        val result = "${PARTY}Party".initials()
+        assertEquals(PARTY, result)
+        assertFalse(result.hasLoneSurrogate())
+    }
+
+    @Test
+    fun emoji_only_name_keeps_the_whole_code_point() {
+        val result = PARTY.initials()
+        assertEquals(PARTY, result)
+        assertFalse(result.hasLoneSurrogate())
+    }
+
+    @Test
+    fun emoji_led_first_and_last_name() {
+        val result = "$PARTY Ada".initials()
+        assertEquals("${PARTY}A", result)
+        assertFalse(result.hasLoneSurrogate())
+    }
+
+    @Test
+    fun last_word_starting_with_emoji() {
+        val result = "Ada ${PARTY}Lovelace".initials()
+        assertEquals("A$PARTY", result)
+        assertFalse(result.hasLoneSurrogate())
+    }
+
+    @Test
+    fun both_words_starting_with_emoji() {
+        val result = "$PARTY $PARTY".initials()
+        assertEquals("$PARTY$PARTY", result)
+        assertFalse(result.hasLoneSurrogate())
+    }
+
+    @Test
+    fun non_bmp_cjk_extension_name() {
+        val result = "$CJK_EXT_B Wang".initials()
+        assertEquals("${CJK_EXT_B}W", result)
+        assertFalse(result.hasLoneSurrogate())
+    }
+
+    @Test
+    fun plain_ascii_first_and_last() {
+        assertEquals("AL", "Ada Lovelace".initials())
+    }
+
+    @Test
+    fun plain_ascii_is_uppercased() {
+        assertEquals("AL", "ada lovelace".initials())
+    }
+
+    @Test
+    fun middle_names_use_first_and_last_token() {
+        assertEquals("AL", "Ada King Lovelace".initials())
+    }
+
+    @Test
+    fun single_word() {
+        assertEquals("A", "Ada".initials())
+    }
+
+    @Test
+    fun surrounding_whitespace_is_trimmed() {
+        assertEquals("AL", "  Ada Lovelace  ".initials())
+    }
+
+    @Test
+    fun empty_string() {
+        assertEquals("", "".initials())
+    }
+
+    @Test
+    fun blank_string() {
+        assertEquals("", "   ".initials())
+    }
+
+    @Test
+    fun whitespace_only_tabs_and_newlines() {
+        assertEquals("", " \t\n ".initials())
+    }
+}


### PR DESCRIPTION
Fixes #1268

## The bug

`initials()` read UTF-16 code units, not code points, so a display name led by a non-BMP character produced a **lone surrogate**. Probe of the pre-fix algorithm (hex of the returned string):

```
"🎉 Ada"          -> [D83C 0041]   loneSurrogate=true
"🎉Party"         -> [D83C]        loneSurrogate=true
"Ada 🎉Lovelace"  -> [0041 D83C]   loneSurrogate=true
"𠀀 Wang"         -> [D840 0057]   loneSurrogate=true   (U+20000, CJK ext B)
"Ada Lovelace"    -> [0041 004C]   loneSurrogate=false
```

An unpaired surrogate renders as a replacement glyph and can break downstream serialization. It is also **not blank**, so the avatar fallback that swaps in a placeholder icon on empty initials never fired — the broken glyph was rendered instead.

## Scope: it was four functions, not one

The issue names `String.initials()`, but the identical `first()` / `firstOrNull()` defect existed in three more implementations, all reachable from the same avatar call sites (`session.initials()`, `identity.initials()`, contact avatars). Fixing only one would have left the bug live:

| Function | Module |
|---|---|
| `String.initials()` | homebase-common |
| `OwnerSession.initials()` | homebase-api |
| `PublicIdentity.initials()` | homebase-api |
| `ContactName?.initials()` | homebase-api |

All four now take the first whole code point via `truncateToCodePoints`, the helper CLAUDE.md already designates for this. `homebase-common` declares `api(project(":homebase-api"))` in `commonMain`, so the dependency direction allows the reuse on every target; the three api-side functions cannot reach homebase-common's private `codePointAt`, so the shared helper is what makes all four identical instead of two idioms for one operation.

Also fixed: `ShareShortcutAvatarLoader` capped its rendered initials with `initials.take(2)` — the `name.take(2)` pattern CLAUDE.md bans, and a real splitter (`"A🎉".take(2)` = `A` + lone `D83C`). Routed through the same helper. It was the only hand-rolled instance in the tree.

## The emoji-vs-letter question

The issue asked whether an emoji should count as an initial at all, or be skipped in favour of the first letter. **Kept as the first code point**, deliberately.

`isEmojiBase` — the helper that would drive a skip rule — includes `in 0x203C..0x3299`. That range spans **Hiragana (0x3040–0x309F) and Katakana (0x30A0–0x30FF)**, so "skip emoji, take the first letter" would classify Japanese names as emoji and blank their initials. Trading a rendering nit for a regression on a whole writing system isn't worth it, and `Char.isLetter()` can't be used to narrow it either — it's false for every surrogate, so it would also reject the non-BMP CJK characters this fix exists to support.

`"🎉 Ada"` therefore gives `🎉A`, and an all-emoji name keeps its emoji rather than collapsing to a generic placeholder. Retargeting to first-letter-only remains a separate, self-contained change if the product view differs.

## Tests

38 new JVM tests, all green. Each non-BMP case asserts both the exact expected string and the absence of an unpaired surrogate (note: asserting `none { it.isSurrogate() }` as the issue suggested would be wrong — a correctly paired emoji *does* contain two surrogates; the invariant is that neither is unpaired).

`StringInitialsTest` (homebase-common, 14): emoji-led single word, emoji-only name, emoji-led first+last, last word emoji-led, both words emoji-led, non-BMP CJK extension, plain ASCII, lowercase uppercased, middle names, single word, surrounding whitespace, empty, blank, whitespace-only.

`OwnerSessionInitialsTest` (8), `PublicIdentityInitialsTest` (7), `ContactNameInitialsTest` (9): emoji-led name parts and display names, ASCII regressions, and the `"?"` / domain-initial fallbacks.

The tests fail against the pre-fix code — the probe above is the old algorithm, and it returns `D83C 0041` where the test asserts `🎉A`.

## Verification

Local:

- `:homebase-api:compileKotlinJvm`, `:homebase-common:compileKotlinJvm` — clean, no new warnings.
- `:homebase-api:jvmTest`, `:homebase-common:jvmTest` — green, 38 tests, 0 skipped, 0 failures.

CI: all six checks green — Build Android & Desktop, Build iOS, Run unittests, JVM Test Results, Lint & Format Check, Detect silent reverts. The Android and iOS builds cover the `androidApp` and `commonMain`/native sides respectively.

**Not device-verified.** `androidApp:assembleDebug` could not run locally: the build host is out of disk (`df` reports 125 MiB available, 100% capacity) and the Gradle daemon died with "Could not receive a message from the daemon". That is an environment failure, not a code one — freeing space would have meant deleting caches that aren't mine to delete, so the build was left alone rather than forced through. CI's Android build has since covered the compile.

Independently of the disk problem, the emoji case was not reproducible on the available device anyway: producing an emoji-led display name needs a contact created or edited on a real account. The behaviour rests on the unit tests, which is where it is best pinned — this is pure string logic with no platform component.
