### PR TITLE
Save a shared file vended as Data, not just as a URL

### DIFF
--- a/iosApp/ShareExtension/SharedContentSaver.swift
+++ b/iosApp/ShareExtension/SharedContentSaver.swift
@@ -144,6 +144,17 @@ struct SharedContentSaver {
                                 fileNames.append(result.name)
                                 mimeTypes.append(result.mimeType)
                             }
+                        } else if let videoData = item as? Data {
+                            if let result = writeData(
+                                videoData,
+                                from: provider,
+                                conformingTo: .movie,
+                                fallbackExtension: "mov",
+                                to: filesDir
+                            ) {
+                                fileNames.append(result.name)
+                                mimeTypes.append(result.mimeType)
+                            }
                         }
                         group.leave()
                     }
@@ -156,6 +167,17 @@ struct SharedContentSaver {
                     provider.loadItem(forTypeIdentifier: UTType.data.identifier, options: nil) { item, _ in
                         if let fileURL = item as? URL {
                             if let result = copyFile(from: fileURL, to: filesDir) {
+                                fileNames.append(result.name)
+                                mimeTypes.append(result.mimeType)
+                            }
+                        } else if let fileData = item as? Data {
+                            if let result = writeData(
+                                fileData,
+                                from: provider,
+                                conformingTo: .data,
+                                fallbackExtension: "dat",
+                                to: filesDir
+                            ) {
                                 fileNames.append(result.name)
                                 mimeTypes.append(result.mimeType)
                             }
@@ -227,6 +249,46 @@ struct SharedContentSaver {
         } catch {
             return nil
         }
+    }
+
+    private static func writeData(
+        _ data: Data,
+        from provider: NSItemProvider,
+        conformingTo type: UTType,
+        fallbackExtension: String,
+        to directory: URL
+    ) -> CopyResult? {
+        let ext = dataExtension(for: provider, conformingTo: type, fallback: fallbackExtension)
+        let name = "share_\(Int(Date().timeIntervalSince1970 * 1000))_\(Int.random(in: 0...9999)).\(ext)"
+        let destURL = directory.appendingPathComponent(name)
+
+        do {
+            try data.write(to: destURL)
+            return CopyResult(name: name, mimeType: mimeTypeForExtension(ext))
+        } catch {
+            return nil
+        }
+    }
+
+    /// Only the extension is taken from `suggestedName`: it is cross-process input and must
+    /// never become a path component of its own.
+    private static func dataExtension(
+        for provider: NSItemProvider,
+        conformingTo type: UTType,
+        fallback: String
+    ) -> String {
+        if let suggested = provider.suggestedName {
+            let ext = (suggested as NSString).pathExtension
+            if !ext.isEmpty { return ext }
+        }
+        for identifier in provider.registeredTypeIdentifiers {
+            guard let registered = UTType(identifier),
+                  registered.conforms(to: type),
+                  let ext = registered.preferredFilenameExtension
+            else { continue }
+            return ext
+        }
+        return fallback
     }
 
     private static func mimeTypeForExtension(_ ext: String) -> String {

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -41,6 +41,8 @@
 		A1B89255D2411EA1E606A9FA /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 83540B919899D142F6699230 /* Foundation.framework */; };
 		CF04EFF288B21720D5F2C2A5 /* fixture_1080p.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = 03A0D16625BBBB6D9B0E2DFC /* fixture_1080p.mp4 */; };
 		DC82714879B26AB0D9534606 /* FFmpegPipelineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E585E03C7BEE52F79C7D8BE /* FFmpegPipelineTests.swift */; };
+		F1207A520000000000006B01 /* SharedContentSaverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1207A520000000000006A01 /* SharedContentSaverTests.swift */; };
+		F1207A520000000000006D01 /* SharedContentSaver.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1207A520000000000006C01 /* SharedContentSaver.swift */; };
 		DF79A08C91D0173E80D2106A /* fixture_720p.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = F72A108F8868D83B449653CC /* fixture_720p.mp4 */; };
 		E37B55745513C31F5CF240ED /* ffmpegkit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 43296FB22F3A0C08000B3AFE /* ffmpegkit.xcframework */; };
 		EEDEB518C1A6676F6AD39843 /* FirebaseCrashlytics in Frameworks */ = {isa = PBXBuildFile; productRef = 035D6D85BD3FD3872BA0F427 /* FirebaseCrashlytics */; };
@@ -109,6 +111,8 @@
 /* Begin PBXFileReference section */
 		03A0D16625BBBB6D9B0E2DFC /* fixture_1080p.mp4 */ = {isa = PBXFileReference; includeInIndex = 1; path = fixture_1080p.mp4; sourceTree = "<group>"; };
 		1E585E03C7BEE52F79C7D8BE /* FFmpegPipelineTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FFmpegPipelineTests.swift; sourceTree = "<group>"; };
+		F1207A520000000000006A01 /* SharedContentSaverTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SharedContentSaverTests.swift; sourceTree = "<group>"; };
+		F1207A520000000000006C01 /* SharedContentSaver.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SharedContentSaver.swift; path = ShareExtension/SharedContentSaver.swift; sourceTree = SOURCE_ROOT; };
 		43296FAE2F3A0C08000B3AFE /* libavformat.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = libavformat.xcframework; path = "../homebase-api/libs/ffmpegkit-bundled.xcframework/libavformat.xcframework"; sourceTree = "<group>"; };
 		43296FAF2F3A0C08000B3AFE /* libavutil.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = libavutil.xcframework; path = "../homebase-api/libs/ffmpegkit-bundled.xcframework/libavutil.xcframework"; sourceTree = "<group>"; };
 		43296FB02F3A0C08000B3AFE /* libavfilter.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = libavfilter.xcframework; path = "../homebase-api/libs/ffmpegkit-bundled.xcframework/libavfilter.xcframework"; sourceTree = "<group>"; };
@@ -312,6 +316,8 @@
 			isa = PBXGroup;
 			children = (
 				1E585E03C7BEE52F79C7D8BE /* FFmpegPipelineTests.swift */,
+				F1207A520000000000006A01 /* SharedContentSaverTests.swift */,
+				F1207A520000000000006C01 /* SharedContentSaver.swift */,
 				E5FC7FF390C4D1659F6B3703 /* fixture_4k.mp4 */,
 				03A0D16625BBBB6D9B0E2DFC /* fixture_1080p.mp4 */,
 				F72A108F8868D83B449653CC /* fixture_720p.mp4 */,
@@ -612,6 +618,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				DC82714879B26AB0D9534606 /* FFmpegPipelineTests.swift in Sources */,
+				F1207A520000000000006B01 /* SharedContentSaverTests.swift in Sources */,
+				F1207A520000000000006D01 /* SharedContentSaver.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/iosApp/iosAppTests/SharedContentSaverTests.swift
+++ b/iosApp/iosAppTests/SharedContentSaverTests.swift
@@ -1,0 +1,253 @@
+import XCTest
+import UniformTypeIdentifiers
+
+final class SharedContentSaverTests: XCTestCase {
+
+    private final class StubExtensionContext: NSExtensionContext {
+        private let items: [NSExtensionItem]
+
+        init(_ items: [NSExtensionItem]) {
+            self.items = items
+            super.init()
+        }
+
+        override var inputItems: [Any] { items }
+    }
+
+    private var containerURL: URL!
+    private var filesDir: URL!
+    private var descriptorURL: URL!
+    private var tempDir: URL!
+    private var preexistingFiles: Set<String> = []
+    private var preexistingDescriptor: Data?
+
+    private let vcardBytes = Data("BEGIN:VCARD\nVERSION:3.0\nFN:Ada Vance\nEND:VCARD\n".utf8)
+    private let movieBytes = Data([0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70, 0x6D, 0x70, 0x34, 0x32])
+    private let pngBytes = Data([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D])
+    private let opaqueBytes = Data([0x7F, 0x21, 0x03, 0xEE, 0x00, 0x91, 0xAB, 0x5C])
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        containerURL = try XCTUnwrap(
+            FileManager.default.containerURL(
+                forSecurityApplicationGroupIdentifier: SharedContentSaver.appGroupId
+            ),
+            "host app must carry the \(SharedContentSaver.appGroupId) App Group entitlement"
+        )
+        filesDir = containerURL.appendingPathComponent(SharedContentSaver.sharedFilesDir)
+        descriptorURL = containerURL.appendingPathComponent(SharedContentSaver.sharedContentFile)
+
+        preexistingFiles = Set((try? FileManager.default.contentsOfDirectory(atPath: filesDir.path)) ?? [])
+        preexistingDescriptor = try? Data(contentsOf: descriptorURL)
+
+        tempDir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("shared_content_saver_\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        let current = (try? FileManager.default.contentsOfDirectory(atPath: filesDir.path)) ?? []
+        for name in current where !preexistingFiles.contains(name) {
+            try? FileManager.default.removeItem(at: filesDir.appendingPathComponent(name))
+        }
+        if let preexistingDescriptor {
+            try preexistingDescriptor.write(to: descriptorURL)
+        } else {
+            try? FileManager.default.removeItem(at: descriptorURL)
+        }
+        try? FileManager.default.removeItem(at: tempDir)
+
+        try super.tearDownWithError()
+    }
+
+    // MARK: - Data-vended attachments
+
+    func testMovieVendedAsDataIsSaved() throws {
+        let descriptor = try save([dataProvider(movieBytes, .mpeg4Movie)])
+
+        XCTAssertEqual(descriptor.contentType, "VIDEO")
+        XCTAssertEqual(descriptor.mimeTypes, ["video/mp4"])
+        let name = try XCTUnwrap(descriptor.fileNames.first)
+        XCTAssertEqual(descriptor.fileNames.count, 1)
+        XCTAssertTrue(name.hasPrefix("share_"))
+        XCTAssertTrue(name.hasSuffix(".mp4"))
+        XCTAssertEqual(try writtenBytes(descriptor), movieBytes)
+    }
+
+    func testMovieVendedAsDataFallsBackToMovWhenTypeOffersNoExtension() throws {
+        XCTAssertNil(UTType.movie.preferredFilenameExtension)
+
+        let descriptor = try save([dataProvider(movieBytes, .movie)])
+
+        XCTAssertEqual(descriptor.contentType, "VIDEO")
+        XCTAssertEqual(descriptor.mimeTypes, ["video/quicktime"])
+        XCTAssertTrue(try XCTUnwrap(descriptor.fileNames.first).hasSuffix(".mov"))
+        XCTAssertEqual(try writtenBytes(descriptor), movieBytes)
+    }
+
+    func testGenericFileVendedAsDataIsSaved() throws {
+        let descriptor = try save([dataProvider(vcardBytes, .vCard)])
+
+        XCTAssertEqual(descriptor.contentType, "FILE")
+        XCTAssertEqual(descriptor.mimeTypes, ["text/vcard"])
+        XCTAssertEqual(descriptor.fileNames.count, 1)
+        XCTAssertTrue(try XCTUnwrap(descriptor.fileNames.first).hasSuffix(".vcf"))
+        XCTAssertEqual(try writtenBytes(descriptor), vcardBytes)
+    }
+
+    func testGenericFileVendedAsDataFallsBackToDatWhenTypeOffersNoExtension() throws {
+        XCTAssertNil(UTType.data.preferredFilenameExtension)
+
+        let descriptor = try save([dataProvider(opaqueBytes, .data)])
+
+        XCTAssertEqual(descriptor.contentType, "FILE")
+        XCTAssertEqual(descriptor.mimeTypes, ["application/octet-stream"])
+        XCTAssertTrue(try XCTUnwrap(descriptor.fileNames.first).hasSuffix(".dat"))
+        XCTAssertEqual(try writtenBytes(descriptor), opaqueBytes)
+    }
+
+    func testTextAlongsideDataFileKeepsBoth() throws {
+        let descriptor = try save([dataProvider(vcardBytes, .vCard)], text: "look at this")
+
+        XCTAssertEqual(descriptor.contentType, "MIXED")
+        XCTAssertEqual(descriptor.text, "look at this")
+        XCTAssertEqual(descriptor.fileNames.count, 1)
+        XCTAssertEqual(descriptor.mimeTypes, ["text/vcard"])
+    }
+
+    // MARK: - Extension derivation
+
+    func testSuggestedNameExtensionWinsOverRegisteredType() throws {
+        let descriptor = try save([dataProvider(vcardBytes, .vCard, suggestedName: "report.pdf")])
+
+        XCTAssertEqual(descriptor.mimeTypes, ["application/pdf"])
+        XCTAssertTrue(try XCTUnwrap(descriptor.fileNames.first).hasSuffix(".pdf"))
+    }
+
+    func testRegisteredTypeSuppliesExtensionWhenSuggestedNameHasNone() throws {
+        let descriptor = try save([dataProvider(vcardBytes, .vCard, suggestedName: "Ada Vance")])
+
+        XCTAssertEqual(descriptor.mimeTypes, ["text/vcard"])
+        XCTAssertTrue(try XCTUnwrap(descriptor.fileNames.first).hasSuffix(".vcf"))
+    }
+
+    func testSuggestedNameCannotEscapeTheSharedFilesDirectory() throws {
+        let descriptor = try save([
+            dataProvider(vcardBytes, .vCard, suggestedName: "../../../../escaped.vcf")
+        ])
+
+        let name = try XCTUnwrap(descriptor.fileNames.first)
+        XCTAssertFalse(name.contains("/"))
+        XCTAssertFalse(name.contains(".."))
+        XCTAssertTrue(name.hasPrefix("share_"))
+        XCTAssertTrue(name.hasSuffix(".vcf"))
+
+        let written = filesDir.appendingPathComponent(name).standardizedFileURL
+        XCTAssertEqual(written.deletingLastPathComponent().path, filesDir.standardizedFileURL.path)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: written.path))
+        XCTAssertFalse(
+            FileManager.default.fileExists(
+                atPath: containerURL.appendingPathComponent("escaped.vcf").path
+            )
+        )
+    }
+
+    // MARK: - URL-vended attachments
+
+    func testMovieVendedAsURLIsCopied() throws {
+        let source = try tempFile("clip.mp4", movieBytes)
+        let descriptor = try save([urlProvider(source, .mpeg4Movie)])
+
+        XCTAssertEqual(descriptor.contentType, "VIDEO")
+        XCTAssertEqual(descriptor.mimeTypes, ["video/mp4"])
+        XCTAssertTrue(try XCTUnwrap(descriptor.fileNames.first).hasSuffix(".mp4"))
+        XCTAssertEqual(try writtenBytes(descriptor), movieBytes)
+    }
+
+    func testGenericFileVendedAsURLIsCopied() throws {
+        let source = try tempFile("contact.vcf", vcardBytes)
+        let descriptor = try save([urlProvider(source, .vCard)])
+
+        XCTAssertEqual(descriptor.contentType, "FILE")
+        XCTAssertEqual(descriptor.mimeTypes, ["text/vcard"])
+        XCTAssertTrue(try XCTUnwrap(descriptor.fileNames.first).hasSuffix(".vcf"))
+        XCTAssertEqual(try writtenBytes(descriptor), vcardBytes)
+    }
+
+    func testImageVendedAsURLIsCopied() throws {
+        let source = try tempFile("photo.png", pngBytes)
+        let descriptor = try save([urlProvider(source, .png)])
+
+        XCTAssertEqual(descriptor.contentType, "IMAGE")
+        XCTAssertEqual(descriptor.mimeTypes, ["image/png"])
+        XCTAssertTrue(try XCTUnwrap(descriptor.fileNames.first).hasSuffix(".png"))
+        XCTAssertEqual(try writtenBytes(descriptor), pngBytes)
+    }
+
+    func testImageVendedAsDataIsSniffedFromMagicBytes() throws {
+        let descriptor = try save([dataProvider(pngBytes, .png)])
+
+        XCTAssertEqual(descriptor.contentType, "IMAGE")
+        XCTAssertEqual(descriptor.mimeTypes, ["image/png"])
+        XCTAssertTrue(try XCTUnwrap(descriptor.fileNames.first).hasSuffix(".png"))
+        XCTAssertEqual(try writtenBytes(descriptor), pngBytes)
+    }
+
+    // MARK: - Helpers
+
+    private func save(
+        _ providers: [NSItemProvider],
+        text: String? = nil,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws -> SharedContentSaver.ContentDescriptor {
+        let item = NSExtensionItem()
+        item.attachments = providers
+        if let text {
+            item.attributedContentText = NSAttributedString(string: text)
+        }
+
+        var saved = false
+        let finished = expectation(description: "SharedContentSaver.save")
+        SharedContentSaver.save(
+            extensionContext: StubExtensionContext([item]),
+            conversationId: "conversation-under-test"
+        ) { success in
+            saved = success
+            finished.fulfill()
+        }
+        wait(for: [finished], timeout: 10)
+        XCTAssertTrue(saved, "save() reported failure", file: file, line: line)
+
+        return try JSONDecoder().decode(
+            SharedContentSaver.ContentDescriptor.self,
+            from: Data(contentsOf: descriptorURL)
+        )
+    }
+
+    private func writtenBytes(_ descriptor: SharedContentSaver.ContentDescriptor) throws -> Data {
+        let name = try XCTUnwrap(descriptor.fileNames.first)
+        return try Data(contentsOf: filesDir.appendingPathComponent(name))
+    }
+
+    private func dataProvider(
+        _ bytes: Data,
+        _ type: UTType,
+        suggestedName: String? = nil
+    ) -> NSItemProvider {
+        let provider = NSItemProvider(item: bytes as NSData, typeIdentifier: type.identifier)
+        provider.suggestedName = suggestedName
+        return provider
+    }
+
+    private func urlProvider(_ url: URL, _ type: UTType) -> NSItemProvider {
+        NSItemProvider(item: url as NSURL, typeIdentifier: type.identifier)
+    }
+
+    private func tempFile(_ name: String, _ bytes: Data) throws -> URL {
+        let url = tempDir.appendingPathComponent(name)
+        try bytes.write(to: url)
+        return url
+    }
+}


### PR DESCRIPTION
Fixes #1263.

## The defect

`SharedContentSaver.save` handled an attachment vended as a file `URL` in the movie
and generic-file branches, and nothing else. A sender that registers its
`NSItemProvider` with in-memory `Data` fell through both `if let … as? URL` checks and
the item was dropped: `fileNames` stayed empty, so with accompanying text the file
silently vanished, and without it `hasSendableContent()` returned false and the user
got the "Couldn't read the shared content" error from #1097.

The image branch already grew this exact `Data` arm (#854), for the same reason.

## The fix

An `else if let data = item as? Data` arm on the movie and generic branches, both
routed through one `writeData` helper.

**Filename and extension.** The bytes are written under the same
`share_<millis>_<rand>.<ext>` name that `copyFile` already produces for the URL path,
so the same file shared as `Data` or as a `URL` lands identically. Only the
*extension* is derived from the provider, in this order:

1. the extension of `provider.suggestedName`, when it has one;
2. the first entry in `provider.registeredTypeIdentifiers` that conforms to the
   branch's type and has a `preferredFilenameExtension` — this is what turns
   `public.vcard` into `vcf`, and therefore `text/vcard`;
3. a per-branch literal fallback.

Step 3 is not decorative: `UTType.movie.preferredFilenameExtension` and
`UTType.data.preferredFilenameExtension` are both `nil` (verified on the iOS 26.5 UTI
database), so an abstract-only provider has no extension to offer. The movie branch
falls back to `mov` rather than something generic so the descriptor still classifies
as `VIDEO`; the generic branch falls back to `dat`, which resolves to
`application/octet-stream` — the honest answer for bytes of unknown type.

Only the extension is taken from `suggestedName`, never the whole name: it is
cross-process input, and `appendingPathComponent` on an attacker-chosen string would
let `../` escape the container. Keeping the generated name also avoids two attachments
with the same suggested name colliding inside `shared_files/`.

`mimeTypeForExtension` then fills `mimeTypes`, which is what `SharedVCardDetector`
keys off (`isVCardMime(mimeTypes.first)` or a `.vcf` suffix — both hold).

## Verification

The issue notes the author could not reproduce this. It now reproduces, on a
simulator, and the fix is verified end to end there.

The share sheet's activation rule was the obstacle: no stock app vends a shareable
`Data` item to this extension, so a throwaway sender app was used to present a
`UIActivityViewController` over `NSItemProvider`s of controlled shapes. Which shapes
actually reach the extension (iPhone 17, iOS 26.5):

| attachment | Homebase offered? |
| --- | --- |
| plain `String` | yes |
| file URL to a `.vcf` | yes |
| `Data` as `public.png` | yes |
| `Data` as `public.mpeg-4` | yes |
| `Data` as `public.vcard` | no |
| `Data` as `public.data` | no |
| `registerFileRepresentation` + `registerDataRepresentation`, `public.vcard` | no |

`NSExtensionActivationSupportsImageWithMaxCount` and
`…SupportsMovieWithMaxCount` activate on the type alone, so a `Data`-vended image or
movie does reach `save()`. That is why #854 had to handle `Data` for images, and it
means the **movie** branch's gap was reachable and live.
`…SupportsFileWithMaxCount` appears to want a real file URL, so the generic branch is
harder to reach from a `UIActivityViewController` sender; its `Data` arm is included
because the branch is the fallback for everything and should not silently drop bytes
it was handed.

**End to end**, sharing MP4 bytes vended as `Data` and reading the App Group
afterwards:

Before (`main`) — attachment dropped, and with no text the share is unsendable:

```json
{"targetConversationId":"…","mimeTypes":[],"fileNames":[],"contentType":"TEXT"}
```
`shared_files/` empty.

After:

```json
{"targetConversationId":"…","contentType":"VIDEO","mimeTypes":["video/mp4"],
 "fileNames":["share_1787045614005_5514.mp4"]}
```
`shared_files/share_1787045614005_5514.mp4`, 72 bytes — byte-exact with what was sent.

The hand-off URL scheme was removed from the installed app for this run so the picker's
Send could exercise `save()` without the main app waking up and posting a real message.

**Unit level**, a harness compiled the real `SharedContentSaver.swift` (both revisions,
unmodified) against genuine `NSItemProvider`s and drove `save()` to completion. Nine
cases, three consecutive repeats, all stable:

| case | before | after |
| --- | --- | --- |
| `.vcf` `Data`, suggestedName `Ada Vance.vcf` | dropped | `FILE` / `text/vcard` |
| `.vcf` `Data`, no suggestedName | dropped | `FILE` / `text/vcard` |
| `Data` registered `public.data` only | dropped | `FILE` / `application/octet-stream`, `.dat` |
| `Data` registered `public.mpeg-4` | dropped | `VIDEO` / `video/mp4` |
| `Data` registered `public.movie` | dropped | `VIDEO` / `video/quicktime`, `.mov` |
| text + `.vcf` `Data` | text only, file lost | `MIXED`, both kept |
| file URL through the generic branch | works | unchanged |
| PNG `Data` through the image branch | works | unchanged |
| plain text | works | unchanged |

The predicate readout from those runs also confirms the issue's UTI analysis:
`public.vcard` reports `url=false plainText=false image=false movie=false data=true`,
so it does land in the generic branch.

`xcodebuild -target ShareExtension` is clean for both the Debug and Dev
configurations against the iphonesimulator SDK, no errors or warnings.

**Committed as tests.** That harness now lives in the repo as
`iosApp/iosAppTests/SharedContentSaverTests.swift` — twelve cases driving the real
`save()` against genuine `NSItemProvider`s through a stubbed `NSExtensionContext`,
asserting on the descriptor written to the App Group. `SharedContentSaver.swift` was
added to the `iosAppTests` target's compile sources to reach it; the target is hosted by
`Homebase.app`, so the App Group entitlement the saver needs is present.

Against the pre-fix saver, eight of the twelve fail with exactly the dropped-attachment
signature (`contentType` `TEXT`, empty `mimeTypes`/`fileNames`); the four URL and
image-`Data` cases are regression guards and pass either way. Coverage includes the
`suggestedName` hardening (a `../`-laden name yields a single-component filename inside
`shared_files/`) and both literal fallbacks, each pinned by an assertion that the
abstract type really does offer no `preferredFilenameExtension`.

No CI job compiles `iosApp/` today, so these run locally or in Xcode:

```
xcodebuild test -project iosApp/iosApp.xcodeproj -scheme iosApp \
  -destination 'platform=iOS Simulator,name=iPhone 17' \
  -only-testing:iosAppTests/SharedContentSaverTests
```

## Noticed, not fixed here

`save()` writes the descriptor with `try? jsonData.write(to:)` and then calls
`completion(true)` unconditionally, so a failed descriptor write is reported as
success and the caller opens the main app on a share that was never staged. Unrelated
to this change; worth its own issue.

