### PR TITLE
fix(location): pin the emergency-locate sheet while its request is in flight

### DIFF
--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/EmergencyLocateSheet.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/EmergencyLocateSheet.kt
@@ -73,7 +73,7 @@ fun EmergencyLocateSheet(
     var ambush by remember { mutableStateOf(false) }
     var windowMenuOpen by remember { mutableStateOf(false) }
 
-    AdaptiveSheet(onDismiss = { if (!submitting) onDismiss() }) {
+    AdaptiveSheet(onDismiss = onDismiss, dismissible = !submitting) {
         Column(
             modifier = Modifier
                 .verticalScroll(rememberScrollState())

--- a/homebase-core/src/jvmTest/kotlin/id/homebase/core/ui/screens/location/EmergencyLocateSheetDismissTest.kt
+++ b/homebase-core/src/jvmTest/kotlin/id/homebase/core/ui/screens/location/EmergencyLocateSheetDismissTest.kt
@@ -18,12 +18,8 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.uuid.Uuid
 
-/**
- * Phone-width only: `ModalBottomSheet` hides itself *before* it asks whether it may, so a caller
- * that refuses inside `onDismissRequest` keeps a sheet that has already animated away, over a
- * dialog window that still eats every touch. The wide branch is a plain `Dialog` and cannot
- * reach that state, so these run at a forced compact size.
- */
+// Forced compact size: the wide branch is a plain Dialog and cannot reach the bug, so these pass
+// against broken code at the default 1024x768.
 @OptIn(ExperimentalTestApi::class)
 class EmergencyLocateSheetDismissTest {
 
@@ -53,7 +49,6 @@ class EmergencyLocateSheetDismissTest {
         waitForIdle()
     }
 
-    /** The scrim above the sheet, in the sheet's own window — the last root the scene put up. */
     private fun SkikoComposeUiTest.tapAboveTheSheet() {
         onAllNodes(isRoot()).onLast().performTouchInput {
             click(Offset(width / 2f, 4f))

--- a/homebase-core/src/jvmTest/kotlin/id/homebase/core/ui/screens/location/EmergencyLocateSheetDismissTest.kt
+++ b/homebase-core/src/jvmTest/kotlin/id/homebase/core/ui/screens/location/EmergencyLocateSheetDismissTest.kt
@@ -1,0 +1,87 @@
+package id.homebase.core.ui.screens.location
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.SkikoComposeUiTest
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.click
+import androidx.compose.ui.test.isRoot
+import androidx.compose.ui.test.onLast
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.runSkikoComposeUiTest
+import id.homebase.api.common.OdinId
+import id.homebase.chat.data.ContactUiModel
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.uuid.Uuid
+
+/**
+ * Phone-width only: `ModalBottomSheet` hides itself *before* it asks whether it may, so a caller
+ * that refuses inside `onDismissRequest` keeps a sheet that has already animated away, over a
+ * dialog window that still eats every touch. The wide branch is a plain `Dialog` and cannot
+ * reach that state, so these run at a forced compact size.
+ */
+@OptIn(ExperimentalTestApi::class)
+class EmergencyLocateSheetDismissTest {
+
+    private val compactPhone = Size(400f, 800f)
+
+    private val title = "Emergency location request"
+
+    private val contact = ContactUiModel(
+        id = Uuid.random(),
+        odinId = OdinId("ada.example.com"),
+        name = "Ada Vance",
+        avatarInitials = "AV",
+    )
+
+    private fun SkikoComposeUiTest.showSheet(submitting: Boolean, onDismiss: () -> Unit) {
+        setContent {
+            MaterialTheme {
+                EmergencyLocateSheet(
+                    contact = contact,
+                    lastPointAgeMs = null,
+                    submitting = submitting,
+                    onDismiss = onDismiss,
+                    onConfirm = { _, _, _ -> },
+                )
+            }
+        }
+        waitForIdle()
+    }
+
+    /** The scrim above the sheet, in the sheet's own window — the last root the scene put up. */
+    private fun SkikoComposeUiTest.tapAboveTheSheet() {
+        onAllNodes(isRoot()).onLast().performTouchInput {
+            click(Offset(width / 2f, 4f))
+        }
+        waitForIdle()
+    }
+
+    @Test
+    fun `a tap outside mid-submit leaves the sheet on screen`() =
+        runSkikoComposeUiTest(size = compactPhone) {
+            var dismissals = 0
+            showSheet(submitting = true) { dismissals++ }
+
+            onNodeWithText(title).assertIsDisplayed()
+            tapAboveTheSheet()
+
+            onNodeWithText(title).assertIsDisplayed()
+            assertEquals(0, dismissals)
+        }
+
+    @Test
+    fun `a tap outside while idle dismisses`() =
+        runSkikoComposeUiTest(size = compactPhone) {
+            var dismissals = 0
+            showSheet(submitting = false) { dismissals++ }
+
+            tapAboveTheSheet()
+
+            assertEquals(1, dismissals)
+        }
+}


### PR DESCRIPTION
Fixes #1267.

## Root cause

The sheet was never "kept open by a state flag that didn't reset" and no one-time event was lost — the ViewModel side is already correct. `LocationViewModel.confirmEmergencyLocate` sets `locateSubmitInFlight` in `_uiState.update {}`, clears it in a `finally`, and emits its terminal outcome on the `MutableSharedFlow` `events` (`OpenPeerHistory` / `LocateFetchFailed`), which `LocationScreen` collects to clear `pendingLocate`. Both service calls it awaits swallow non-cancellation exceptions and return a result type, so an event always arrives.

The defect is entirely in how the call site refused the dismissal:

```kotlin
AdaptiveSheet(onDismiss = { if (!submitting) onDismiss() })
```

On compact widths `AdaptiveSheet` renders a `ModalBottomSheet`, and M3 hides the sheet **before** it consults `onDismissRequest` — verified against the `material3` 1.9.0 sources this project resolves:

- `animateToDismiss` (`ModalBottomSheet.kt:151-161`) — `hide()`, then `onDismissRequest()` in `invokeOnCompletion`. Its only gate is `anchoredDraggableState.confirmValueChange(Hidden)`, which defaults to accepting.
- `settleToDismiss` (`:162-166`) — `settle()`, then `onDismissRequest()`, ungated.
- the back path (`:181`) — `hide()`, then `onDismissRequest()`, ungated.
- the scrim (`:187-192`) routes to `animateToDismiss`, and the drag handle carries an **unconditional** `Modifier.clickable { … animateToDismiss() }` at `:386` — only the `.semantics` block below it is guarded by `sheetGesturesEnabled`.

So a scrim tap, swipe, back press or handle tap while `submitting == true` hid the sheet for good. Nothing brings it back: `LaunchedEffect(sheetState) { sheetState.show() }` (`:213`) is keyed on the state remembered at the call site, and that call site stays composed because `pendingLocate` is still non-null.

The consequence is worse than an invisible sheet. `ModalBottomSheet` is a real `Dialog` window sized `MATCH_PARENT`, and it is touch-modal — so for the whole duration of the send + history fetch, an undrawn window sat on top of the app swallowing every touch and the back key.

### Evidence (Redmi Note 5 Pro, Android 11, `id.homebase.feed.debug`)

Driven with a temporary local-only patch that opens the sheet with a synthetic contact and pins `submitting`, so nothing was ever sent and no account data was touched. Reverted before commit.

Before, after one scrim tap: the screen shows only the dashboard, but `describe` still returns the entire sheet —

```
View "Close sheet" [clickable]  (0.000, 0.000, 1.000, 0.500)
View "Drag handle" [clickable,long-clickable]  (0.439, 0.500, 0.122, 0.062)
StaticText "Emergency location request" ...
```

`dumpsys window windows` shows two `id.homebase.feed.debug/MainActivity` windows with `mCurrentFocus` on the upper, undrawn one. Three back presses and a bottom-nav tap did nothing — the app was soft-locked.

After: the `Close sheet` scrim node is gone (`shouldDismissOnClickOutside = false`), and a scrim tap + swipe-down + drag-handle tap + back press in sequence all leave the sheet fully on screen. With `submitting = false` the scrim node returns, one tap dismisses, and `describe` goes back to the real dashboard tree.

## Fix

```kotlin
AdaptiveSheet(onDismiss = onDismiss, dismissible = !submitting)
```

`AdaptiveSheet` already grew `dismissible` for the contact-card save sheet under #1262. It threads through to `sheetGesturesEnabled`, `ModalBottomSheetProperties(shouldDismissOnBackPress, shouldDismissOnClickOutside)` and an identity-stable `confirmValueChange` that refuses `Hidden` — which is what closes the drag-handle tap the other three do not cover. The wide branch (`Dialog`) is declarative and was never affected, but takes the same flag.

## Tests

`EmergencyLocateSheetDismissTest` (`homebase-core/src/jvmTest`). It uses `runSkikoComposeUiTest(size = Size(400f, 800f))` rather than plain `runComposeUiTest`, because the default 1024×768 test window lands on the wide `Dialog` branch, where the bug cannot occur.

- `a tap outside mid-submit leaves the sheet on screen` — **fails on the unfixed call site** with `Assert failed: The component with Text … contains 'Emergency location request' … is not displayed!`, passes with the fix.
- `a tap outside while idle dismisses` — passes both ways, so the fix cannot degenerate into pinning the sheet permanently.

`:homebase-core:compileKotlinJvm`, `:homebase-core:jvmTest` and `:homebase-common:jvmTest` are green (113 test classes, 0 failures).

## Left out deliberately

The same shape survives at three raw `ModalBottomSheet` call sites that do not go through `AdaptiveSheet` — `ConnectRequestBottomSheet.kt` (`if (!state.isSending)`), `GroupSettingsScreen.kt:905` (`if (sheet.finished)`) and `GuardedComposerSheet.kt:61` (the discard-confirm path). They are separate surfaces with no coverage here; widening this commit would repeat the mistake #1267 was filed to avoid. Worth a follow-up issue.
