### PR TITLE
Stop an offline cold start throwing out of an add-on's drive activation

### DIFF
--- a/desktopApp/src/jvmMain/kotlin/id/homebase/app/Main.kt
+++ b/desktopApp/src/jvmMain/kotlin/id/homebase/app/Main.kt
@@ -297,7 +297,8 @@ private fun setupCrashHandler() {
                     "Transient network failure"
                 }
                 "$kind leaked to '${thread.name}' (no local handler); " +
-                    "app not crashing: ${throwable.message}"
+                    "app not crashing: ${throwable.message}\n" +
+                    throwable.stackTraceToString()
             }
             return@setDefaultUncaughtExceptionHandler
         }

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/auth/AuthConnectionCoordinator.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/auth/AuthConnectionCoordinator.kt
@@ -648,7 +648,10 @@ class AuthConnectionCoordinator(
      * it locally) — persisting again would just churn the file with the same content.
      */
     suspend fun mountDrive(drive: LabeledDrive, persist: Boolean = true) {
-        if (persist) driveRegistry.addDrive(drive)
+        // Best-effort: an add-on activating during an offline cold start still mounts locally
+        // (and re-registers on a later activation) instead of throwing out of the caller's
+        // viewModelScope, which carries no CoroutineExceptionHandler.
+        if (persist) driveRegistry.addDriveBestEffort(drive)
         val owner = drive.ownerOdinId
         val newlyMounted = driveSyncManager.mountDrive(drive.drive.alias, drive.label, owner)
         if (!newlyMounted) {

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/auth/AuthConnectionCoordinator.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/auth/AuthConnectionCoordinator.kt
@@ -648,9 +648,7 @@ class AuthConnectionCoordinator(
      * it locally) — persisting again would just churn the file with the same content.
      */
     suspend fun mountDrive(drive: LabeledDrive, persist: Boolean = true) {
-        // Best-effort: an add-on activating during an offline cold start still mounts locally
-        // (and re-registers on a later activation) instead of throwing out of the caller's
-        // viewModelScope, which carries no CoroutineExceptionHandler.
+        // Must not throw: callers activate add-ons from a viewModelScope with no handler.
         if (persist) driveRegistry.addDriveBestEffort(drive)
         val owner = drive.ownerOdinId
         val newlyMounted = driveSyncManager.mountDrive(drive.drive.alias, drive.label, owner)

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/sync/DriveRegistry.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/sync/DriveRegistry.kt
@@ -16,6 +16,7 @@ import id.homebase.api.client.drives.upload.UploadFileMetadata
 import id.homebase.api.client.drives.upload.UploadFileRequest
 import id.homebase.api.client.eventbus.BackendEvent
 import id.homebase.api.client.eventbus.EventBus
+import id.homebase.api.client.isTransientNetworkFailure
 import id.homebase.api.crypto.ByteArrayUtil
 import id.homebase.api.serialization.OdinSystemSerializer
 import id.homebase.api.sync.database.DatabaseManager
@@ -283,6 +284,24 @@ class DriveRegistry(
         updateRegistry { current ->
             if (current.any { it.drive.alias == drive.drive.alias }) current
             else current + drive
+        }
+    }
+
+    /**
+     * [addDrive] where a transport failure is logged instead of thrown — the cold-start case
+     * where the identity host has no DNS yet. [drive] stays out of the cross-device list until
+     * a later activation re-registers it; every other failure still propagates.
+     */
+    suspend fun addDriveBestEffort(drive: LabeledDrive) {
+        try {
+            addDrive(drive)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Throwable) {
+            if (!e.isTransientNetworkFailure()) throw e
+            Logger.w(tag = TAG, throwable = e) {
+                "addDrive(${drive.label}) hit a transport failure — not registered this session"
+            }
         }
     }
 

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/sync/DriveRegistry.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/sync/DriveRegistry.kt
@@ -287,11 +287,8 @@ class DriveRegistry(
         }
     }
 
-    /**
-     * [addDrive] where a transport failure is logged instead of thrown — the cold-start case
-     * where the identity host has no DNS yet. [drive] stays out of the cross-device list until
-     * a later activation re-registers it; every other failure still propagates.
-     */
+    // Transport failure only: the drive stays out of the cross-device list until a later
+    // activation re-registers it. Every other failure still propagates.
     suspend fun addDriveBestEffort(drive: LabeledDrive) {
         try {
             addDrive(drive)

--- a/homebase-common/src/jvmTest/kotlin/id/homebase/core/sync/DriveRegistryTest.kt
+++ b/homebase-common/src/jvmTest/kotlin/id/homebase/core/sync/DriveRegistryTest.kt
@@ -1,6 +1,7 @@
 package id.homebase.core.sync
 
 import id.homebase.api.client.ClientException
+import id.homebase.api.client.NetworkException
 import id.homebase.api.client.OdinClientErrorCode
 import id.homebase.api.client.ProblemDetails
 import id.homebase.api.client.auth.ApiCredentials
@@ -25,6 +26,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
+import java.nio.channels.UnresolvedAddressException
 import kotlin.io.encoding.Base64
 import kotlin.io.encoding.ExperimentalEncodingApi
 import kotlin.test.Test
@@ -239,6 +241,56 @@ class DriveRegistryTest {
 
         assertFailsWith<ClientException> {
             registry.addDrive(feedLabeledDrive)
+        }
+        db.close()
+    }
+
+    /**
+     * The offline cold start: the read-before-write can't reach the identity host. Ktor CIO
+     * surfaces that as `UnresolvedAddressException` — an `IllegalArgumentException`, not an
+     * `IOException` — wrapped by the API layer into [NetworkException]. `mountDrive` calls
+     * this variant so the throw can't escape an add-on ViewModel's handler-less
+     * `viewModelScope` and reach the platform uncaught handler.
+     */
+    @Test
+    fun addDriveBestEffortSwallowsOfflineTransportFailure() = runTest {
+        val db = createTestDatabaseManager()
+        val recorder = WriteRecorder(
+            fetchResolver = { throw NetworkException(UnresolvedAddressException()) },
+        )
+        val registry = buildRegistry(db, recorder = recorder)
+
+        registry.addDriveBestEffort(feedLabeledDrive)
+
+        assertTrue(recorder.uploads.isEmpty(), "nothing should have been written")
+        assertTrue(recorder.updates.isEmpty(), "nothing should have been written")
+        db.close()
+    }
+
+    /** Same, for a path that reaches the registry without the API layer's wrap. */
+    @Test
+    fun addDriveBestEffortSwallowsRawCioConnectFailure() = runTest {
+        val db = createTestDatabaseManager()
+        val registry = buildRegistry(
+            db,
+            recorder = WriteRecorder(fetchResolver = { throw UnresolvedAddressException() }),
+        )
+
+        registry.addDriveBestEffort(feedLabeledDrive)
+
+        db.close()
+    }
+
+    @Test
+    fun addDriveBestEffortPropagatesNonTransportFailures() = runTest {
+        val db = createTestDatabaseManager()
+        val recorder = WriteRecorder(
+            uploadErrorOnCall = { OdinClientErrorCode.UnhandledScenario },
+        )
+        val registry = buildRegistry(db, recorder = recorder)
+
+        assertFailsWith<ClientException> {
+            registry.addDriveBestEffort(feedLabeledDrive)
         }
         db.close()
     }

--- a/homebase-common/src/jvmTest/kotlin/id/homebase/core/sync/DriveRegistryTest.kt
+++ b/homebase-common/src/jvmTest/kotlin/id/homebase/core/sync/DriveRegistryTest.kt
@@ -245,13 +245,8 @@ class DriveRegistryTest {
         db.close()
     }
 
-    /**
-     * The offline cold start: the read-before-write can't reach the identity host. Ktor CIO
-     * surfaces that as `UnresolvedAddressException` — an `IllegalArgumentException`, not an
-     * `IOException` — wrapped by the API layer into [NetworkException]. `mountDrive` calls
-     * this variant so the throw can't escape an add-on ViewModel's handler-less
-     * `viewModelScope` and reach the platform uncaught handler.
-     */
+    // CIO throws UnresolvedAddressException, an IllegalArgumentException — a catch on IOException
+    // misses it.
     @Test
     fun addDriveBestEffortSwallowsOfflineTransportFailure() = runTest {
         val db = createTestDatabaseManager()


### PR DESCRIPTION
Fixes #1279.

## What was actually happening

The issue could not name the crashing call site — the stack is entirely Ktor/coroutine frames. It is now named, from a real reproduction. **Both** uncaught throws per run (the issue reported exactly 2, ~0.9s apart) come from the same shape:

```
MomentsViewModel$1.invokeSuspend(MomentsViewModel.kt:62)          <- viewModelScope.launch, no CEH
  MomentsViewModel$1$2.emit(MomentsViewModel.kt:70)               <- optionalDriveActivation.activate(...)
    AuthConnectionCoordinator.mountDrive(AuthConnectionCoordinator.kt:651)
      DriveRegistry.updateRegistry(DriveRegistry.kt:402)
        DriveFileProvider.getFileHeaderByUid(DriveFileProvider.kt:137)   <- HTTP
          java.nio.channels.UnresolvedAddressException
```

```
LocationViewModel$3.invokeSuspend(LocationViewModel.kt:174)       <- viewModelScope.launch, no CEH
  LocationViewModel$3$2.emit(LocationViewModel.kt:182)            <- optionalDriveActivation.activate(...)
    AuthConnectionCoordinator.mountDrive(AuthConnectionCoordinator.kt:651)
      ... identical from here
```

An add-on that auto-activates at launch (Moments and Location both do, off a `permissionsGranted` collector) calls `AuthConnectionCoordinator.mountDrive` on the bare `viewModelScope` — `Dispatchers.Main.immediate`, no `CoroutineExceptionHandler`, no try/catch. `mountDrive`'s **first** statement is `driveRegistry.addDrive(drive)`, and `addDrive`'s read-before-write (`getFileHeaderByUid`) is an HTTP GET to the identity host. With no DNS yet, CIO throws `UnresolvedAddressException`, `OdinApiProviderBase.networkCall` wraps it in `NetworkException`, and nothing between there and the JVM's uncaught handler catches it. That matches the issue's diagnosis exactly: `StandaloneCoroutine` on `Dispatchers.Main.immediate` with no CEH, and no `OdinApiProviderBase` frame in the *outer* trace.

Two consequences, not one:

1. **The crash.** On the reported build (2026-06-21) this killed the process. On current `main` it no longer does — `isConnectTimeNetworkType()` (added 2026-06-29, after that build) makes the desktop `Thread.setDefaultUncaughtExceptionHandler` contain it — but the unguarded path is still there, and on any scope/platform without that containment it is still fatal.
2. **A silent functional bug.** Because the registry write threw *before* the local mount, the add-on did not mount at all on an offline launch, and the collector's one-shot `activationKicked` latch was already set — so it never retried for the rest of the session.

## The fix

`mountDrive` now registers **best-effort**: `DriveRegistry.addDriveBestEffort` logs a transport failure instead of throwing, so the drive still mounts locally and re-registers on a later activation. Non-transport failures (auth, server errors, bugs) still propagate unchanged — the catch is keyed on the existing `isTransientNetworkFailure()` predicate, not on `Throwable`.

This is one seam covering every add-on: Moments, Location, Vault and Stickers all reach the network through `OptionalDriveActivation.activate` -> `mountDrive`.

The desktop containment path in `Main.kt` also now logs `throwable.stackTraceToString()`. It previously recorded only `throwable.message`, which is how a framework-only trace stayed unattributable — that one line is what made the two call sites above readable. (Logged as text, not via Kermit's `throwable` parameter, so it is not double-recorded as a non-fatal alongside `crashlyticsRecordException`.)

## How it was reproduced

Process-local DNS blackout via a temporary JDK 18+ `java.net.spi.InetAddressResolverProvider` registered in `desktopApp`'s `META-INF/services`, failing every lookup while a flag file exists. No machine DNS or Wi-Fi was touched, and deleting the flag file mid-run restores resolution so recovery can be observed in the same process. The harness is not part of this PR.

Attribution came from running that build with `-ea -Dkotlinx.coroutines.debug=on`, which turns on kotlinx stack-trace recovery — `NetworkException(Throwable)` is copyable, so the recovered trace carries the suspend call chain with app frames. Also not part of this PR.

## Before / after

Same offline cold start, same identity, same machine.

**Before** (current `main`, 2 uncaught per run — the issue reports 2):

```
Warn: (CrashHandler) Transient network failure leaked to 'AWT-EventQueue-0 @coroutine#221' (no local handler); app not crashing: Network failure: UnresolvedAddressException
Warn: (CrashHandler) Transient network failure leaked to 'AWT-EventQueue-0 @coroutine#249' (no local handler); app not crashing: Network failure: UnresolvedAddressException
```

`grep -c "Transient network failure leaked"` -> **2**

**After**:

```
Warn: (DriveRegistry) addDrive(Moments) hit a transport failure — not registered this session
Warn: (DriveRegistry) addDrive(Location) hit a transport failure — not registered this session
```

`grep -c "Transient network failure leaked"` -> **0**

Then deleting the flag file, in the same process:

```
Info: (WebSocket) WS[1] handshake successful
Info: (AuthLifecycle) AuthCC: onConnected fired for WS[1]
```

## Tests

`DriveRegistryTest` gains three cases: the wrapped `NetworkException(UnresolvedAddressException)` is swallowed with nothing written, a raw `UnresolvedAddressException` (a path reaching the registry without the API layer's wrap) is swallowed too, and a `ClientException` still propagates.

No Android regression: `NetworkExceptionTest` and `CioOfflineConnectTest` are untouched and green — the OkHttp `UnknownHostException` shape still classifies transient, and a plain `IllegalArgumentException` still stays fatal.

Green: `:homebase-common:jvmTest` (37 in `DriveRegistryTest`, 0 failures), `:homebase-api:jvmTest`, `:homebase-common:compileAndroidMain`, `:homebase-common:compileKotlinIosSimulatorArm64`, `:desktopApp:compileKotlinJvm`.

## Not done here

The issue's direction 1 ("every scope that can make a network call needs a CEH") is a broader architectural sweep. This PR fixes the two paths that actually fire, at their shared cause. Two adjacent latent traps found while looking and left alone: `DesktopViewModel`'s update-check loop and `AppViewModel.checkForUpdate` both run unguarded on `viewModelScope`, and `JvmUpdateAppManager` only catches `UpdateCheckException` — neither threw in this reproduction.
