### PR TITLE
investigate(desktop): Windows + → File crash — why a try/catch can't catch it and why the FileKit fix is blocked (#1276)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -72,6 +72,8 @@ cryptography = "0.5.0"
 robolectric = "4.16.1"
 navigation = "2.9.2"
 koin = "4.2.1"
+# Held at 0.13.0: 0.14.2+ publishes klibs with abi_version 2.4.0, unreadable by Kotlin 2.3.x.
+# Bumping needs the Kotlin 2.4 upgrade first, or every Kotlin/Native target fails to resolve.
 filekit = "0.13.0"
 androidx-work = "2.11.2"
 atomicfu = "0.32.1"


### PR DESCRIPTION
Investigation for #1276 (Windows desktop `+ → File` crash). **The root cause is still unconfirmed** and this PR deliberately ships **no fix** — only a two-line note in the version catalog recording a hard blocker I hit, plus the findings below.

I could not reproduce: the host is macOS, the crash is on a packaged Windows MSIX (.1543), and the crash stack in the issue is truncated before its `Caused by:`.

## 1. A try/catch at the launch site cannot intercept this crash

This was the requested defensive fix. It does not work, for two independent reasons — both verified against the exact dependency versions this project resolves.

**`CoroutinesInternalError` is never thrown up a call stack.** In kotlinx-coroutines 1.10.2, `DispatchedTask.run()` catches the throwable and calls `handleFatalException(e)`, which does:

```kotlin
val reason = CoroutinesInternalError("Fatal exception in coroutines machinery for $this…", exception)
handleCoroutineException(this.delegate.context, reason)
```

`handleCoroutineException` routes to the context's `CoroutineExceptionHandler` or falls through to `propagateExceptionFinalResort`, which on JVM is `Thread.currentThread().uncaughtExceptionHandler.uncaughtException(...)`. It is **delivered as a callback, never propagated**, so no `try`/`catch` anywhere in our code can see it.

**Nothing at the launch site is catchable anyway.** `PickerResultLauncher.launch()` in FileKit 0.13.0 is fire-and-forget:

```kotlin
PickerResultLauncher {
    coroutineScope.launch {
        val result = FileKit.openFilePicker(...)
        currentMode.consumeResult(result, currentOnConsumed)
    }
}
```

`launch()` returns as soon as the coroutine is dispatched. Any exception from the picker surfaces inside FileKit's own coroutine, not in the caller's frame.

**Consequence worth noting on its own:** that coroutine comes from `rememberCoroutineScope()`, which has no `CoroutineExceptionHandler`. So *any* picker failure escapes to `Thread.uncaughtExceptionHandler` → `setupCrashHandler` in `desktopApp/src/jvmMain/kotlin/id/homebase/app/Main.kt` → `CrashRecoveryDialog.showAndBlock` → the app dies. On Desktop, a failing file picker is **structurally fatal today**, and there is no hook on 0.13.0 to change that.

Wrapping `fileLauncher.launch()` in a `try`/`catch` would have caught nothing while looking like protection — the anti-pattern CLAUDE.md calls out. So it is not in this PR.

## 2. The packaging hypothesis is refuted

- The shipped Windows artifact is built by **Conveyor (MSIX)**, not jpackage. `TargetFormat.Msi` is declared but never invoked — every workflow runs on ubuntu/macos runners, and `build-desktop-release-*.yml` runs `conveyor ... make site` over `machines = [ windows.amd64, ... ]` (`desktopApp/conveyor_common.conf:18`).
- The Conveyor Gradle plugin resolves `jvmRuntimeClasspath` and emits the **full transitive graph** into `app.inputs`. `net.java.dev.jna:jna` / `jna-platform` 5.18.1 arrive transitively via `filekit-dialogs` and are bundled on all five machines; `extract-native-libraries = true` is set (`conveyor_common.conf:35`).
- Consistent with the crash stack, which shows no `UnsatisfiedLinkError` / `NoClassDefFoundError`.

Incidental finding: JNA reaches desktop only through the `filekit` redeclarations in `homebase-core`/`homebase-common`. `jvmJarWindowsX64` is an artifact-only configuration (no `extendsFrom`) and `desktopApp` excludes `homebase-chat`, so dropping those redeclarations would break the Windows picker at runtime.

## 3. FileKit 0.13.0 has a real threading defect — but we cannot adopt the fix

In 0.13.0, `platformOpenFilePicker` (JVM) has **no dispatcher hop**, so `PlatformFilePicker.current` — the `by lazy` that constructs `WindowsFilePicker` and triggers JNA/COM class loading — initialises on the **caller's dispatcher**, i.e. Compose Desktop's `FlushCoroutineDispatcher`. That is the exact dispatcher named in the crash. (`openDirectoryPicker` and `openFileSaver` in the same file *do* hop to `Dispatchers.IO`; the file picker was simply missed.)

Upstream fixed precisely this in **0.14.2** — "Fixed JVM file picker work executing off main thread to prevent blocking Compose Desktop apps" — by adding `= withContext(Dispatchers.IO)`. **0.15.0** adds more ("Windows file dialogs on a dedicated STA thread with proper COM initialization") plus `onError` callbacks that would finally make a picker failure non-fatal.

**Both are unusable here.** Their Kotlin/Native klibs are built with `abi_version=2.4.0` / `compiler_version=2.4.x`, and this project is on Kotlin 2.3.21. Every Kotlin/Native target fails at KLIB resolution:

```
e: KLIB resolver: Could not find ".../filekit-dialogs-compose-iosSimulatorArm64Main.klib"
```

Verified as a control: iOS compiles at 0.13.0 and fails at 0.14.2 and 0.15.0. The klibs are intact zips — it is an ABI floor, not a bad download. **So closing #1276 via a FileKit bump is gated on upgrading the project to Kotlin 2.4.** That is what the version-catalog comment in this PR records, so the next person does not spend the same day on it.

## What is still needed

Posted on the issue: the untruncated `crash-*.txt`, and whether **Image/gallery** also crashes on Windows or only **File**. Note `CrashReporting.writeReport` uses `throwable.stackTraceToString()`, so the on-disk file already contains the full `Caused by:` chain — the truncation is in the paste, not the reporter.

## Verified

- `:homebase-chat:compileKotlinJvm`, `:homebase-core:compileKotlinJvm`, `:homebase-chat:compileAndroidMain`, `:homebase-core:compileAndroidMain` — green
- `homebase-chat:jvmTest`, `homebase-common:jvmTest` — green
- `:homebase-api:compileKotlinIosSimulatorArm64` — green at 0.13.0 (the control above)
- `./gradlew desktopApp:run` on macOS — app boots fully (session restored, `FileKit.init` fine). The picker happy path could **not** be exercised interactively: a pre-existing desktop instance holds the `SingleInstanceManager` lock and I did not kill the user's running app.

Closes nothing. Leaves #1276 open.
