### PR TITLE
fix(chat): gate a contact card's avatar on your contact book, not on who sent it (#1284)

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/contactcard/ContactCardBubble.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/contactcard/ContactCardBubble.kt
@@ -80,7 +80,6 @@ fun ContactCardBubble(
     onLongClick: (() -> Unit)? = null,
     canOpenDetail: Boolean = true,
     authorOdinId: String? = null,
-    sentByYou: Boolean = false,
     photo: HomebaseImageData? = null,
     footer: (@Composable () -> Unit)? = null,
 ) {
@@ -140,7 +139,6 @@ fun ContactCardBubble(
                     descriptor = descriptor,
                     size = 44.dp,
                     authorOdinId = authorOdinId,
-                    sentByYou = sentByYou,
                     photo = photo,
                 )
                 Spacer(Modifier.width(12.dp))
@@ -227,7 +225,6 @@ fun ContactCardBubble(
         ContactCardDetailDialog(
             descriptor = descriptor,
             authorOdinId = authorOdinId,
-            sentByYou = sentByYou,
             photo = photo,
             onDismiss = { showDetail = false },
             // Close first: the editor is hosted above the nav graph and this dialog would outlive it.
@@ -253,7 +250,6 @@ internal fun ContactCardAvatar(
     descriptor: ContactCardDescriptor,
     size: Dp,
     authorOdinId: String?,
-    sentByYou: Boolean,
     photo: HomebaseImageData? = null,
 ) {
     val initials = remember(descriptor) { descriptor.avatarInitials() }
@@ -277,9 +273,10 @@ internal fun ContactCardAvatar(
 
     // An identity publishes its avatar at a URL derived from the odinId, so the card shows a real
     // picture without the descriptor carrying one — nothing would fit in the 7 KB header anyway.
-    // Gated on the sender: see ContactCardDescriptor.avatarIdentity.
-    val identity = remember(descriptor, authorOdinId, sentByYou) {
-        descriptor.avatarIdentity(authorOdinId, sentByYou)
+    // Gated: see ContactCardDescriptor.avatarIdentity.
+    val savedContacts = LocalSavedContactIdentities.current
+    val identity = remember(descriptor, authorOdinId, savedContacts) {
+        descriptor.avatarIdentity(authorOdinId, savedContacts)
     }
     if (identity != null) {
         Box(modifier = Modifier.clearAndSetSemantics {}) {

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/contactcard/ContactCardBubble.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/contactcard/ContactCardBubble.kt
@@ -273,7 +273,6 @@ internal fun ContactCardAvatar(
 
     // An identity publishes its avatar at a URL derived from the odinId, so the card shows a real
     // picture without the descriptor carrying one — nothing would fit in the 7 KB header anyway.
-    // Gated: see ContactCardDescriptor.avatarIdentity.
     val savedContacts = LocalSavedContactIdentities.current
     val identity = remember(descriptor, authorOdinId, savedContacts) {
         descriptor.avatarIdentity(authorOdinId, savedContacts)

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/contactcard/ContactCardDescriptor.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/contactcard/ContactCardDescriptor.kt
@@ -54,22 +54,20 @@ data class ContactCardDescriptor(
      *
      * Drawing the avatar dials `https://<odinId>/pub/image`, and any client can author a card
      * naming any host — so an ungated fetch is a tracking pixel: open the chat and the named host
-     * learns your IP and the moment you read it. Two cases disclose nothing new:
+     * learns your IP and the moment you read it. Only hosts this app already dials on the same
+     * screens resolve:
      *
-     * - [author] (the envelope's `originalAuthor`, which the card's author cannot forge) equals the
-     *   card's identity: the sender already knows their message reached you.
-     * - [sentByYou]: you picked this contact out of your own book, so it is a host you already
-     *   resolve in the contact list.
+     * - [author] — the envelope's `originalAuthor`, which the card's author cannot forge. Their
+     *   avatar is already drawn beside their own messages in a group and in the 1:1 header.
+     * - a member of [savedContacts] — the contact list already draws their avatar.
      *
-     * Ceiling: a card you *forwarded* rather than composed counts as [sentByYou] but was named by
-     * its original sender. Gating on "is already one of my contacts" would close that too, at the
-     * cost of a contact lookup per bubble.
+     * Empty [savedContacts] therefore denies, which is what a host that supplies nothing gets.
      *
      * Saving has no equivalent gate: this one exists because the bubble fetches without being asked.
      */
-    fun avatarIdentity(author: String?, sentByYou: Boolean = false): OdinId? =
+    fun avatarIdentity(author: String?, savedContacts: Set<OdinId> = emptySet()): OdinId? =
         identity()?.takeIf {
-            sentByYou || it.domainName.equals(author?.trim(), ignoreCase = true)
+            it.domainName.equals(author?.trim(), ignoreCase = true) || it in savedContacts
         }
 
     fun isValid(): Boolean {

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/contactcard/ContactCardDescriptor.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/contactcard/ContactCardDescriptor.kt
@@ -49,22 +49,8 @@ data class ContactCardDescriptor(
     fun identity(): OdinId? =
         odinId.trim().ifBlank { null }?.let { runCatching { OdinId(it) }.getOrNull() }
 
-    /**
-     * The identity whose avatar this card may fetch, or null to fall back to initials.
-     *
-     * Drawing the avatar dials `https://<odinId>/pub/image`, and any client can author a card
-     * naming any host — so an ungated fetch is a tracking pixel: open the chat and the named host
-     * learns your IP and the moment you read it. Only hosts this app already dials on the same
-     * screens resolve:
-     *
-     * - [author] — the envelope's `originalAuthor`, which the card's author cannot forge. Their
-     *   avatar is already drawn beside their own messages in a group and in the 1:1 header.
-     * - a member of [savedContacts] — the contact list already draws their avatar.
-     *
-     * Empty [savedContacts] therefore denies, which is what a host that supplies nothing gets.
-     *
-     * Saving has no equivalent gate: this one exists because the bubble fetches without being asked.
-     */
+    // Ungated, this is a tracking pixel: any client can author a card naming any host, and drawing
+    // its avatar dials that host. Only hosts already dialled on the same screens resolve.
     fun avatarIdentity(author: String?, savedContacts: Set<OdinId> = emptySet()): OdinId? =
         identity()?.takeIf {
             it.domainName.equals(author?.trim(), ignoreCase = true) || it in savedContacts

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/contactcard/ContactCardDetailDialog.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/contactcard/ContactCardDetailDialog.kt
@@ -89,7 +89,6 @@ fun ContactCardDetailDialog(
     onSaveToContacts: ((ContactCardDescriptor) -> Unit)? = null,
     onMessageIdentity: ((String) -> Unit)? = null,
     authorOdinId: String? = null,
-    sentByYou: Boolean = false,
     photo: HomebaseImageData? = null,
 ) {
     Dialog(
@@ -102,7 +101,6 @@ fun ContactCardDetailDialog(
             onSaveToContacts = onSaveToContacts,
             onMessageIdentity = onMessageIdentity,
             authorOdinId = authorOdinId,
-            sentByYou = sentByYou,
             photo = photo,
         )
     }
@@ -116,7 +114,6 @@ private fun ContactCardDetailContent(
     onSaveToContacts: ((ContactCardDescriptor) -> Unit)?,
     onMessageIdentity: ((String) -> Unit)?,
     authorOdinId: String?,
-    sentByYou: Boolean,
     photo: HomebaseImageData?,
 ) {
     val uriHandler = LocalUriHandler.current
@@ -197,7 +194,6 @@ private fun ContactCardDetailContent(
                     descriptor = descriptor,
                     size = 72.dp,
                     authorOdinId = authorOdinId,
-                    sentByYou = sentByYou,
                     photo = photo,
                 )
                 Spacer(Modifier.width(16.dp))

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/contactcard/LocalSavedContactIdentities.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/contactcard/LocalSavedContactIdentities.kt
@@ -1,0 +1,7 @@
+package id.homebase.chat.contactcard
+
+import androidx.compose.runtime.compositionLocalOf
+import id.homebase.api.common.OdinId
+
+// Empty denies: a host that renders a card without providing this gets initials, not a fetch.
+val LocalSavedContactIdentities = compositionLocalOf<Set<OdinId>> { emptySet() }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiState.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiState.kt
@@ -154,7 +154,6 @@ data class MessageListUiState(
      *  viewer) don't re-scroll. */
     val scrollToLatestRequest: Uuid? = null,
     val awaitingJumpMessageId: Uuid? = null,
-    /** Contact-book identities, published to the bubbles as [id.homebase.chat.contactcard.LocalSavedContactIdentities]. */
     val savedContactIdentities: Set<OdinId> = emptySet(),
 )
 

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiState.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiState.kt
@@ -154,6 +154,8 @@ data class MessageListUiState(
      *  viewer) don't re-scroll. */
     val scrollToLatestRequest: Uuid? = null,
     val awaitingJumpMessageId: Uuid? = null,
+    /** Contact-book identities, published to the bubbles as [id.homebase.chat.contactcard.LocalSavedContactIdentities]. */
+    val savedContactIdentities: Set<OdinId> = emptySet(),
 )
 
 /**

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
@@ -886,7 +886,6 @@ class ConversationListViewModel(
                 }
         }
 
-        // Whose avatar a contact-card bubble is allowed to dial; see ContactCardDescriptor.
         viewModelScope.launch {
             contactService.contacts
                 .map { contacts -> contacts.mapTo(mutableSetOf()) { it.odinId } }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
@@ -886,6 +886,16 @@ class ConversationListViewModel(
                 }
         }
 
+        // Whose avatar a contact-card bubble is allowed to dial; see ContactCardDescriptor.
+        viewModelScope.launch {
+            contactService.contacts
+                .map { contacts -> contacts.mapTo(mutableSetOf()) { it.odinId } }
+                .distinctUntilChanged()
+                .collect { identities ->
+                    _messagesUiState.update { it.copy(savedContactIdentities = identities) }
+                }
+        }
+
         // Set connected state
         viewModelScope.launch {
             authConnectionCoordinator.connectionState

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
@@ -119,6 +119,7 @@ import id.homebase.api.util.truncateToCodePoints
 import id.homebase.chat.data.MessageUiModel
 import kotlinx.collections.immutable.ImmutableList
 import id.homebase.api.common.OdinId
+import id.homebase.chat.contactcard.LocalSavedContactIdentities
 import id.homebase.chat.conversationlist.AutoConnectRowState
 import id.homebase.chat.conversationlist.ConversationListUiAction
 import co.touchlab.kermit.Logger
@@ -718,6 +719,7 @@ fun ConversationContent(
     CompositionLocalProvider(
         LocalCurrentOdinId provides (uiState.ownerSession?.odinId?.domainName ?: ""),
         LocalUploadConnected provides uiState.isConnected,
+        LocalSavedContactIdentities provides uiState.savedContactIdentities,
     ) {
     Scaffold(
         modifier = Modifier,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubbleRaw.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubbleRaw.kt
@@ -259,7 +259,6 @@ fun MessageBubbleRaw(
                 canOpenDetail = !displayOnly,
                 // From the envelope, not the card: the card's own odinId is attacker-controlled.
                 authorOdinId = message.originalAuthor?.domainName,
-                sentByYou = sentByYou,
                 photo = cardPhoto,
                 footer = {
                     MessageTimestampFooter(

--- a/homebase-chat/src/commonTest/kotlin/id/homebase/chat/contactcard/ContactCardValuesTest.kt
+++ b/homebase-chat/src/commonTest/kotlin/id/homebase/chat/contactcard/ContactCardValuesTest.kt
@@ -323,8 +323,6 @@ class ContactCardValuesTest {
         )
     }
 
-    // The common case, and the one an author-only gate silently turned into a no-op: you share a
-    // contact out of your own book, so the host is one you already resolve in the contact list.
     @Test
     fun `a card naming someone in your book fetches whoever sent it`() {
         val card = card().copy(odinId = "todd.mitchell.demo.rocks")

--- a/homebase-chat/src/commonTest/kotlin/id/homebase/chat/contactcard/ContactCardValuesTest.kt
+++ b/homebase-chat/src/commonTest/kotlin/id/homebase/chat/contactcard/ContactCardValuesTest.kt
@@ -1,5 +1,6 @@
 package id.homebase.chat.contactcard
 
+import id.homebase.api.common.OdinId
 import id.homebase.chat.services.content.MessageContent
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -322,23 +323,26 @@ class ContactCardValuesTest {
         )
     }
 
-    // The common case, and the one a author-only gate silently turned into a no-op: you share a
+    // The common case, and the one an author-only gate silently turned into a no-op: you share a
     // contact out of your own book, so the host is one you already resolve in the contact list.
     @Test
-    fun `a card you sent yourself fetches whoever it names`() {
+    fun `a card naming someone in your book fetches whoever sent it`() {
         val card = card().copy(odinId = "todd.mitchell.demo.rocks")
+        val book = setOf(OdinId("todd.mitchell.demo.rocks"))
 
         assertEquals(
             "todd.mitchell.demo.rocks",
-            assertNotNull(card.avatarIdentity(author = "me.demo.rocks", sentByYou = true)).domainName,
+            assertNotNull(card.avatarIdentity(author = "me.demo.rocks", savedContacts = book))
+                .domainName,
         )
         assertNull(
-            card.avatarIdentity(author = "me.demo.rocks", sentByYou = false),
-            "Received from someone else, the same card must not resolve.",
+            card.avatarIdentity(author = "me.demo.rocks", savedContacts = emptySet()),
+            "Off your book, the same card must not resolve however it got here.",
         )
         assertNull(
-            card().copy(odinId = "not a domain").avatarIdentity(author = null, sentByYou = true),
-            "Sending it yourself does not make a non-identity into a host.",
+            card().copy(odinId = "not a domain")
+                .avatarIdentity(author = null, savedContacts = book),
+            "Having them in your book does not make a non-identity into a host.",
         )
     }
 
@@ -521,8 +525,8 @@ class ContactCardValuesTest {
     fun `the avatar of a card someone else sent is not fetched`() {
         val hostile = card().copy(odinId = "tracker.evil.tld")
 
-        assertNull(hostile.avatarIdentity(author = "friend.demo.rocks", sentByYou = false))
-        assertNull(hostile.avatarIdentity(author = null, sentByYou = false))
+        assertNull(hostile.avatarIdentity(author = "friend.demo.rocks"))
+        assertNull(hostile.avatarIdentity(author = null))
     }
 
     @Test
@@ -531,11 +535,14 @@ class ContactCardValuesTest {
 
         assertEquals(
             "samwise.gamgee.demo.rocks",
-            own.avatarIdentity(author = "samwise.gamgee.demo.rocks", sentByYou = false)?.domainName,
+            own.avatarIdentity(author = "samwise.gamgee.demo.rocks")?.domainName,
         )
         assertEquals(
             "samwise.gamgee.demo.rocks",
-            own.avatarIdentity(author = null, sentByYou = true)?.domainName,
+            own.avatarIdentity(
+                author = null,
+                savedContacts = setOf(OdinId("samwise.gamgee.demo.rocks")),
+            )?.domainName,
         )
     }
 

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/contactcard/ContactCardAvatarFetchTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/contactcard/ContactCardAvatarFetchTest.kt
@@ -37,14 +37,8 @@ import kotlin.test.assertTrue
 import kotlin.time.Instant
 import kotlin.uuid.Uuid
 
-/**
- * What a contact card is allowed to dial.
- *
- * Rendering an identity avatar issues `GET https://<odinId>/pub/image`, and the odinId comes off a
- * card any client may have authored — so the assertions here are on the Coil requests the render
- * actually produces, not on what the tree looks like. Both avatar branches clear their semantics,
- * so a screen-level assertion cannot tell a fetch from initials at all.
- */
+// Asserts on Coil requests, not on the tree: both avatar branches clear their semantics, so a
+// screen-level assertion cannot tell a fetch from initials.
 @OptIn(ExperimentalTestApi::class, ExperimentalSharedTransitionApi::class)
 class ContactCardAvatarFetchTest {
 
@@ -54,8 +48,6 @@ class ContactCardAvatarFetchTest {
 
     private val requested = CopyOnWriteArrayList<Any>()
 
-    // Records what the render asked for and fails every request: nothing here needs pixels, and a
-    // real fetch would leave the test dependent on the network.
     private val recorder = Interceptor { chain ->
         requested += chain.request.data
         ErrorResult(null, chain.request, UnsupportedOperationException("recorded"))
@@ -133,8 +125,6 @@ class ContactCardAvatarFetchTest {
 
     @Test
     fun `a card you sent naming someone off your book dials nobody`() = runComposeUiTest {
-        // The forwarded card: authored by you, but the identity on it was chosen by whoever sent
-        // it to you first.
         renderBubble(card(stranger), authorOdinId = me.domainName)
 
         assertEquals(emptyList(), publicImageHosts())
@@ -202,9 +192,8 @@ class ContactCardAvatarFetchTest {
         assertEquals(emptyList(), publicImageHosts())
     }
 
-    // Through MessageItem, not the bubble: the book crosses ConversationContent -> MessageItem ->
-    // MessageBubble -> MessageBubbleRaw to reach the avatar, and a direct bubble call cannot see a
-    // layer that swallows the CompositionLocal.
+    // Through MessageItem, not the bubble: a direct bubble call cannot see a layer that swallows
+    // the CompositionLocal.
     @Test
     fun `the book reaches a card rendered in the stream`() = runComposeUiTest {
         setContent {

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/contactcard/ContactCardAvatarFetchTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/contactcard/ContactCardAvatarFetchTest.kt
@@ -1,0 +1,280 @@
+package id.homebase.chat.contactcard
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.animation.SharedTransitionLayout
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.runComposeUiTest
+import coil3.ImageLoader
+import coil3.PlatformContext
+import coil3.Uri
+import coil3.intercept.Interceptor
+import coil3.request.ErrorResult
+import com.russhwolf.settings.PreferencesSettings
+import id.homebase.api.client.KeyHeader
+import id.homebase.api.common.OdinId
+import id.homebase.api.common.SecureByteArray
+import id.homebase.chat.data.MessageUiModel
+import id.homebase.chat.services.MessageAppData
+import id.homebase.chat.services.content.MessageContent
+import id.homebase.chat.widget.MessageItem
+import id.homebase.core.image.HomebaseImageData
+import id.homebase.core.settings.UserPreferences
+import id.homebase.core.ui.theme.HomebaseTheme
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.persistentMapOf
+import org.koin.compose.KoinIsolatedContext
+import org.koin.dsl.koinApplication
+import org.koin.dsl.module
+import java.util.prefs.Preferences
+import java.util.concurrent.CopyOnWriteArrayList
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.time.Instant
+import kotlin.uuid.Uuid
+
+/**
+ * What a contact card is allowed to dial.
+ *
+ * Rendering an identity avatar issues `GET https://<odinId>/pub/image`, and the odinId comes off a
+ * card any client may have authored — so the assertions here are on the Coil requests the render
+ * actually produces, not on what the tree looks like. Both avatar branches clear their semantics,
+ * so a screen-level assertion cannot tell a fetch from initials at all.
+ */
+@OptIn(ExperimentalTestApi::class, ExperimentalSharedTransitionApi::class)
+class ContactCardAvatarFetchTest {
+
+    private val me = OdinId("me.demo.rocks")
+    private val stranger = "tracker.evil.tld"
+    private val friend = "samwise.gamgee.demo.rocks"
+
+    private val requested = CopyOnWriteArrayList<Any>()
+
+    // Records what the render asked for and fails every request: nothing here needs pixels, and a
+    // real fetch would leave the test dependent on the network.
+    private val recorder = Interceptor { chain ->
+        requested += chain.request.data
+        ErrorResult(null, chain.request, UnsupportedOperationException("recorded"))
+    }
+
+    private val preferences =
+        UserPreferences(PreferencesSettings(Preferences.userRoot().node("/id/homebase/test")))
+
+    private val koin = koinApplication {
+        modules(
+            module {
+                single { preferences }
+                single {
+                    ImageLoader.Builder(PlatformContext.INSTANCE)
+                        .components { add(recorder) }
+                        .build()
+                }
+            },
+        )
+    }
+
+    private fun card(odinId: String) = ContactCardDescriptor(
+        displayName = "Ada Vance",
+        phones = listOf("+14155550123"),
+        odinId = odinId,
+    )
+
+    private val photo = HomebaseImageData(
+        driveId = Uuid.random(),
+        fileId = Uuid.random(),
+        payloadKey = "chat_web0",
+        keyHeader = KeyHeader(iv = ByteArray(16), aesKey = SecureByteArray(ByteArray(16))),
+    )
+
+    @Composable
+    private fun Host(savedContacts: Set<OdinId>, content: @Composable () -> Unit) {
+        KoinIsolatedContext(koin) {
+            HomebaseTheme(darkTheme = false) {
+                CompositionLocalProvider(
+                    LocalSavedContactIdentities provides savedContacts,
+                    content = content,
+                )
+            }
+        }
+    }
+
+    private fun ComposeUiTest.renderBubble(
+        descriptor: ContactCardDescriptor,
+        authorOdinId: String?,
+        savedContacts: Set<OdinId> = emptySet(),
+        photo: HomebaseImageData? = null,
+    ) {
+        setContent {
+            Host(savedContacts) {
+                ContactCardBubble(
+                    descriptor = descriptor,
+                    authorOdinId = authorOdinId,
+                    photo = photo,
+                )
+            }
+        }
+        waitForIdle()
+    }
+
+    private fun publicImageHosts(): List<String> = requested.mapNotNull { data ->
+        val url = when (data) {
+            is String -> data
+            is Uri -> data.toString()
+            else -> return@mapNotNull null
+        }
+        url.takeIf { it.contains("/pub/image") }
+            ?.removePrefix("https://")
+            ?.substringBefore("/pub/image")
+    }
+
+    @Test
+    fun `a card you sent naming someone off your book dials nobody`() = runComposeUiTest {
+        // The forwarded card: authored by you, but the identity on it was chosen by whoever sent
+        // it to you first.
+        renderBubble(card(stranger), authorOdinId = me.domainName)
+
+        assertEquals(emptyList(), publicImageHosts())
+    }
+
+    @Test
+    fun `a card naming a saved contact dials that contact`() = runComposeUiTest {
+        renderBubble(
+            card(friend),
+            authorOdinId = stranger,
+            savedContacts = setOf(OdinId(friend)),
+        )
+
+        assertEquals(listOf(friend), publicImageHosts())
+    }
+
+    @Test
+    fun `a card received from a stranger naming a third party dials nobody`() = runComposeUiTest {
+        renderBubble(card(friend), authorOdinId = stranger)
+
+        assertEquals(emptyList(), publicImageHosts())
+    }
+
+    @Test
+    fun `a card its own subject sent dials them, book or no book`() = runComposeUiTest {
+        renderBubble(card(friend), authorOdinId = friend)
+
+        assertEquals(listOf(friend), publicImageHosts())
+    }
+
+    @Test
+    fun `a card carrying a photo draws it without dialing the identity it names`() =
+        runComposeUiTest {
+            renderBubble(card(stranger), authorOdinId = me.domainName, photo = photo)
+
+            assertEquals(emptyList(), publicImageHosts())
+            assertTrue(
+                requested.any { it is HomebaseImageData },
+                "The payload bytes are already on the message; drawing them dials nobody.",
+            )
+        }
+
+    @Test
+    fun `a card with no identity dials nobody, however full the book is`() = runComposeUiTest {
+        renderBubble(
+            card(""),
+            authorOdinId = friend,
+            savedContacts = setOf(OdinId(friend), OdinId(stranger)),
+        )
+
+        assertEquals(emptyList(), publicImageHosts())
+    }
+
+    @Test
+    fun `a host that provides no book gets no fetch`() = runComposeUiTest {
+        setContent {
+            KoinIsolatedContext(koin) {
+                HomebaseTheme(darkTheme = false) {
+                    ContactCardBubble(descriptor = card(friend), authorOdinId = null)
+                }
+            }
+        }
+        waitForIdle()
+
+        assertEquals(emptyList(), publicImageHosts())
+    }
+
+    // Through MessageItem, not the bubble: the book crosses ConversationContent -> MessageItem ->
+    // MessageBubble -> MessageBubbleRaw to reach the avatar, and a direct bubble call cannot see a
+    // layer that swallows the CompositionLocal.
+    @Test
+    fun `the book reaches a card rendered in the stream`() = runComposeUiTest {
+        setContent {
+            Host(setOf(OdinId(friend))) {
+                SharedTransitionLayout {
+                    AnimatedVisibility(visible = true) {
+                        MessageItem(
+                            message = message(author = me, card = card(friend)),
+                            userDefaultReactions = persistentListOf(),
+                            decryptedFiles = persistentMapOf(),
+                            currentOdinId = me.domainName,
+                            animatedVisibilityScope = this@AnimatedVisibility,
+                            sharedTransitionScope = this@SharedTransitionLayout,
+                            onUiAction = {},
+                            downloadingFiles = emptySet(),
+                        )
+                    }
+                }
+            }
+        }
+        waitForIdle()
+
+        assertEquals(listOf(friend), publicImageHosts())
+    }
+
+    @Test
+    fun `a card you sent in the stream naming a stranger dials nobody`() = runComposeUiTest {
+        setContent {
+            Host(emptySet()) {
+                SharedTransitionLayout {
+                    AnimatedVisibility(visible = true) {
+                        MessageItem(
+                            message = message(author = me, card = card(stranger)),
+                            userDefaultReactions = persistentListOf(),
+                            decryptedFiles = persistentMapOf(),
+                            currentOdinId = me.domainName,
+                            animatedVisibilityScope = this@AnimatedVisibility,
+                            sharedTransitionScope = this@SharedTransitionLayout,
+                            onUiAction = {},
+                            downloadingFiles = emptySet(),
+                        )
+                    }
+                }
+            }
+        }
+        waitForIdle()
+
+        assertEquals(emptyList(), publicImageHosts())
+    }
+
+    private fun message(author: OdinId?, card: ContactCardDescriptor) = MessageUiModel(
+        id = Uuid.random(),
+        globalTransitId = null,
+        fileId = Uuid.random(),
+        conversationId = Uuid.random(),
+        content = "",
+        userDate = Instant.fromEpochMilliseconds(0),
+        modified = null,
+        created = Instant.fromEpochMilliseconds(0),
+        originalAuthor = author,
+        sender = author,
+        displayName = "Ada Vance",
+        messageAppData = MessageAppData(),
+        reactionPreview = null,
+        previewThumbnail = null,
+        payloads = null,
+        keyHeader = KeyHeader(iv = ByteArray(16), aesKey = SecureByteArray(ByteArray(16))),
+        versionTag = Uuid.random(),
+        isPendingSend = false,
+        hasMore = false,
+        messageContent = MessageContent.ContactCard(card),
+    )
+}


### PR DESCRIPTION
Closes #1284.

## The ceiling this closes

`avatarIdentity(author, sentByYou)` let a card resolve when **you** were its sender. A card you *forwarded* rather than composed counts as `sentByYou`, but the identity on it was chosen by whoever sent it to you first — so a hostile card could still reach `https://<odinId>/pub/image` if it persuaded you to forward it and then look at your own copy.

`sentByYou` is replaced by membership of the contact book:

```kotlin
fun avatarIdentity(author: String?, savedContacts: Set<OdinId> = emptySet()): OdinId? =
    identity()?.takeIf {
        it.domainName.equals(author?.trim(), ignoreCase = true) || it in savedContacts
    }
```

The single principle is now **the app must not issue a request to a host it doesn't already contact on the same screens**, and both arms satisfy it:

- **the envelope author** — unforgeable by the card's author, and already dialed: `MessageBubble.kt:569` renders `PublicAvatar(message.originalAuthor)` beside every message in a group, and `ConversationAvatar` → `PublicAvatar` does it in a 1:1. Keeping this arm discloses nothing the open conversation hasn't already disclosed, and it's what makes "someone shares their own card with you" work.
- **a saved contact** — the contact list already draws their avatar through the same `/pub/image` URL.

Empty set denies. That is also the `CompositionLocal` default, so a host that provides nothing renders initials rather than fetching.

## Where the check lives, and why

The issue says the contact book lives in `:homebase-core`, which is true of the *screens* but not of the data. `ContactService` — including the `contactByOdinId` map the issue points at — is in **`:homebase-chat`** (`id.homebase.chat.services.convo.contact`), and it derives from `ContactRepository` in **`:homebase-api`**, which `:homebase-chat` already depends on. **No dependency inversion is needed and none was added.**

So the answer is available in `:homebase-chat`, and the question became *how* it reaches `ContactCardAvatar` — six composables below `ConversationContent`. Two options:

- **`koinInject<ContactService>()` inside the avatar.** There's precedent (`EventDetailDialog.kt:158`), but it makes a leaf widget carry a hidden global dependency and needs a Koin graph in every test that renders a bubble.
- **State down from the ViewModel, ambient at the host** — chosen. `ConversationListViewModel` already holds `contactService` and already calls `start()`; it publishes the identity set on `MessageListUiState`, and `ConversationContent` provides it beside the two locals it already provides (`LocalCurrentOdinId`, `LocalUploadConnected`). That keeps the gate a pure function of its inputs, matches the repo's stated MVVM shape, and lets the tests hand the bubble a book directly.

Parameter threading was rejected: it would touch six signatures that already take 20–30 parameters, purely to carry one ambient fact.

**"Already a contact" means an identity-bearing row in the Contacts drive.** `Contact.toContactUiModel()` returns null for a contact with no `odinId`, so `ContactService.contacts` *is* the identity set — a vCard-only contact can never widen the gate. Since #1265 a saved card keeps its odinId, so saving a card is what turns its avatar on, which is the behaviour the acceptance criteria ask for.

**Conversation participants were considered and left out** (the issue's "worth checking"). For a member who has posted, they're already covered — `MessageBubble.kt:569` dials them unconditionally. For a *silent* group member it would be a genuinely new disclosure, and "has posted in the loaded window" is not a property worth encoding. Acceptance bullet 1 ("a received card naming a non-contact renders initials, whoever sent it") reads against admitting them.

## Tests

`ContactCardAvatarFetchTest` (new, jvmTest) asserts on the **Coil requests the render actually issues**, via a recording `Interceptor` on a Koin-supplied `ImageLoader`. Screen-level assertions cannot work here: both avatar branches sit under `clearAndSetSemantics {}`, so the tree cannot tell a fetch from initials.

| case | `/pub/image` |
|---|---|
| you sent it, identity off your book (the forwarded card) | none |
| card names a saved contact | `https://<contact>/pub/image` |
| received from a stranger, names a third party | none |
| card's own subject sent it | `https://<author>/pub/image` |
| card carries a `chat_web0` photo | none — the payload is requested instead |
| card names no identity, book full | none |
| host provides no book at all | none |

The last two rows also run through `MessageItem`, so a layer that swallowed the `CompositionLocal` between `ConversationContent` and the avatar would fail rather than pass quietly.

**Efficacy checked, not just safety.** With `avatarIdentity` temporarily reduced to `identity()` (ungated), 4 of the 9 tests fail — the "dials nobody" rows are detecting a real request, not a pipeline that never runs. The positive rows passing is what proves the recorder sees real traffic.

`ContactCardValuesTest` keeps its pure-logic matrix, retargeted off `sentByYou`.

## Device verification — Redmi Note 5 Pro, Android 11 AOSP

`androidApp:installDebug` → `id.homebase.feed.debug` v1.4.1505 (never `id.homebase.feed`). Evidence channel is `HttpIO` in `files/logs/homebase.log`, which logs the request line for every `/pub/image` GET. Coil is configured with `.diskCache(null)`, so the only cache in front is `homebase-public-images-v2`; that was cleared and the app force-stopped before the run, so an absent GET means an absent fetch.

- The channel is live: the conversation list and the contact book produced 11 distinct `<identity>/pub/image` GETs during the same session.
- Opening a conversation holding five contact-card bubbles — one of which carries the identity `samwisegamgee.me` — produced **zero** `/pub/image` requests, and the identity-bearing card still drew its real photo. That is the payload (`chat_web0`) short-circuit ahead of the gate: **the photo path is not gated by this change.** Confirmed by the detail dialog, which shows the Homebase ID row while the log stays empty.
- The cards rendering initials were confirmed to carry no odinId (their detail view has no Homebase ID row), so the empty log is not an artefact of nothing having an identity to fetch.

**Not verified on device:** the card→fetch positive and the forwarded-non-contact negative. Reproducing either needs a card naming an identity that is *not* in the book, or an identity card with no photo payload; this account has neither, and creating one means sending a chat message. Both are covered by `ContactCardAvatarFetchTest`, including the efficacy probe above.
