### PR TITLE
Web two pane layout

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListScreen.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListScreen.kt
@@ -66,7 +66,7 @@ import id.homebase.core.connections.ConnectRequestViewModel
 import id.homebase.core.localization.TranslationUtil
 import id.homebase.core.ui.theme.HomebaseTheme
 import id.homebase.core.util.getUriHandler
-import id.homebase.core.util.isDesktop
+import id.homebase.core.util.isExpandedLayout
 import id.homebase.core.widget.DialogButtons
 import id.homebase.core.widget.DialogCard
 import id.homebase.core.widget.DialogText
@@ -764,7 +764,7 @@ fun ConversationListUi(
 ) {
     val windowAdaptiveInfo = currentWindowAdaptiveInfo()
     val defaultDirective = calculatePaneScaffoldDirective(windowAdaptiveInfo)
-    val isExpanded = isDesktop() &&  windowAdaptiveInfo.windowSizeClass.isWidthAtLeastBreakpoint(800)
+    val isExpanded = isExpandedLayout()
     val scaffoldDirective = PaneScaffoldDirective(
         maxHorizontalPartitions = if (isExpanded) 2 else 1,
         horizontalPartitionSpacerSize = 0.dp, // Remove the white border
@@ -866,7 +866,7 @@ fun ConversationListUi(
         scope.launch {
             if (messagesUiState.fullScreenOverlay != null) {
                 onUiAction(ConversationListUiAction.CloseFullScreenOverlay)
-            } else if (!isDesktop()) {
+            } else if (!isExpanded) {
                 scaffoldNavigator.navigateBack(BackNavigationBehavior.PopUntilContentChange)
             }
         }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationListPane.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationListPane.kt
@@ -45,7 +45,6 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
-import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
@@ -62,7 +61,6 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.window.core.layout.WindowSizeClass
 import id.homebase.api.client.auth.initials
 import id.homebase.chat.conversationlist.ConversationListContentModel
 import id.homebase.chat.conversationlist.ConversationListContentState
@@ -72,6 +70,7 @@ import id.homebase.chat.data.ConversationState
 import id.homebase.core.avatars.AvatarOptions
 import id.homebase.core.avatars.OwnerAvatar
 import id.homebase.core.ui.assets.FeatherEdit
+import id.homebase.core.util.isExpandedLayout
 import id.homebase.core.widget.HomebaseVerticalScrollbar
 import id.homebase.core.widget.MinimalSearchTextField
 import id.homebase.resources.MR
@@ -101,10 +100,7 @@ fun ConversationListPane(
     onUiAction: (ConversationListUiAction) -> Unit,
     onConversationSelected: (conversationId: Uuid) -> Unit,
 ) {
-    val adaptiveInfo = currentWindowAdaptiveInfo()
-    val twoPaneWindow = adaptiveInfo.windowSizeClass.isWidthAtLeastBreakpoint(
-        WindowSizeClass.WIDTH_DP_EXPANDED_LOWER_BOUND
-    )
+    val twoPaneWindow = isExpandedLayout()
     val listState = rememberLazyListState()
     val focusRequesterNone = remember { FocusRequester() }
     val focusRequesterSearch = remember { FocusRequester() }

--- a/homebase-common/build.gradle.kts
+++ b/homebase-common/build.gradle.kts
@@ -89,6 +89,7 @@ kotlin {
             implementation(libs.jetbrains.compose.foundation)
             implementation(libs.jetbrains.compose.resources)
             implementation(libs.jetbrains.compose.material3)
+            implementation(libs.jetbrains.compose.material3.adaptive)
             implementation(libs.jetbrains.compose.material.icons.extended)
             implementation(libs.androidx.lifecycle.viewmodelCompose)
             implementation(libs.androidx.lifecycle.runtimeCompose)

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/util/AdaptiveLayout.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/util/AdaptiveLayout.kt
@@ -1,0 +1,15 @@
+package id.homebase.core.util
+
+import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
+import androidx.compose.runtime.Composable
+
+private const val ExpandedWidthBreakpointDp = 800
+
+/** Wide phones and tablets stay single-column: their touch targets and FAB placement
+ *  assume one viewport, so the split is limited to pointer-driven targets. */
+@Composable
+fun isExpandedLayout(): Boolean =
+    isDesktopOrWeb() &&
+        currentWindowAdaptiveInfo().windowSizeClass.isWidthAtLeastBreakpoint(
+            ExpandedWidthBreakpointDp
+        )

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentsScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentsScreen.kt
@@ -54,7 +54,6 @@ import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.VerticalDivider
 import androidx.compose.material3.rememberModalBottomSheetState
-import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
@@ -88,7 +87,6 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
 import coil3.compose.AsyncImage
-import androidx.window.core.layout.WindowSizeClass
 import id.homebase.api.client.auth.OwnerSession
 import id.homebase.api.client.auth.initials
 import id.homebase.api.common.OdinId
@@ -116,6 +114,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import id.homebase.core.util.isDesktop
+import id.homebase.core.util.isExpandedLayout
 import id.homebase.resources.MR
 import kotlin.time.Instant
 import kotlin.uuid.Uuid
@@ -199,15 +198,7 @@ fun MomentsScreen(
     // Self-renders only when the VM transitions to ShowDialog. No-op otherwise.
     ExtendPermissionDialog(viewModel = extendPermissionViewModel)
 
-    // Desktop wide-screen split: feed on the left, embedded detail pane on the
-    // right. Gated on `isDesktop()` so wide phones/tablets stay on the single
-    // column — the touch targets and FAB placement on mobile assume one
-    // viewport, and the chat module gates its split the same way.
-    val adaptiveInfo = currentWindowAdaptiveInfo()
-    val isWide = isDesktop() &&
-        adaptiveInfo.windowSizeClass.isWidthAtLeastBreakpoint(
-            WindowSizeClass.WIDTH_DP_EXPANDED_LOWER_BOUND
-        )
+    val isWide = isExpandedLayout()
 
     // Reels is omitted from the desktop view menu; coerce a persisted/synced Reels
     // preference to Timeline on desktop (wide or narrow window) so a pointer user

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentsScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentsScreen.kt
@@ -113,7 +113,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import id.homebase.core.util.isDesktop
+import id.homebase.core.util.isDesktopOrWeb
 import id.homebase.core.util.isExpandedLayout
 import id.homebase.resources.MR
 import kotlin.time.Instant
@@ -200,10 +200,9 @@ fun MomentsScreen(
 
     val isWide = isExpandedLayout()
 
-    // Reels is omitted from the desktop view menu; coerce a persisted/synced Reels
-    // preference to Timeline on desktop (wide or narrow window) so a pointer user
-    // never lands in the touch-first reels view with no menu entry to leave it.
-    val effectiveViewMode = if (isDesktop() && uiState.viewMode == MomentsViewMode.Reels) {
+    // Reels has no menu entry on pointer targets, so a persisted/synced Reels
+    // preference must be coerced or the user lands there with no way back out.
+    val effectiveViewMode = if (isDesktopOrWeb() && uiState.viewMode == MomentsViewMode.Reels) {
         MomentsViewMode.Timeline
     } else {
         uiState.viewMode
@@ -625,7 +624,7 @@ private fun MomentsFeedList(
     // Disabled on desktop: on a pointer-driven window the feed shouldn't start
     // playing videos on its own as the user scrolls — playback stays manual
     // (tap a card's play button, which sets playingMomentId via onToggleVideoPlay).
-    val feedAutoplayEnabled = !isDesktop()
+    val feedAutoplayEnabled = !isDesktopOrWeb()
     LaunchedEffect(listState, videoMomentIds, feedAutoplayEnabled) {
         if (!feedAutoplayEnabled) return@LaunchedEffect
         snapshotFlow {
@@ -1507,9 +1506,9 @@ private fun MomentsViewModeMenu(
                     onSelect(MomentsViewMode.Album)
                 },
             )
-            // Reels is a touch-first, full-screen vertical-swipe mode — omit it
-            // from the desktop menu so pointer users only see Timeline / Album.
-            if (!isDesktop()) {
+            // Reels is a touch-first, full-screen vertical-swipe mode — pointer
+            // targets only see Timeline / Album.
+            if (!isDesktopOrWeb()) {
                 MomentsViewModeMenuItem(
                     label = stringResource(MR.string.moments_view_reels),
                     icon = Icons.Outlined.Slideshow,


### PR DESCRIPTION
Running the app in a browser, chat stayed single-column no matter how wide the window
was — no conversation list on the left with the thread on the right the way desktop does.

## Cause

`ConversationListScreen.kt` gated its `ListDetailPaneScaffold` on `isDesktop() && width >= 800dp`.
`isDesktop()` is hardcoded `false` on wasm, so `maxHorizontalPartitions` was always 1 and the
width check never got a chance to run. Moments was gated the same way.

The app shell was already width-driven — `AppNavHost`'s navigation rail is a pure width check —
so chat and moments were the outliers.

## Approach

Rather than sprinkle `isDesktopOrWeb()` at each site, this adds one helper in `homebase-common`:

```kotlin
@Composable
fun isExpandedLayout(): Boolean =
    isDesktopOrWeb() && currentWindowAdaptiveInfo().windowSizeClass
        .isWidthAtLeastBreakpoint(ExpandedWidthBreakpointDp)
```

The expression was already duplicated in three places at two different breakpoints (800 in the
chat scaffold, 840 in both moments and the conversation list pane), so it was drifting. All three
now share one definition at 800dp.

Web belongs on the same side of this check as desktop: both are pointer-driven and freely
resizable. The width term still keeps wide phones and tablets on a single column, and a phone
browser is well under 800dp so it stays single-pane too.

## Changes

| Site | Before | After |
|---|---|---|
| `ConversationListScreen.kt:767` | `isDesktop() && >=800dp` | `isExpandedLayout()` |
| `ConversationListScreen.kt:869` | `BackHandler` on `!isDesktop()` | `!isExpanded` |
| `ConversationListPane.kt:104` | `>=840dp` (container color) | `isExpandedLayout()` |
| `MomentsScreen.kt:201` | `isDesktop() && >=840dp` | `isExpandedLayout()` |
| `MomentsScreen.kt:206` | Reels preference coerced to Timeline on desktop | `isDesktopOrWeb()` |
| `MomentsScreen.kt:628` | feed autoplay off on desktop | `isDesktopOrWeb()` |
| `MomentsScreen.kt:1512` | Reels hidden from desktop view menu | `isDesktopOrWeb()` |

## Behavior changes beyond web

- **The chat back handler is now layout-gated, not platform-gated.** It previously refused to pop
  the detail pane on desktop unconditionally; a desktop user who dragged the window below the
  breakpoint got a back gesture that did nothing. It now follows the layout you are actually in.
- **Moments splits at 800dp instead of 840dp.** Chat is unchanged at 800.
- **The 800–840dp band is no longer inconsistent in chat** — the scaffold was two-pane there while
  the list pane still painted its single-pane container color.

## Tradeoff worth a look

The three moments flags are gated on the platform, not the width, so a **phone browser** also loses
Reels and feed autoplay. `isWeb()` cannot distinguish a phone browser from a desktop one. This
matches what the existing `isDesktopOrWeb()` sites already do (Enter-to-send and the formatting
toolbar in `MessageInputBar`), so it is at least consistent — but autoplay in particular is the one
where a metered or battery-constrained browser tab argues the other way. Easy to move to a
width-based gate if reviewers prefer that.

## Not included

Hover affordances on message bubbles (reply / react / info) are still `isDesktop()`-gated, so a
mouse user in the browser does not get them. Real gap, separate and larger change.

## Testing

`homebase-common`, `homebase-chat`, `homebase-core` compile on JVM, wasmJs, Android and
iosSimulatorArm64. `:homebase-common:jvmTest` and `:homebase-chat:jvmTest` pass, including the
Konsist architecture test.

Pre-existing and unrelated: `:homebase-chat:compileTestKotlinIosSimulatorArm64` fails on
`VCardParserTest.kt:165` (`Name contains illegal characters: ","`). Confirmed identical on `main`
with these changes stashed.

Not yet exercised in a running browser — worth a `./gradlew webApp:wasmJsBrowserDevelopmentRun
--no-configuration-cache` and a window drag across the 800px line before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
