### PR TITLE
Fix main: drop test arguments removed by #1293

### DIFF
--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/video/FfmpegCompressPlannerTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/video/FfmpegCompressPlannerTest.kt
@@ -299,9 +299,6 @@ class FfmpegCompressPlannerTest {
                 quality = VideoQuality.STANDARD,
                 trimStartMs = trim.first, trimEndMs = trim.second,
                 probedWidthPx = 1920, probedHeightPx = 1080,
-                probedCodecMime = "video/avc",
-                inputDurationMs = 10_000L, inputBytes = 10_000_000L,
-                probedBitDepth = 8, probedIsHdr = false,
             )
             val idx = plan.args.indexOf("-map_metadata")
             assertTrue(idx >= 0, "must strip source metadata; args=${plan.args}")

--- a/homebase-upload/src/jvmTest/kotlin/id/homebase/upload/PayloadBundleImageScrubTest.kt
+++ b/homebase-upload/src/jvmTest/kotlin/id/homebase/upload/PayloadBundleImageScrubTest.kt
@@ -28,7 +28,6 @@ class PayloadBundleImageScrubTest {
             fileOps = fileOps,
             videoProcessor = VideoPayloadProcessor(fileOps),
             eventBus = EventBus(),
-            videoEncodePolicy = object : VideoEncodePolicy { override val allowTenBitVideo = false },
         )
 
     private fun bundle(vararg payloads: PayloadFile) =


### PR DESCRIPTION
`main` does not compile. `Run unittests` and `Build iOS` are red on `main` itself
(`600f2815`), failing `:homebase-api:compileTestKotlinJvm` and
`:homebase-upload:compileTestKotlinJvm`. Every branch cut from it inherits the
failure — #1312 is red for this reason and not for anything in that PR.

```
PayloadBundleImageScrubTest.kt:31  No parameter with name 'videoEncodePolicy' found.
PayloadBundleImageScrubTest.kt:31  Unresolved reference 'VideoEncodePolicy'.
FfmpegCompressPlannerTest.kt:302   No parameter with name 'probedCodecMime' found.
FfmpegCompressPlannerTest.kt:303   No parameter with name 'inputDurationMs' found.
FfmpegCompressPlannerTest.kt:303   No parameter with name 'inputBytes' found.
FfmpegCompressPlannerTest.kt:304   No parameter with name 'probedBitDepth' found.
FfmpegCompressPlannerTest.kt:304   No parameter with name 'probedIsHdr' found.
```

## Cause

#1293 removed the `videoEncodePolicy` constructor parameter and the planner's
`probedCodecMime` / `probedBitDepth` / `probedIsHdr` / `inputBytes` /
`inputDurationMs` parameters. #1295 and #1298 each added a **test** that still
passes them.

Each PR was green on its own, because each was tested against a `main` that did
not yet contain the others. Git merged all three with no textual conflict. The
breakage exists only in the combination, so nothing caught it until it was on
`main`.

## The change

Four dead argument lines deleted, across two test files. No production code
changes, no assertions change — both tests still exercise exactly what they did
before, they just stop passing parameters that no longer exist.

These are the same two fixes already sitting on the `test-media-privacy`
integration branch, where the conflict first showed up; this lifts them onto
`main`.

## Verified

`homebase-api`, `homebase-upload`, `homebase-chat` and `homebase-common` JVM
suites pass, and `compileTestKotlinIosSimulatorArm64` compiles — the two checks
that are currently red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
