### PR TITLE
Say the feed is unavailable on web instead of showing a blank panel

### DIFF
--- a/homebase-common/src/commonMain/composeResources/values-da/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values-da/strings.xml
@@ -1150,6 +1150,7 @@
     <string name="feed_error_title">Kunne ikke indlæse feed</string>
     <string name="feed_error_retry">Prøv igen</string>
     <string name="feed_loading">Indlæser feed…</string>
+    <string name="feed_unavailable_web">Feedet er endnu ikke tilgængeligt i browseren. Åbn Homebase på din telefon eller computer for at se det.</string>
     <string name="pending_attachment_one">1 vedhæftning</string>
     <string name="pending_attachment_many">%1$d vedhæftninger</string>
     <string name="crop">Beskær</string>

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -1238,6 +1238,7 @@
     <string name="feed_error_title">Failed to load feed</string>
     <string name="feed_error_retry">Retry</string>
     <string name="feed_loading">Loading feed…</string>
+    <string name="feed_unavailable_web">The feed isn't available in the browser yet. Open Homebase on your phone or desktop to view it.</string>
     <string name="pending_attachment_one">1 attachment</string>
     <string name="pending_attachment_many">%1$d attachments</string>
     <string name="crop">Crop</string>

--- a/homebase-core/src/wasmJsMain/kotlin/id/homebase/core/ui/screens/feed/FeedWebView.web.kt
+++ b/homebase-core/src/wasmJsMain/kotlin/id/homebase/core/ui/screens/feed/FeedWebView.web.kt
@@ -2,16 +2,24 @@ package id.homebase.core.ui.screens.feed
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import id.homebase.resources.MR
+import id.homebase.resources.feed_unavailable_web
+import org.jetbrains.compose.resources.stringResource
 
-// No real WebView on wasmJs — kdroidfilter `composenativewebview` has no
-// wasmJs artifact. Step 9b ships a no-op handle so FeedScreen compiles for
-// the wasmJs target; an actual browser embed (iframe, web component) and a
-// user-facing "feed unavailable on web" string resource can come in a
-// follow-up if/when the Feed UX matters on web.
+// No real WebView on wasmJs — kdroidfilter `composenativewebview` has no wasmJs
+// artifact. The controller is a no-op so FeedScreen compiles for the wasmJs target;
+// an actual browser embed (iframe, web component) can come in a follow-up if/when
+// the Feed UX matters on web. Until then say so rather than rendering an empty
+// surface the user reads as a broken screen.
 
 @Composable
 actual fun rememberFeedWebView(
@@ -24,8 +32,18 @@ actual fun PlatformFeedWebView(
     webView: FeedWebView,
     modifier: Modifier,
 ) {
-    // Empty placeholder surface — see file-level comment for rationale.
-    Box(modifier = modifier.background(MaterialTheme.colorScheme.surfaceVariant))
+    Box(
+        modifier = modifier.background(MaterialTheme.colorScheme.surfaceVariant),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = stringResource(MR.string.feed_unavailable_web),
+            modifier = Modifier.padding(32.dp),
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center,
+        )
+    }
 }
 
 private object NoopFeedWebView : FeedWebView {


### PR DESCRIPTION
The Feed tab on web shows an empty grey panel. No error, no message — it reads as
broken rather than unimplemented.

## Cause

`FeedWebView.web.kt` is a no-op stub. There is no WebView on wasmJs (kdroidfilter
`composenativewebview` ships no wasmJs artifact), so `PlatformFeedWebView` rendered
a bare `surfaceVariant` box and the controller silently swallowed `loadUrl` /
`evaluateJavaScript`. Nothing is ever requested, so there is not even failing
network traffic to notice in the console.

The file's own comment already proposed this fix:

> …an actual browser embed (iframe, web component) and a user-facing "feed
> unavailable on web" string resource can come in a follow-up

This is that string resource.

## Change

- `feed_unavailable_web` in EN and DA
- The placeholder box now centres that message instead of rendering empty

Three files. **Does not implement the feed on web** — that still wants a real
embed, and the interceptor-based auth injection is the open question there.

## Verification

`:homebase-core:compileKotlinWasmJs` passes, and the Konsist architecture test
(which fails the build on hardcoded `Text("…")` literals) passes.

Web-only file; no other platform is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)