### PR TITLE
Let a pasted image reach the attachment editor on web

### DIFF
--- a/homebase-api/src/wasmJsMain/kotlin/id/homebase/api/file/WebFileBytes.kt
+++ b/homebase-api/src/wasmJsMain/kotlin/id/homebase/api/file/WebFileBytes.kt
@@ -1,0 +1,12 @@
+package id.homebase.api.file
+
+import okio.Path.Companion.toPath
+
+/**
+ * Reads a file back out of the in-memory web [systemFileSystem], or null if it isn't there.
+ *
+ * Exists so callers outside this module can reach the wasm temp filesystem without taking an
+ * okio dependency of their own — okio is `implementation`-scoped here.
+ */
+fun readWebFileBytes(path: String): ByteArray? =
+    runCatching { systemFileSystem.read(path.toPath()) { readByteArray() } }.getOrNull()

--- a/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/clipboard/ClipboardPlatformFileFactory.web.kt
+++ b/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/clipboard/ClipboardPlatformFileFactory.web.kt
@@ -1,9 +1,49 @@
+@file:OptIn(kotlin.js.ExperimentalWasmJsInterop::class, kotlin.io.encoding.ExperimentalEncodingApi::class)
+
 package id.homebase.core.clipboard
 
+import id.homebase.api.file.readWebFileBytes
 import io.github.vinceglb.filekit.PlatformFile
+import kotlin.io.encoding.Base64
+import org.w3c.files.File
 
+/**
+ * The browser has no filesystem, but the wasm build's temp files are real: [readWebFileBytes]
+ * serves them from the in-memory okio FakeFileSystem the upload pipeline writes to. FileKit's
+ * wasm PlatformFile is a thin wrapper over a W3C File, so the bytes at [path] can be handed
+ * straight back as one.
+ *
+ * The extension is load-bearing, not cosmetic — the send path derives the wire content-type from
+ * the filename when a pending file carries no richer MIME, which is exactly the clipboard case.
+ * Keep [mimeTypeForExtension] in step with `clipboardImageSuffix`, which chose the extension by
+ * sniffing the pasted bytes.
+ */
 actual fun platformFileFromPath(path: String): PlatformFile {
-    // Web has no filesystem path concept; this code path is unreachable
-    // because getImageFromClipboard() always returns null on web.
-    error("platformFileFromPath is not supported on web")
+    val bytes = readWebFileBytes(path)
+        ?: error("No file at $path on the web filesystem")
+    val name = path.substringAfterLast('/')
+    val mimeType = mimeTypeForExtension(name.substringAfterLast('.', ""))
+    return PlatformFile(makeJsFile(Base64.encode(bytes), name, mimeType))
 }
+
+private fun mimeTypeForExtension(extension: String): String = when (extension.lowercase()) {
+    "gif" -> "image/gif"
+    "jpg", "jpeg" -> "image/jpeg"
+    "webp" -> "image/webp"
+    "png" -> "image/png"
+    else -> "application/octet-stream"
+}
+
+/**
+ * Base64 rather than a typed array over the boundary — the same string-bridge idiom
+ * [id.homebase.core.clipboard.readClipboardImage] and the ffmpeg/video bridges use, which keeps
+ * the wasm side free of typed-array ownership concerns.
+ */
+private fun makeJsFile(base64: String, fileName: String, mimeType: String): File = js(
+    """{
+        var bin = atob(base64);
+        var u8 = new Uint8Array(bin.length);
+        for (var i = 0; i < bin.length; i++) { u8[i] = bin.charCodeAt(i); }
+        return new File([u8], fileName, { type: mimeType });
+    }"""
+)


### PR DESCRIPTION
## The bug

Pasting an image in the wasm app surfaced **"couldn't paste image"**.

Everything up to the last step already worked — clipboard image paste shipped across all four platforms in `fe3af0263`, and only web fell over at the final hop:

```
Cmd+V → readClipboardImage()        ✅ bridges navigator.clipboard.read(), returns real bytes
      → writeBytesToTempFile()      ✅ web FileOperationsProvider is Okio over an in-memory FakeFileSystem
      → platformFileFromPath()      💥 error("platformFileFromPath is not supported on web")
      → caught → chat_error_paste_image
```

## Why it was believed safe

The `error()` carried a comment explaining the path was unreachable:

> Web has no filesystem path concept; this code path is unreachable because `getImageFromClipboard()` always returns null on web.

That was true when written — the **synchronous** reader was the only one, and it does return null on web. The **async** `readClipboardImage()` arrived later and does return bytes, so the path became reachable. The comment was the only thing still asserting otherwise.

## The fix

FileKit's wasm `PlatformFile` is a thin wrapper over a W3C `File`:

```kotlin
public actual data class PlatformFile(val file: org.w3c.files.File)
```

The bytes are already sitting in the temp filesystem, so serve them back as one.

- **`homebase-api/.../file/WebFileBytes.kt`** — `readWebFileBytes(path)` over the in-memory okio FS. It lives in `homebase-api` because okio is `implementation`-scoped there, and `homebase-common` should not take an okio dependency to read one file.
- **`ClipboardPlatformFileFactory.web.kt`** — reads those bytes, wraps them in a W3C `File`. Base64 over the boundary, matching the string-bridge idiom `readClipboardImage` and the ffmpeg/video bridges already use.

MIME is derived from the extension, which is load-bearing here rather than cosmetic: the send path resolves the wire content-type from the filename when a pending file carries no richer MIME — exactly the clipboard case — and `clipboardImageSuffix()` already picked that extension by sniffing magic bytes. So a pasted GIF stays a GIF instead of shipping as a mislabeled PNG.

Paste then opens the same `FullScreenOverlay.AttachmentData` editor the file picker does; that wiring was already shared and needed no change.

## Scope

**Web only.** Desktop's actual is `PlatformFile(File(path))` and works today; Android and iOS are untouched.

## Verified

- wasm compiles: `homebase-api`, `homebase-common`, `homebase-chat`, `homebase-core`
- JVM / Android / iOS compile for the touched modules
- JVM tests green: `homebase-api`, `homebase-common`, `homebase-chat`

**Not verified at runtime** — the wasm build was not loaded in a browser. Worth confirming there.

Two things gate web paste independently of this fix: `navigator.clipboard.read()` requires a **secure context** (https or localhost) plus a permission grant, and Firefox below 127 has no `read()` at all. If paste still does nothing on web, check those before suspecting this change.

## Related gaps found, not addressed here

- `MessageTextFieldForAttachment` (`MessageInputBar.kt:1184`) has no `onPasteImage` — once the editor is open you cannot paste another image into it, on **any** platform. Same for the Android share receiver.
- No drag-and-drop anywhere in the repo — dropping an image on the composer is unsupported on desktop and web.