### PR TITLE
Read the clipboard asynchronously when Cmd+V lands on web

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageInputBar.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageInputBar.kt
@@ -460,6 +460,14 @@ fun MessageTextFieldExpanded(
                                     onPasteImage.invoke(imageBytes)
                                     true
                                 } else {
+                                    // The browser clipboard is async-only, so the read above
+                                    // always returns null on web. Start the async read and
+                                    // report the event unhandled: consuming it would swallow
+                                    // an ordinary text paste, and we cannot know yet whether
+                                    // the clipboard holds an image.
+                                    pasteScope.launch {
+                                        readClipboardImage()?.let { onPasteImage.invoke(it) }
+                                    }
                                     false
                                 }
                             }
@@ -752,6 +760,14 @@ fun MessageTextFieldCompact(
                                                     onPasteImage.invoke(imageBytes)
                                                     true
                                                 } else {
+                                                    // The browser clipboard is async-only, so the read above
+                                                    // always returns null on web. Start the async read and
+                                                    // report the event unhandled: consuming it would swallow
+                                                    // an ordinary text paste, and we cannot know yet whether
+                                                    // the clipboard holds an image.
+                                                    pasteScope.launch {
+                                                        readClipboardImage()?.let { onPasteImage.invoke(it) }
+                                                    }
                                                     false
                                                 }
                                             }


### PR DESCRIPTION
Follow-up to #1330, which fixed the **right-click → "Paste image"** route on web. Cmd+V still did nothing, for a different reason.

## The bug

The composer's key handler reads the clipboard synchronously:

```kotlin
keyEvent.key == Key.V && (isCtrlPressed || isMetaPressed) && onPasteImage != null -> {
    val imageBytes = getImageFromClipboard()   // <-- sync
    ...
}
```

and the web actual of that reader returns null unconditionally, by design:

```kotlin
actual fun getImageFromClipboard(): ByteArray? {
    // Browser clipboard image access requires async Clipboard API which
    // is not compatible with this synchronous expect/actual signature.
    return null
}
```

The browser exposes no synchronous clipboard. So on web the branch always took its null path, reported the event unhandled, and **no clipboard read ever happened**. Only the context-menu item used the async `readClipboardImage()` — which is why the two routes behaved differently, and why #1330 alone did not make Cmd+V work.

## The fix

Fall back to the async read when the synchronous one comes back empty, in both composer fields (`MessageTextFieldExpanded`, `MessageTextFieldCompact`).

The event is reported **unhandled** either way. Consuming it would swallow an ordinary text paste, and at that moment we cannot know whether the clipboard holds an image. So text paste keeps working exactly as before, and an image attaches when the async read resolves.

`navigator.clipboard.read()` is gated on transient user activation rather than synchronous execution, so the dispatch hop is within budget — a keydown is the gesture that opens the window. This matches the reasoning already documented on `readClipboardImage`.

## Scope

Desktop and iOS keep taking the synchronous path unchanged. On Android the sync reader is null by design and hardware keyboards are the exception, so this adds the read the `contentReceiver` path already performs.

## Verified

- Compiles: wasm, JVM, Android, iOS simulator
- `homebase-chat:jvmTest` green

Reported from a real deployment: screenshot copied to clipboard, Cmd+V in the composer, nothing happened.