### PR TITLE
Cache peer feed media and decrypt it with the file-header key

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/cache/DriveFileProviderCached.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/cache/DriveFileProviderCached.kt
@@ -193,49 +193,9 @@ class DriveFileProviderCached(
         // cache — split caches would make every seg-0 prefetch a guaranteed
         // playback miss AND pollute the payload LRU.
         val cache = if (options.chunkStart != null) hlsChunkDiskCache else payloadDiskCache
-
-        // 1️⃣ Check in-memory 404 cache first
-        if (cacheKey in notFoundCache) {
-            return ByteApiResponse.EMPTY_404
+        return readThrough(cache, cacheKey, payloadSemaphore, "PayloadIO") {
+            delegate.getPayloadBytesRawNetwork(driveId, fileId, key, options, onDownloadProgress)
         }
-
-        // 2️⃣ Peek in disk cache and return result if it's there
-        readCachedPayloadOrLog(cache, cacheKey)?.let { return it }
-
-        // 2️⃣ Fetch from network but lock to make sure that we don't load the same
-        // resource twice over the network
-        val mutex: Mutex
-        lock.withLock { mutex = keyLocks.getOrPut(cacheKey) { Mutex() } }
-
-        return mutex.withLock {
-            // Re-try caches JIC there's a thread race
-            if (cacheKey in notFoundCache) {
-                return@withLock ByteApiResponse.EMPTY_404
-            }
-            readCachedPayloadOrLog(cache, cacheKey)?.let { return@withLock it }
-
-            // we allow up to 3 concurrent semaphore payloads over the network
-            return payloadSemaphore.withPermit {
-                try {
-                    val result = delegate.getPayloadBytesRawNetwork(driveId, fileId, key, options, onDownloadProgress)
-
-                    // 3️⃣ Store to disk (only 200/206 can reach here — throwForFailure throws for everything else)
-                    check(result.status in 200..299) {
-                        "Unexpected non-2xx status ${result.status} reached disk cache write — not caching"
-                    }
-                    writeToDiskCache(cache, cacheKey, "PayloadIO", result)
-                    result
-                } catch (e: NotFoundException) {
-                    // 404 thrown by network layer — cache it so future calls skip the network
-                    notFoundCacheMutex.withLock { notFoundCache = notFoundCache + cacheKey }
-                    throw e
-                } catch (e: Exception) {
-                    // For other errors (500, network issues, etc.), don't cache and rethrow
-                    Logger.w(tag = "PayloadIO") { "payload network-fetch FAILED (${e::class.simpleName}): ${e.message} key=$cacheKey" }
-                    throw e
-                }
-            }
-        } // Mutex.lock
     }
 
     suspend fun getPayloadBytesDecrypted(
@@ -337,88 +297,85 @@ class DriveFileProviderCached(
             lastModified: Long? = null
     ): ByteApiResponse {
         val cacheKey = buildThumbCacheKey(driveId, fileId, payloadKey, width, height, lastModified)
-
-        // 1️⃣ Check in-memory 404 cache first
-        if (cacheKey in notFoundCache) return ByteApiResponse.EMPTY_404
-
-        // 2️⃣ Peek in disk cache and return result if it's there
-        readCachedThumbOrLog(cacheKey)?.let { return it }
-
-        // 2️⃣ Fetch from network but lock to make sure that we don't load the same
-        // resource twice over the network
-        val mutex: Mutex
-        lock.withLock { mutex = keyLocks.getOrPut(cacheKey) { Mutex() } }
-
-        return mutex.withLock {
-            // Re-try caches JIC there's a thread race
-            if (cacheKey in notFoundCache) {
-                return@withLock ByteApiResponse.EMPTY_404
-            }
-            readCachedThumbOrLog(cacheKey)?.let { return@withLock it }
-
-            // we allow up to 30 concurrent semaphore thumbnails over the network
-            return thumbnailSemaphore.withPermit {
-                try {
-                    val result =
-                            delegate.getThumbBytesRawNetwork(
-                                    driveId,
-                                    fileId,
-                                    payloadKey,
-                                    width,
-                                    height,
-                                    lastModified
-                            )
-
-                    // 3️⃣ Store to disk (only 200/206 can reach here — throwForFailure throws for everything else).
-                    check(result.status in 200..299) {
-                        "Unexpected non-2xx status ${result.status} reached disk cache write — not caching"
-                    }
-                    writeToDiskCache(thumbDiskCache, cacheKey, "ThumbIO", result)
-                    result
-                } catch (e: NotFoundException) {
-                    // 404 thrown by network layer — cache it so future calls skip the network
-                    notFoundCacheMutex.withLock { notFoundCache = notFoundCache + cacheKey }
-                    throw e
-                } catch (e: Exception) {
-                    // For other errors (500, network issues, etc.), don't cache and rethrow
-                    Logger.w(tag = "ThumbIO") { "thumb network-fetch FAILED (${e::class.simpleName}): ${e.message} key=$cacheKey" }
-                    throw e
-                }
-            }
-        } // Mutex.lock
-    }
-
-    /**
-     * Read a thumb from the disk cache. Returns null on cache miss OR when the
-     * cached file cannot be parsed (corrupted entry, truncated write, etc.).
-     * All exceptions are logged as errors so the caller can fall through to
-     * the network cleanly.
-     */
-    private fun readCachedThumbOrLog(cacheKey: String): ByteApiResponse? {
-        return try {
-            thumbDiskCache.openSnapshot(cacheKey.toDiskKey())?.use { snap ->
-                readBytesResponse(snap.data.toString())
-            }
-        } catch (e: Exception) {
-            Logger.e(tag = "ThumbIO", throwable = e) { "thumb cache-read FAILED key=$cacheKey" }
-            null
+        return readThrough(thumbDiskCache, cacheKey, thumbnailSemaphore, "ThumbIO") {
+            delegate.getThumbBytesRawNetwork(driveId, fileId, payloadKey, width, height, lastModified)
         }
     }
 
     /**
-     * Payload-cache analog of [readCachedThumbOrLog]. Defense-in-depth against
-     * parse failures.
+     * Read from a disk cache. Returns null on cache miss OR when the cached file
+     * cannot be parsed (corrupted entry, truncated write, etc.). All exceptions are
+     * logged as errors so the caller can fall through to the network cleanly.
      */
-    private fun readCachedPayloadOrLog(cache: DiskCache, cacheKey: String): ByteApiResponse? {
+    private fun readCachedOrLog(
+            cache: DiskCache,
+            cacheKey: String,
+            logTag: String
+    ): ByteApiResponse? {
         return try {
             cache.openSnapshot(cacheKey.toDiskKey())?.use { snap ->
                 readBytesResponse(snap.data.toString())
             }
         } catch (e: Exception) {
-            Logger.e(tag = "PayloadIO", throwable = e) { "payload cache-read FAILED key=$cacheKey" }
+            Logger.e(tag = logTag, throwable = e) { "cache-read FAILED key=$cacheKey" }
             null
         }
     }
+
+    // Peek, lock, re-peek, fetch, store. Shared by own-drive and peer reads so both get the
+    // same 404 memo, single-flight lock and concurrency cap; a peer read differs only in its
+    // cache key and in which network call [fetch] makes.
+    private suspend fun readThrough(
+            cache: DiskCache,
+            cacheKey: String,
+            semaphore: Semaphore,
+            logTag: String,
+            fetch: suspend () -> ByteApiResponse
+    ): ByteApiResponse {
+        if (cacheKey in notFoundCache) return ByteApiResponse.EMPTY_404
+        readCachedOrLog(cache, cacheKey, logTag)?.let { return it }
+
+        val mutex: Mutex
+        lock.withLock { mutex = keyLocks.getOrPut(cacheKey) { Mutex() } }
+
+        return mutex.withLock {
+            if (cacheKey in notFoundCache) return@withLock ByteApiResponse.EMPTY_404
+            readCachedOrLog(cache, cacheKey, logTag)?.let { return@withLock it }
+
+            semaphore.withPermit {
+                try {
+                    val result = fetch()
+                    check(result.status in 200..299) {
+                        "Unexpected non-2xx status ${result.status} reached disk cache write — not caching"
+                    }
+                    writeToDiskCache(cache, cacheKey, logTag, result)
+                    result
+                } catch (e: NotFoundException) {
+                    notFoundCacheMutex.withLock { notFoundCache = notFoundCache + cacheKey }
+                    throw e
+                } catch (e: Exception) {
+                    Logger.w(tag = logTag) {
+                        "network-fetch FAILED (${e::class.simpleName}): ${e.message} key=$cacheKey"
+                    }
+                    throw e
+                }
+            }
+        }
+    }
+
+    // Entry points for reads this class cannot issue itself. A peer read lives in
+    // PeerFileByGlobalTransitProvider, which injecting here would cycle, so it hands in its
+    // own key and fetch instead. Cached bytes stay encrypted — callers decrypt post-read
+    // with the KeyHeader from the file header, since no response headers survive a hit.
+    suspend fun readPayloadThrough(
+            cacheKey: String,
+            fetch: suspend () -> ByteApiResponse
+    ): ByteApiResponse = readThrough(payloadDiskCache, cacheKey, payloadSemaphore, "PayloadIO", fetch)
+
+    suspend fun readThumbThrough(
+            cacheKey: String,
+            fetch: suspend () -> ByteApiResponse
+    ): ByteApiResponse = readThrough(thumbDiskCache, cacheKey, thumbnailSemaphore, "ThumbIO", fetch)
 
     suspend fun getThumbBytesDecrypted(
             driveId: Uuid,

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/peer/PeerFileByGlobalTransitProvider.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/peer/PeerFileByGlobalTransitProvider.kt
@@ -1,11 +1,15 @@
 package id.homebase.api.client.peer
 
 import co.touchlab.kermit.Logger
+import id.homebase.api.client.ByteApiResponse
+import id.homebase.api.client.KeyHeader
+import id.homebase.api.client.NotFoundException
 import id.homebase.api.client.OdinApiProviderBase
 import id.homebase.api.client.PayloadSizePolicy
 import id.homebase.api.client.auth.CredentialsManager
+import id.homebase.api.client.drives.cache.DriveFileProviderCached
 import id.homebase.api.client.drives.files.BytesResponse
-import id.homebase.api.client.drives.files.DriveFileProvider
+import id.homebase.api.client.drives.files.DriveFileHttpProvider
 import id.homebase.api.common.OdinId
 import io.ktor.client.HttpClient
 import io.ktor.client.request.bearerAuth
@@ -14,22 +18,22 @@ import kotlin.uuid.Uuid
 
 // Feed posts from people you follow land on the local feed drive as header-only references — the media bytes
 // stay on the author's drive — so displaying their images needs this read over peer. The user's own host
-// brokers the request and re-encrypts under the caller's shared secret, so the decode path is identical to a
-// local read.
+// brokers the request.
+//
+// Decryption uses the [keyHeader] the caller already holds from its feed-drive row, not the
+// `sharedsecretencryptedheader64` the broker re-encrypts per request. Feed distribution preserves the
+// author's file AES key end to end (one key per file, one iv per payload), so the two carry the same key —
+// and only the caller-supplied one survives a disk-cache hit, where no response headers exist.
 //
 // Full payload reads are size-guarded at PayloadSizePolicy.RENDER_LIMIT_BYTES so a followed identity's
 // oversized photo can't be buffered into RAM; thumbnails stay uncapped, matching the local read.
 //
 // The remote resolves the drive by ALIAS only (Type is ignored), so [driveId] is the channel drive's alias.
-//
-// TODO: unlike the local read this bypasses DriveFileProviderCached, so every followed-post thumbnail is
-// re-downloaded. Routing it through needs peer/gtid-aware cache keys AND a cache entry format that persists
-// `sharedsecretencryptedheader64` — the cached bytes stay encrypted and no caller-supplied KeyHeader exists to
-// decrypt them on a hit. TemporalDriveReadProvider has the same gap.
 class PeerFileByGlobalTransitProvider(
     httpClient: HttpClient,
     credentialsManager: CredentialsManager,
-    private val driveFileProvider: DriveFileProvider,
+    private val driveFileHttpProvider: DriveFileHttpProvider,
+    private val driveCache: DriveFileProviderCached,
 ) : OdinApiProviderBase(httpClient, credentialsManager) {
 
     /** Null on 404. */
@@ -38,6 +42,7 @@ class PeerFileByGlobalTransitProvider(
         driveId: Uuid,
         globalTransitId: Uuid,
         payloadKey: String,
+        keyHeader: KeyHeader,
     ): BytesResponse? {
         require(payloadKey.isNotBlank()) { "payloadKey must be defined" }
         val creds = requireCreds()
@@ -45,10 +50,19 @@ class PeerFileByGlobalTransitProvider(
             creds.domain,
             "/peer/$peer/drives/$driveId/files/by-gtid/$globalTransitId/payload/$payloadKey",
         )
+        val cacheKey = peerCacheKey("payload", peer, driveId, globalTransitId, payloadKey)
         Logger.i(tag = TAG) {
             "getPayload: GET peer=${peer.domainName} drive=$driveId gtid=$globalTransitId key=$payloadKey"
         }
-        return fetchAndDecrypt(url, creds.accessToken, maxBytes = PayloadSizePolicy.RENDER_LIMIT_BYTES)
+        val response = try {
+            driveCache.readPayloadThrough(cacheKey) {
+                fetch(url, creds.accessToken, PayloadSizePolicy.RENDER_LIMIT_BYTES)
+            }
+        } catch (_: NotFoundException) {
+            Logger.i(tag = TAG) { "404 (not shared / missing) url=$url" }
+            return null
+        }
+        return decrypted(response, keyHeader)
     }
 
     /** Null on 404. */
@@ -59,6 +73,7 @@ class PeerFileByGlobalTransitProvider(
         payloadKey: String,
         width: Int,
         height: Int,
+        keyHeader: KeyHeader,
     ): BytesResponse? {
         require(payloadKey.isNotBlank()) { "payloadKey must be defined" }
         require(width > 0 && height > 0) { "width/height must be positive" }
@@ -67,26 +82,38 @@ class PeerFileByGlobalTransitProvider(
             creds.domain,
             "/peer/$peer/drives/$driveId/files/by-gtid/$globalTransitId/payload/$payloadKey/thumb/$width/$height",
         )
+        val cacheKey =
+            peerCacheKey("thumb", peer, driveId, globalTransitId, payloadKey, width, height)
         Logger.i(tag = TAG) {
             "getThumb: GET peer=${peer.domainName} drive=$driveId gtid=$globalTransitId key=$payloadKey ${width}x$height"
         }
-        return fetchAndDecrypt(url, creds.accessToken)
-    }
-
-    private suspend fun fetchAndDecrypt(
-        url: String,
-        token: String,
-        maxBytes: Long? = null,
-    ): BytesResponse? {
-        val response = requestBytes(maxBytes) { httpClient.get(url) { bearerAuth(token) } }
-        if (response.status == 404) {
+        val response = try {
+            driveCache.readThumbThrough(cacheKey) { fetch(url, creds.accessToken, maxBytes = null) }
+        } catch (_: NotFoundException) {
             Logger.i(tag = TAG) { "404 (not shared / missing) url=$url" }
             return null
         }
-        throwForFailure(response)
-        val decrypted = driveFileProvider.decryptBytes(response.headers, response.bytes)
-        return BytesResponse(bytes = decrypted, contentType = response.contentType)
+        return decrypted(response, keyHeader)
     }
+
+    private suspend fun fetch(url: String, token: String, maxBytes: Long?): ByteApiResponse {
+        val response = requestBytes(maxBytes) { httpClient.get(url) { bearerAuth(token) } }
+        // 404 becomes NotFoundException, which the cache memoises so a followed post with no
+        // server-side thumbnail stops being re-requested on every scroll past it.
+        throwForFailure(response)
+        return response
+    }
+
+    private suspend fun decrypted(response: ByteApiResponse, keyHeader: KeyHeader): BytesResponse? {
+        if (response.status == 404) return null
+        val bytes = driveFileHttpProvider.decryptBytes(keyHeader, response.headers, response.bytes)
+        return BytesResponse(bytes = bytes, contentType = response.contentType)
+    }
+
+    // The peer segment keeps these off the own-drive keys: a followed post has no local fileId, and
+    // two identities can publish the same gtid on same-aliased channel drives.
+    private fun peerCacheKey(kind: String, vararg parts: Any): String =
+        (listOf(kind, "peer") + parts.toList()).joinToString(":")
 
     companion object { private const val TAG = "PeerFileByGtid" }
 }

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/peer/PeerFileByGlobalTransitProvider.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/peer/PeerFileByGlobalTransitProvider.kt
@@ -51,9 +51,6 @@ class PeerFileByGlobalTransitProvider(
             "/peer/$peer/drives/$driveId/files/by-gtid/$globalTransitId/payload/$payloadKey",
         )
         val cacheKey = peerCacheKey("payload", peer, driveId, globalTransitId, payloadKey)
-        Logger.i(tag = TAG) {
-            "getPayload: GET peer=${peer.domainName} drive=$driveId gtid=$globalTransitId key=$payloadKey"
-        }
         val response = try {
             driveCache.readPayloadThrough(cacheKey) {
                 fetch(url, creds.accessToken, PayloadSizePolicy.RENDER_LIMIT_BYTES)
@@ -84,9 +81,6 @@ class PeerFileByGlobalTransitProvider(
         )
         val cacheKey =
             peerCacheKey("thumb", peer, driveId, globalTransitId, payloadKey, width, height)
-        Logger.i(tag = TAG) {
-            "getThumb: GET peer=${peer.domainName} drive=$driveId gtid=$globalTransitId key=$payloadKey ${width}x$height"
-        }
         val response = try {
             driveCache.readThumbThrough(cacheKey) { fetch(url, creds.accessToken, maxBytes = null) }
         } catch (_: NotFoundException) {
@@ -97,6 +91,8 @@ class PeerFileByGlobalTransitProvider(
     }
 
     private suspend fun fetch(url: String, token: String, maxBytes: Long?): ByteApiResponse {
+        // Only reached on a cache miss, so one line here is exactly one network read.
+        Logger.i(tag = TAG) { "GET $url" }
         val response = requestBytes(maxBytes) { httpClient.get(url) { bearerAuth(token) } }
         // 404 becomes NotFoundException, which the cache memoises so a followed post with no
         // server-side thumbnail stops being re-requested on every scroll past it.

--- a/homebase-api/src/jvmTest/kotlin/id/homebase/api/client/drives/cache/DriveFileProviderCachedTest.kt
+++ b/homebase-api/src/jvmTest/kotlin/id/homebase/api/client/drives/cache/DriveFileProviderCachedTest.kt
@@ -255,7 +255,7 @@ class DriveFileProviderCachedTest {
             "corrupted cache must fall through to the network"
         )
         assertTrue(
-            logCollector.hasError(tag = "ThumbIO", substring = "thumb cache-read FAILED"),
+            logCollector.hasError(tag = "ThumbIO", substring = "cache-read FAILED"),
             "expected error log for cache-read corruption; got: ${logCollector.messages("ThumbIO")}"
         )
     }

--- a/homebase-api/src/jvmTest/kotlin/id/homebase/api/client/peer/PeerFileByGlobalTransitProviderTest.kt
+++ b/homebase-api/src/jvmTest/kotlin/id/homebase/api/client/peer/PeerFileByGlobalTransitProviderTest.kt
@@ -1,11 +1,12 @@
 package id.homebase.api.client.peer
 
+import id.homebase.api.client.KeyHeader
 import id.homebase.api.client.PayloadSizePolicy
 import id.homebase.api.client.PayloadTooLargeException
 import id.homebase.api.client.auth.ApiCredentials
 import id.homebase.api.client.auth.CredentialsManager
 import id.homebase.api.client.drives.cache.DriveFileProviderCached
-import id.homebase.api.client.drives.files.DriveFileProvider
+import id.homebase.api.client.drives.files.DriveFileHttpProvider
 import id.homebase.api.client.profile.FakeFileOperationsProvider
 import id.homebase.api.common.OdinId
 import id.homebase.api.common.SecureByteArray
@@ -25,12 +26,20 @@ import kotlin.uuid.Uuid
 
 // The over-peer routes must stay the UnifiedV2 `PeerByGtid` paths — that is what odin-core's
 // `V2DrivePeerQueryByGtidController` serves; the retired V1 `/transit/query/…` shape 404s.
+//
+// FakeFileOperationsProvider points the disk cache at a fixed /tmp path that outlives the test run,
+// so every test that asserts on network behaviour mints a fresh gtid — a reused one would be served
+// from a previous run's cache entry and never reach the engine.
 class PeerFileByGlobalTransitProviderTest {
 
     private val peer = OdinId("author.example.com")
     private val driveId = Uuid.parse("11111111-1111-1111-1111-111111111111")
-    private val gtid = Uuid.parse("22222222-2222-2222-2222-222222222222")
     private val key = "pst0mdi0"
+
+    private fun keyHeader() = KeyHeader(
+        iv = ByteArray(16) { 3 },
+        aesKey = SecureByteArray(ByteArray(16) { 7 }),
+    )
 
     private suspend fun provider(engine: MockEngine): PeerFileByGlobalTransitProvider {
         val cm = CredentialsManager()
@@ -42,16 +51,17 @@ class PeerFileByGlobalTransitProviderTest {
         cm.storeCredentials(creds)
         cm.setActiveCredentials(creds)
         val http = HttpClient(engine)
-        val driveFileProvider = DriveFileProvider(
+        return PeerFileByGlobalTransitProvider(
             httpClient = http,
             credentialsManager = cm,
+            driveFileHttpProvider = DriveFileHttpProvider(http, cm),
             driveCache = DriveFileProviderCached(http, cm, FakeFileOperationsProvider()),
         )
-        return PeerFileByGlobalTransitProvider(http, cm, driveFileProvider)
     }
 
     @Test
     fun payload_hitsV2ByGtidRoute_andReturnsPlaintextBytes() = runTest {
+        val gtid = Uuid.random()
         var path: String? = null
         val bytes = byteArrayOf(1, 2, 3, 4)
         // payloadencrypted absent → decryptBytes returns the bytes untouched (the public-feed case).
@@ -60,7 +70,8 @@ class PeerFileByGlobalTransitProviderTest {
             respond(bytes, HttpStatusCode.OK, headersOf(HttpHeaders.ContentType, "image/jpeg"))
         }
 
-        val result = provider(engine).getPayloadOverPeerByGlobalTransitId(peer, driveId, gtid, key)
+        val result = provider(engine)
+            .getPayloadOverPeerByGlobalTransitId(peer, driveId, gtid, key, keyHeader())
 
         assertEquals(
             "/api/v2/peer/$peer/drives/$driveId/files/by-gtid/$gtid/payload/$key",
@@ -71,13 +82,16 @@ class PeerFileByGlobalTransitProviderTest {
 
     @Test
     fun thumb_hitsV2ByGtidThumbRoute() = runTest {
+        val gtid = Uuid.random()
         var path: String? = null
         val engine = MockEngine { request ->
             path = request.url.encodedPath
             respond(byteArrayOf(9), HttpStatusCode.OK, headersOf(HttpHeaders.ContentType, "image/webp"))
         }
 
-        provider(engine).getThumbOverPeerByGlobalTransitId(peer, driveId, gtid, key, width = 320, height = 320)
+        provider(engine).getThumbOverPeerByGlobalTransitId(
+            peer, driveId, gtid, key, width = 320, height = 320, keyHeader = keyHeader(),
+        )
 
         assertEquals(
             "/api/v2/peer/$peer/drives/$driveId/files/by-gtid/$gtid/payload/$key/thumb/320/320",
@@ -85,10 +99,63 @@ class PeerFileByGlobalTransitProviderTest {
         )
     }
 
+    // A CDN-served payload carries the ciphertext and `payloadencrypted`, but no
+    // `sharedsecretencryptedheader64` — the origin only mints that per authenticated request. The read
+    // must therefore decrypt with the KeyHeader the caller already holds from its feed-drive row.
+    @Test
+    fun payload_encrypted_decryptsWithCallerKeyHeader_whenResponseCarriesNoKeyHeader() = runTest {
+        val gtid = Uuid.random()
+        val plaintext = "followed post media".encodeToByteArray()
+        val cipher = keyHeader().encryptDataAes(plaintext)
+        val engine = MockEngine {
+            respond(
+                cipher,
+                HttpStatusCode.OK,
+                headersOf("payloadencrypted", listOf("true")),
+            )
+        }
+
+        val result = provider(engine)
+            .getPayloadOverPeerByGlobalTransitId(peer, driveId, gtid, key, keyHeader())
+
+        assertTrue(
+            result != null && result.bytes.contentEquals(plaintext),
+            "caller-supplied KeyHeader decrypts a response with no key header",
+        )
+    }
+
+    // The bug this fixes: every followed-post thumbnail was re-downloaded on every view because the
+    // peer read bypassed the disk cache entirely.
+    @Test
+    fun thumb_secondRead_isServedFromCache_withoutASecondNetworkCall() = runTest {
+        val gtid = Uuid.random()
+        var networkCalls = 0
+        val bytes = byteArrayOf(4, 5, 6)
+        val engine = MockEngine {
+            networkCalls++
+            respond(bytes, HttpStatusCode.OK, headersOf(HttpHeaders.ContentType, "image/webp"))
+        }
+        val provider = provider(engine)
+
+        val first = provider.getThumbOverPeerByGlobalTransitId(
+            peer, driveId, gtid, key, width = 320, height = 320, keyHeader = keyHeader(),
+        )
+        val second = provider.getThumbOverPeerByGlobalTransitId(
+            peer, driveId, gtid, key, width = 320, height = 320, keyHeader = keyHeader(),
+        )
+
+        assertEquals(1, networkCalls, "second read served from disk cache")
+        assertTrue(first != null && first.bytes.contentEquals(bytes))
+        assertTrue(second != null && second.bytes.contentEquals(bytes))
+    }
+
     @Test
     fun payload_404_returnsNull() = runTest {
         val engine = MockEngine { respond(ByteArray(0), HttpStatusCode.NotFound) }
-        assertNull(provider(engine).getPayloadOverPeerByGlobalTransitId(peer, driveId, gtid, key))
+        assertNull(
+            provider(engine)
+                .getPayloadOverPeerByGlobalTransitId(peer, driveId, Uuid.random(), key, keyHeader()),
+        )
     }
 
     // The typed throw is what `HomebaseImageLoader.fetchFullPayloadUncached` catches to keep the
@@ -107,7 +174,8 @@ class PeerFileByGlobalTransitProviderTest {
         }
 
         val e = assertFailsWith<PayloadTooLargeException> {
-            provider(engine).getPayloadOverPeerByGlobalTransitId(peer, driveId, gtid, key)
+            provider(engine)
+                .getPayloadOverPeerByGlobalTransitId(peer, driveId, Uuid.random(), key, keyHeader())
         }
         assertEquals(oversized, e.sizeBytes)
         assertEquals(PayloadSizePolicy.RENDER_LIMIT_BYTES, e.limitBytes)

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/image/HomebaseImageLoader.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/image/HomebaseImageLoader.kt
@@ -144,6 +144,7 @@ class HomebaseImageLoader(
                         payloadKey = data.payloadKey,
                         width = nativeSize.pixelWidth,
                         height = nativeSize.pixelHeight,
+                        keyHeader = data.keyHeader,
                     )
                 } else {
                     driveFileProvider.getThumbBytesDecrypted(
@@ -232,6 +233,7 @@ class HomebaseImageLoader(
                         driveId = data.driveId,
                         globalTransitId = data.globalTransitId!!,
                         payloadKey = data.payloadKey,
+                        keyHeader = data.keyHeader,
                     )
                 } else {
                     driveFileProvider.getPayloadBytesDecrypted(


### PR DESCRIPTION
Bottom layer of the CDN work. Fixes a real bug on its own; the CDN routing sits on top of it.

## The bug

Followed-post media bypassed `DriveFileProviderCached` entirely, so **every followed-post thumbnail was re-downloaded on every cold start**. Coil's in-memory cache hides this within a session — scrolling back over a post costs nothing — but the ImageLoader sets `diskCache(null)`, so nothing survives process death. Measured on a Redmi Note 5 Pro against `main`: 14 media requests on the first scroll, **0** on scroll-back, and **14 again after an app restart over the same posts**. The existing TODO in `PeerFileByGlobalTransitProvider` named the blocker: caching needs a key that survives a cache hit, and the peer read depended on `sharedsecretencryptedheader64` — a header the origin mints per request, and which no cache entry stores.

## Why the caller's key is the right key

Feed distribution preserves the author's file AES key end to end — one AES key per file, a distinct IV per payload — so the `KeyHeader` on the follower's feed-drive row *is* the key the author encrypted the remote payload with. Verified in odin-core across both distribution paths:

- **Pull** (`FollowerService.TryWriteFeedFileAsync`) decrypts the remote key header with the ICR shared secret and passes the recovered `KeyHeader` straight to `FeedWriter`.
- **Push** (`FeedDriveDistributionRouter` → transit → `PeerFileWriter`) decrypts with the author's drive storage key, re-wraps per recipient, and the follower recovers the identical key.
- Every hop is decrypt-with-one-secret / re-encrypt-with-another of the *same* raw key bytes. No hop mints a new AES key.
- `Feed_Post_Tests.CanDistributeFeedFileToConnectedIdentity_…_And_RecipientCanDecrypt` proves the round trip.
- Payload descriptors (and therefore each payload's `Iv`) are copied verbatim, so `(row.keyHeader.aesKey, payloadDescriptor.iv)` is the correct pair — which is already what `MomentMediaItem` builds.

Caveat worth knowing: encrypted posts only reach *connected* followers. Both paths filter unconnected followers out before any key math.

## Changes

- `PeerFileByGlobalTransitProvider` takes a `KeyHeader` and decrypts with it via `DriveFileHttpProvider.decryptBytes(keyHeader, …)`. It now depends on `DriveFileHttpProvider` + `DriveFileProviderCached` instead of `DriveFileProvider`, which also breaks the old Peer → DriveFileProvider → Cached chain.
- Peer reads go through the disk cache under peer/gtid-scoped keys. A followed post has no local fileId, and two identities can publish the same gtid on same-aliased channel drives, so the `peer` segment keeps these off the own-drive keys.
- A 404 now becomes a `NotFoundException` the cache memoises, so a followed post with no server-side thumbnail stops being re-requested on every scroll past it.
- `DriveFileProviderCached`: the peek → lock → re-peek → fetch → store dance is extracted into one `readThrough`, shared by own-drive and peer reads so both get the same 404 memo, single-flight lock and concurrency cap. The peer provider hands in its own key and fetch rather than being injected here, which would cycle. Net ~90 lines deleted.

No DI change — Koin resolves both new constructor params from existing `singleOf` registrations.

## Tests

`homebase-api:jvmTest` — 3516 tests, 0 failures (2 new). Two of them pin the behaviour that matters rather than the plumbing:

- `thumb_secondRead_isServedFromCache_withoutASecondNetworkCall` — asserts the second read makes **zero** network calls. This is the bug fix.
- `payload_encrypted_decryptsWithCallerKeyHeader_whenResponseCarriesNoKeyHeader` — responds with ciphertext + `payloadencrypted` and **no** key header, i.e. exactly the shape a CDN-served payload has, and asserts the plaintext comes back.

Tests that assert on network behaviour mint a fresh gtid, because `FakeFileOperationsProvider` points the disk cache at a fixed `/tmp` path that outlives the run.

One existing assertion in `DriveFileProviderCachedTest` was updated: merging the two cache-read helpers changed the log text from `"thumb cache-read FAILED"` to `"cache-read FAILED"`. The test's `tag = "ThumbIO"` assertion still carries the discriminator, and its behavioural assertions (200 status, network fallback) were unaffected.

## Not in this PR

Routing feed media through the CDN. Followed-post media needs a `by-gtid` read route under `/api/v2/drives` in odin-core — `by-gtid` exists only under `/api/v2/peer/…`, which is `OwnerOrApp`-gated and off the CDN allow-list. That is a separate odin-core PR.

## Device-verified on a Redmi Note 5 Pro (whyred, AOSP 11)

Evidence is the app's own log. The `PeerFileByGtid` "GET" line now sits inside the fetch lambda, so **one line is exactly one network read** — a cache hit logs nothing. (It previously sat before the read-through and printed "GET" on every call, hit or miss, which was both untrue and useless for this; fixed in the second commit.)

**Media still renders.** Feed loads a followed identity's post media over peer and paints it — so the swap from the response key header to the caller-supplied `KeyHeader` decrypts real peer content, not just the test's.

**Disk cache survives a process restart** — the behaviour that did not exist before this PR:

```
# session 1
11:56:43 (PeerFileByGtid) GET frodo.baggins.demo.rocks gtid=d42f39c7 pst_mdi0/thumb/222/168

# force-stop, relaunch, scroll back to the same post
$ grep -c d42f39c7 after-restart.log
0
```

The thumbnail repainted with **zero** network reads. Before this change peer reads bypassed the cache entirely, so a restart always re-downloaded.

**No re-fetch on a scroll round-trip.** Scrolling to the top of the feed and back down past both posts:

```
log lines during scroll round-trip: 12
peer network reads: 0
```

That covers the 404 memo too — the one post whose thumbnail 404s was requested once and not again for the rest of the session.

**Unrelated pre-existing condition, unchanged by this PR:** one followed post's thumbnail 404s (`biggus.dickus.demo.rocks`, "not shared / missing") and falls back to its embedded preview. That is a server-side sharing state, present before this change; the fallback works as designed. It is re-requested once per process because the 404 memo is in-memory by design, matching own-drive reads.


## Known limits of the cache — what this does NOT cover

The measurements above are real but they are of **completed** fetches. Two cases still re-request on every view. Neither is a regression (before this PR peer reads had no cache at all, so both re-fetched too), but they mean the win is smaller than "thumbnails never re-download":

**1. A 403 is never memoised.** Only 404 becomes a `NotFoundException` that lands in `notFoundCache`; every other failure is treated as transient and rethrown uncached. A followed identity whose media returns 403 ("not shared with you") is therefore re-requested on every recomposition. Observed on device — the same thumbnail requested 8 times in 22 seconds:

```
Warn: (ThumbIO) network-fetch FAILED (ForbiddenException): Forbidden: Remote server returned 403
  key=thumb:peer:<identity>:<drive>:<gtid>:pst_mdi0:699:600
```

**2. A fetch cancelled by scrolling caches nothing.** When the composable leaves composition mid-download the coroutine is cancelled, so `writeToDiskCache` is never reached and the bytes already pulled are discarded. Scroll past the same image again and it starts over — and can be cancelled again:

```
12:00:02  GET  <gtid> thumb/778/820
12:00:02  Warn (ThumbIO) FAILED (ForgottenCoroutineScopeException): rememberCoroutineScope left the composition
12:01:54  GET  <gtid> thumb/778/820   ← starts over
```

This is the fast-scroll case, so it is the common one.

Fixes for both are deliberately **not** in this PR: memoising 403 alongside 404, and letting an in-flight fetch complete into the cache even when the requester cancels. The second needs a scope that cannot leak, so it wants its own review rather than riding along here.

The cache machinery itself is healthy: zero `cache-write FAILED`, zero `cache-read FAILED`, zero `cache-admit REFUSED` across the entire device log.

