### PR TITLE
Implement web audio playback

### DIFF
--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/widget/AudioPlayerWidget.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/widget/AudioPlayerWidget.kt
@@ -92,7 +92,9 @@ fun AudioPlayerWidget(
             override fun onProgressUpdate(progressSeconds: Int, totalSeconds: Int) {
                 Logger.i { "Progress: $progressSeconds / $totalSeconds" }
                 currentFileSeconds = progressSeconds
-                totalFileSeconds = totalSeconds
+                // 0 means the player couldn't determine a duration (web: a stream muxed with no
+                // duration box) — keep the length the payload descriptor already gave us.
+                if (totalSeconds > 0) totalFileSeconds = totalSeconds
             }
         })
     }

--- a/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/audio/AudioPlayer.web.kt
+++ b/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/audio/AudioPlayer.web.kt
@@ -1,16 +1,153 @@
+@file:OptIn(kotlin.js.ExperimentalWasmJsInterop::class, kotlin.io.encoding.ExperimentalEncodingApi::class)
+
 package id.homebase.core.audio
 
-// Pre-flight stub. Browser audio playback will use HTMLAudioElement when wired
-// up properly; for now this no-ops so chat UI compiles without an audio
-// dependency on the web.
-private object NoopAudioPlayer : AudioPlayer {
-    override fun play(filePath: String) {}
-    override fun jump(seconds: Int) {}
-    override fun resume() {}
-    override fun pause() {}
-    override fun stop() {}
-    override fun release() {}
-    override fun setPlaybackObserver(observer: AudioPlaybackObserver) {}
+import co.touchlab.kermit.Logger
+import id.homebase.api.file.readWebFileBytes
+import id.homebase.core.util.detectContentTypeFromExtensionOrHint
+import kotlin.io.encoding.Base64
+
+/*
+ * `filePath` here is a path into the in-memory FakeFileSystem the decrypt-on-demand flow wrote to
+ * (MediaDownloadHandler.handleDecryptFile), not a real file the browser can fetch. Read it back,
+ * wrap the bytes in a Blob object URL and drive a detached HTMLAudioElement — the same bridge the
+ * web video surface uses. Bytes cross to JS as Base64, the idiom used by HtmlVideoOverlay.web.kt.
+ */
+
+private class WebAudioPlayer : AudioPlayer {
+    private var element: JsAny? = null
+    private var objectUrl: String? = null
+    private var observer: AudioPlaybackObserver? = null
+
+    override fun play(filePath: String) {
+        teardown()
+
+        val bytes = readWebFileBytes(filePath)
+        if (bytes == null) {
+            Logger.e(tag = TAG) { "No decrypted audio at $filePath" }
+            return
+        }
+
+        val url = audioBytesToObjectUrl(Base64.encode(bytes), audioMimeForPath(filePath))
+        objectUrl = url
+
+        val el = createAudioElement(url)
+        addAudioProgressListener(el) { currentSec, durationSec ->
+            observer?.onProgressUpdate(currentSec.toWholeSeconds(), durationSec.toWholeSeconds())
+        }
+        addAudioEndedListener(el) { observer?.onComplete() }
+        addAudioErrorListener(el) { code -> Logger.e(tag = TAG) { "Audio element error $code" } }
+        element = el
+
+        playAudioElement(el) { reason -> Logger.w(tag = TAG) { "play() rejected: $reason" } }
+    }
+
+    override fun jump(seconds: Int) {
+        val el = element ?: return
+        setAudioCurrentTime(el, seconds.coerceAtLeast(0).toDouble())
+    }
+
+    override fun resume() {
+        val el = element ?: return
+        playAudioElement(el) { reason -> Logger.w(tag = TAG) { "resume() rejected: $reason" } }
+    }
+
+    override fun pause() {
+        element?.let { pauseAudioElement(it) }
+    }
+
+    override fun stop() {
+        val el = element ?: return
+        pauseAudioElement(el)
+        setAudioCurrentTime(el, 0.0)
+    }
+
+    override fun release() {
+        teardown()
+        observer = null
+    }
+
+    override fun setPlaybackObserver(observer: AudioPlaybackObserver) {
+        this.observer = observer
+    }
+
+    private fun teardown() {
+        element?.let { detachAudioElement(it) }
+        element = null
+        objectUrl?.let { revokeAudioObjectUrl(it) }
+        objectUrl = null
+    }
+
+    private companion object {
+        const val TAG = "WebAudioPlayer"
+    }
 }
 
-actual fun getAudioPlayer(): AudioPlayer = NoopAudioPlayer
+// A stream muxed without a duration box reports NaN/Infinity; 0 tells the widget to keep the
+// length it already read off the payload descriptor.
+private fun Double.toWholeSeconds(): Int =
+    if (isFinite() && this > 0.0) toInt() else 0
+
+private fun audioMimeForPath(path: String): String =
+    detectContentTypeFromExtensionOrHint(path).takeIf { it.startsWith("audio/") } ?: "audio/mp4"
+
+private fun audioBytesToObjectUrl(base64: String, mimeType: String): String = js(
+    """{
+        var bin = atob(base64);
+        var arr = new Uint8Array(bin.length);
+        for (var i = 0; i < bin.length; i++) arr[i] = bin.charCodeAt(i);
+        return URL.createObjectURL(new Blob([arr], { type: mimeType }));
+    }"""
+)
+
+private fun revokeAudioObjectUrl(url: String): Unit = js("{ URL.revokeObjectURL(url); }")
+
+private fun createAudioElement(url: String): JsAny = js(
+    """{
+        var a = new Audio();
+        a.preload = 'auto';
+        a.src = url;
+        a.load();
+        return a;
+    }"""
+)
+
+private fun playAudioElement(el: JsAny, onRejected: (String) -> Unit): Unit = js(
+    """{
+        var p = el.play();
+        if (p && typeof p.catch === 'function') p.catch(function (e) { onRejected(String(e)); });
+    }"""
+)
+
+private fun pauseAudioElement(el: JsAny): Unit = js("{ try { el.pause(); } catch (e) {} }")
+
+private fun setAudioCurrentTime(el: JsAny, seconds: Double): Unit = js(
+    "{ try { el.currentTime = seconds; } catch (e) {} }"
+)
+
+private fun addAudioProgressListener(el: JsAny, cb: (Double, Double) -> Unit): Unit = js(
+    """{
+        var emit = function () { cb(el.currentTime || 0, el.duration || 0); };
+        el.addEventListener('loadedmetadata', emit);
+        el.addEventListener('playing', emit);
+        el.addEventListener('timeupdate', emit);
+        el.addEventListener('seeked', emit);
+    }"""
+)
+
+private fun addAudioEndedListener(el: JsAny, cb: () -> Unit): Unit = js(
+    "{ el.addEventListener('ended', function () { cb(); }); }"
+)
+
+private fun addAudioErrorListener(el: JsAny, cb: (Int) -> Unit): Unit = js(
+    "{ el.addEventListener('error', function () { cb((el.error && el.error.code) || 0); }); }"
+)
+
+private fun detachAudioElement(el: JsAny): Unit = js(
+    """{
+        try { el.pause(); } catch (e) {}
+        try { el.removeAttribute('src'); el.load(); } catch (e) {}
+    }"""
+)
+
+actual fun getAudioPlayer(): AudioPlayer = WebAudioPlayer()


### PR DESCRIPTION
## Problem

On wasm, pressing play on a voice message showed a brief spinner and then nothing — no audio, and the clock never moved off `00:00`. The duration that *does* render comes from the payload descriptor, not the player, which is why it was the one thing that looked right.

`AudioPlayer.web.kt` was a pre-flight stub whose every method was empty, so the tap decrypted the payload and then `play()` no-opped. No `onProgressUpdate` callbacks were ever emitted.

A naive fix wouldn't have worked either: on wasm `systemFileSystem` is an in-memory okio `FakeFileSystem`, so the path `MediaDownloadHandler` hands back is not something the browser can fetch.

## Fix

Read the decrypted bytes back out of the in-memory FS (`readWebFileBytes`), wrap them in a Blob object URL, and drive a detached `HTMLAudioElement`. This is the same DOM bridge and Base64 hand-off the web video surfaces already use (`HtmlVideoOverlay.web.kt` / `LocalVideoPlayerSurface.web.kt`), so it stays consistent with how the rest of wasm media works.

- `timeupdate` / `loadedmetadata` / `playing` / `seeked` → `onProgressUpdate`
- `ended` → `onComplete`, `error` → logged with the media error code
- `jump` sets `currentTime`; the object URL is revoked on `release` and on replay
- MIME comes from the file extension via the existing `detectContentTypeFromExtensionOrHint`

One common-code change: `AudioPlayerWidget`'s progress observer now ignores a reported total of `0`. A blob-backed `<audio>` reports `duration` as `NaN`/`Infinity` for streams muxed without a duration box, which would otherwise wipe out the good length from the descriptor.

## Testing

`:homebase-common:compileKotlinWasmJs`, `:webApp:compileKotlinWasmJs`, `:homebase-common:compileKotlinJvm` and `:homebase-common:jvmTest` all pass. **Not yet verified in a live browser** — that needs a logged-in session with an audio message.

## Notes

- **Safari may need a second tap on the first play.** `play()` runs in the `LaunchedEffect` after decryption finishes, i.e. outside the user gesture. Chrome/Edge allow this once the user has interacted with the page; Safari is stricter. The rejection is logged (`WebAudioPlayer: play() rejected: …`) rather than swallowed, so if it bites we can prime the element on the click instead.
- **Recording is still unsupported on web** — `AudioRecordingFiles.web.kt` still throws. This is playback only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)