### PR TITLE
Give tablets the two-pane chat layout

### DIFF
--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/util/AdaptiveLayout.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/util/AdaptiveLayout.kt
@@ -2,14 +2,12 @@ package id.homebase.core.util
 
 import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
 import androidx.compose.runtime.Composable
+import androidx.window.core.layout.WindowSizeClass
 
-private const val ExpandedWidthBreakpointDp = 800
-
-/** Wide phones and tablets stay single-column: their touch targets and FAB placement
- *  assume one viewport, so the split is limited to pointer-driven targets. */
+// Both the navigation rail and the list/detail scaffolds must read this same gate —
+// if they diverge a tablet gets a rail beside a stretched single column.
 @Composable
 fun isExpandedLayout(): Boolean =
-    isDesktopOrWeb() &&
-        currentWindowAdaptiveInfo().windowSizeClass.isWidthAtLeastBreakpoint(
-            ExpandedWidthBreakpointDp
-        )
+    currentWindowAdaptiveInfo().windowSizeClass.isWidthAtLeastBreakpoint(
+        WindowSizeClass.WIDTH_DP_EXPANDED_LOWER_BOUND
+    )

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
@@ -38,7 +38,6 @@ import androidx.compose.material3.NavigationRailItem
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.ScaffoldDefaults
 import androidx.compose.material3.Text
-import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -67,7 +66,6 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
-import androidx.window.core.layout.WindowSizeClass
 import co.touchlab.kermit.Logger
 import id.homebase.api.sync.database.DatabaseManager
 import id.homebase.api.sync.database.DatabaseUpgradeState
@@ -170,6 +168,7 @@ import id.homebase.resources.vault_label
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.koinInject
 import id.homebase.core.util.getUriHandler
+import id.homebase.core.util.isExpandedLayout
 import kotlinx.io.files.Path
 import id.homebase.core.widget.InAppNotificationBanner
 import id.homebase.core.widget.UpdateAvailableBanner
@@ -212,7 +211,6 @@ fun AppNavHost(
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val authState by youAuthFlowManager.authState.collectAsStateWithLifecycle()
     val isAuthenticated = authState is YouAuthState.Authenticated
-    val adaptiveInfo = currentWindowAdaptiveInfo()
     val navBackStackEntry by navController.currentBackStackEntryAsState()
     val currentDestination = navBackStackEntry?.destination
     val momentsPreferences = koinInject<MomentsPreferences>()
@@ -300,9 +298,7 @@ fun AppNavHost(
 
     // Only show bottom nav if on a top-level route AND not showing only detail pane
     val isOnTopLevelScreen = isAuthenticated && isTopLevelRoute && !showingOnlyDetailPane
-    val showNavigationRail = adaptiveInfo.windowSizeClass.isWidthAtLeastBreakpoint(
-        WindowSizeClass.WIDTH_DP_EXPANDED_LOWER_BOUND
-    )
+    val showNavigationRail = isExpandedLayout()
     val vaultUiState by vaultViewModel.uiState.collectAsStateWithLifecycle()
     val isVaultGalleryOpen = vaultUiState.fullScreenOverlay != null
     // The full-screen image editor (newly-picked images) is a state-driven overlay, not a

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentsScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentsScreen.kt
@@ -198,7 +198,9 @@ fun MomentsScreen(
     // Self-renders only when the VM transitions to ShowDialog. No-op otherwise.
     ExtendPermissionDialog(viewModel = extendPermissionViewModel)
 
-    val isWide = isExpandedLayout()
+    // WideMomentsLayout's fixed 400dp comments rail squeezes the media column below ~1280dp;
+    // keep it pointer-only until it carries its own width threshold.
+    val isWide = isDesktopOrWeb() && isExpandedLayout()
 
     // Reels has no menu entry on pointer targets, so a persisted/synced Reels
     // preference must be coerced or the user lands there with no way back out.


### PR DESCRIPTION
## What

`isExpandedLayout()` required `isDesktopOrWeb()`, so tablets never got the list/detail split. `AppNavHost` meanwhile gated the navigation rail on **width alone**. The two disagreed:

- An iPad in landscape got the desktop navigation rail beside a **stretched single column**.
- Desktop windows between **800 and 840dp** got two panes *and* the bottom navigation bar, because panes used 800 and the rail used 840.

Both now read one gate at the Material 3 expanded bound (840dp). `showBottomNavigationBar` is already `!showNavigationRail`, so rail and pane count are consistent by construction — the dead zone can't come back unless someone reintroduces a second breakpoint.

Net −4 lines.

## Moments is deliberately left out

`MomentsScreen` keeps its `isDesktopOrWeb()` gate. `WideMomentsLayout` floors the feed pane at `FeedPaneMinWidth = 380.dp` and the comments rail is a **fixed** `CommentsRailWidth = 400.dp`, so at 1024dp the media column gets `1024 − 80 − 380 − 400 = 164dp` — a postage stamp in a full-height black column. It needs roughly 1280dp to be usable.

That threshold can't be expressed with `isWidthAtLeastBreakpoint()`, which compares against the size-class bucket bound (0/600/840), not the actual width — so it needs the raw window width and belongs in its own change. Note this also affects **desktop today** at 840–1280dp windows; it is not a new bug.

## Verification

| surface | result |
|---|---|
| iPad Pro 13" portrait (1024dp) | rail + list pane + detail pane empty state |
| iPad Pro 13" landscape (1366dp) | same; list holds ~360dp, detail absorbs the extra |
| iPad live window resize | collapses to single-pane at ~372dp, restores on re-widen — both directions |
| Desktop, 6 width bands | flips at exactly 839→840pt; 800/820/839 now coherently single-pane + bottom bar |
| Desktop Retina 1× and 2× | identical boundary; dp == macOS points regardless of backing scale |
| Redmi Note 5 Pro @ 1080dp | rail + both panes on a real touch device |

Compiles on JVM, Android, and wasmJs.

Desktop rail-vs-bottom-bar was read from the macOS accessibility tree (vertical 80x56 stack at the window edge vs horizontal full-width row), not inferred.

## Known follow-ups, not addressed here

1. **Android does not re-evaluate on rotation.** Cold-starting at 1080dp gives two panes; rotating 720dp → 1440dp stays single-pane, though the rows do reflow to the full width. iOS and desktop are clean — their `currentWindowAdaptiveInfo()` reads `LocalWindowInfo.containerSize`, which is snapshot state, while Android goes through `WindowMetricsCalculator` + configuration. `MainActivity` declares `configChanges="orientation|screenSize|screenLayout|smallestScreenSize"`, so the activity is never recreated. Pre-existing; the rail had the same width gate before this change.
2. **`WideMomentsLayout` needs its own width threshold**, per above.
3. Dropping below the breakpoint clears the selected conversation (`LaunchedEffect(isExpanded)` → `navigateBack()`), so re-expanding shows the empty state rather than reopening it.
