### PR TITLE
Give wide Moments its own width threshold

### DIFF
--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/util/AdaptiveLayout.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/util/AdaptiveLayout.kt
@@ -1,13 +1,18 @@
 package id.homebase.core.util
 
-import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalWindowInfo
+import androidx.compose.ui.unit.dp
 import androidx.window.core.layout.WindowSizeClass
 
-// Both the navigation rail and the list/detail scaffolds must read this same gate —
-// if they diverge a tablet gets a rail beside a stretched single column.
+// Reads the raw window width rather than the size class, because
+// WindowSizeClass.isWidthAtLeastBreakpoint compares against the bucket bound
+// (0/600/840) and so cannot express a threshold above 840.
 @Composable
-fun isExpandedLayout(): Boolean =
-    currentWindowAdaptiveInfo().windowSizeClass.isWidthAtLeastBreakpoint(
-        WindowSizeClass.WIDTH_DP_EXPANDED_LOWER_BOUND
-    )
+fun isExpandedLayout(
+    minWidthDp: Int = WindowSizeClass.WIDTH_DP_EXPANDED_LOWER_BOUND,
+): Boolean {
+    val widthPx = LocalWindowInfo.current.containerSize.width
+    return widthPx > 0 && with(LocalDensity.current) { widthPx.toDp() } >= minWidthDp.dp
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentsScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentsScreen.kt
@@ -198,9 +198,7 @@ fun MomentsScreen(
     // Self-renders only when the VM transitions to ShowDialog. No-op otherwise.
     ExtendPermissionDialog(viewModel = extendPermissionViewModel)
 
-    // WideMomentsLayout's fixed 400dp comments rail squeezes the media column below ~1280dp;
-    // keep it pointer-only until it carries its own width threshold.
-    val isWide = isDesktopOrWeb() && isExpandedLayout()
+    val isWide = isExpandedLayout(MomentsWideMinWidthDp)
 
     // Reels has no menu entry on pointer targets, so a persisted/synced Reels
     // preference must be coerced or the user lands there with no way back out.
@@ -251,6 +249,10 @@ fun MomentsScreen(
         )
     }
 }
+
+// rail 80 + FeedPaneMinWidth 380 + fixed CommentsRailWidth 400 leaves the media column
+// width-860; below this it collapses to a postage stamp (164dp at 1024dp).
+private const val MomentsWideMinWidthDp = 1280
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable


### PR DESCRIPTION
Follow-up to #1342, which noted this as deferred work.

## The bug

`WideMomentsLayout` floors the feed pane at `FeedPaneMinWidth = 380.dp` and its comments rail is a **fixed** `CommentsRailWidth = 400.dp`, so the media column is left with `width − 860`:

| window | media column |
|---|---|
| 840dp (the expanded bound) | **20dp** |
| 1024dp (iPad portrait) | **164dp** — measured |
| 1280dp | 420dp |
| 1366dp (iPad landscape) | **506dp** — measured |

So it was already broken on **desktop** at 840–1280dp windows, and #1342 would have exposed it on tablets too. That PR parked the problem behind an `isDesktopOrWeb()` stopgap; this removes it properly.

## Why the gate had to be reparameterised

`WindowSizeClass.isWidthAtLeastBreakpoint(n)` compares `n` against the size class's **bucket lower bound** (0/600/840), not the actual width — so `isWidthAtLeastBreakpoint(1280)` can never return true. A threshold above 840 is inexpressible with it.

`isExpandedLayout` now reads `LocalWindowInfo.current.containerSize` / `LocalDensity` directly and takes a `minWidthDp` parameter.

**The default is identical by construction, not just by measurement.** The old path reduced to:

```
containerSize.width.toDp() >= 840.dp    // via computeFromDpSize + minWidthDp >= 840
```

which is exactly the new expression. Same source value, same density, same comparison, no rounding on either side. The added `width > 0` guard is also not a behaviour change — the old path returned false at width 0 too.

## Verification (desktop, macOS a11y tree + partition log)

| width | nav | panes |
|---|---|---|
| 700 / 838 / **839** | bottom bar | 1 |
| **840** / 841 | rail | 2 |

Four independent 839→840 crossings, each emitting exactly one `more than 1 partition` line; 840→841 emitted none, correctly.

Moments, exact flip at the pixel:
- **1279** → one 1199-wide scroll area, no comments rail
- **1280** → 380 feed + 420 media + 400 comments rail at x=880

No crashes, no blank frames across ~15 resizes including repeated boundary crossings.

Compiles on JVM, wasmJs, and Android.

## Scope note

Dropping `isDesktopOrWeb()` makes wide Moments reachable on tablets at ≥1280dp. iPad landscape (1366dp) was observed rendering it correctly during #1342's verification, with the 506dp media column above. **Android tablets ≥1280dp are untested** — same commonMain layout, so low risk, but stated rather than assumed.

## Still open from #1342

Android does not re-evaluate the gate on rotation. Confirmed independent of the pane scaffold: the navigation rail also fails to appear, and it reads `isExpandedLayout()` directly. Ruled out — the adaptive library's Android path (it already resolves to the same `containerSize` on every target since adaptive 1.2.0 deleted the Android-specific implementation), the 2-D breakpoint set, and `initialDestinationHistory` latching. The likely cause is that Android's `LazyWindowInfo` refreshes only from `onAttachedToWindow()` and `updateConfiguration()`, with no layout-driven refresh. Separate PR.
