### PR TITLE
Attach files dropped from Finder/Explorer onto a conversation

### DIFF
--- a/homebase-chat/src/androidMain/kotlin/id/homebase/chat/widget/FileDropTarget.android.kt
+++ b/homebase-chat/src/androidMain/kotlin/id/homebase/chat/widget/FileDropTarget.android.kt
@@ -7,6 +7,6 @@ import io.github.vinceglb.filekit.PlatformFile
 @Composable
 actual fun Modifier.fileDropTarget(
     enabled: Boolean,
-    onDragOverChanged: (Boolean) -> Unit,
+    onDragPreviewChanged: (FileDropPreview?) -> Unit,
     onFilesDropped: (List<PlatformFile>) -> Unit,
 ): Modifier = this

--- a/homebase-chat/src/androidMain/kotlin/id/homebase/chat/widget/FileDropTarget.android.kt
+++ b/homebase-chat/src/androidMain/kotlin/id/homebase/chat/widget/FileDropTarget.android.kt
@@ -1,0 +1,12 @@
+package id.homebase.chat.widget
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import io.github.vinceglb.filekit.PlatformFile
+
+@Composable
+actual fun Modifier.fileDropTarget(
+    enabled: Boolean,
+    onDragOverChanged: (Boolean) -> Unit,
+    onFilesDropped: (List<PlatformFile>) -> Unit,
+): Modifier = this

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
@@ -173,6 +173,7 @@ import id.homebase.core.widget.StyledSearchTextField
 import id.homebase.resources.MR
 import id.homebase.resources.cancel
 import id.homebase.resources.chat_auto_connect_connected
+import id.homebase.resources.chat_drop_files_none_usable
 import id.homebase.resources.chat_group_not_connected_disclaimer
 import id.homebase.resources.chat_group_rejoin_accept
 import id.homebase.resources.chat_group_rejoin_decline
@@ -242,6 +243,16 @@ import kotlin.uuid.Uuid
  *  follow token is consumed unscrolled (the send failed or was gated out). */
 private const val OWN_SEND_FOLLOW_TIMEOUT_MS = 5_000L
 
+// Mirrors the states in which the composer below is replaced by a banner — keep the two in sync,
+// or a dropped file lands in a conversation with nothing to send it from.
+private fun EnrichedConversationUiModel.acceptsAttachments(): Boolean =
+    conversation.conversationState != ConversationState.Left &&
+        conversation.conversationState != ConversationState.Removed &&
+        conversation.conversationState != ConversationState.RejoinPending &&
+        oneOnOneConnectionStatus !is OneOnOneConnectionStatus.NotConnected &&
+        oneOnOneConnectionStatus !is OneOnOneConnectionStatus.OutgoingRequestPending &&
+        oneOnOneConnectionStatus !is OneOnOneConnectionStatus.IncomingRequestPending
+
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalComposeUiApi::class)
 @Composable
 fun ConversationContent(
@@ -282,6 +293,9 @@ fun ConversationContent(
     var payloadRenderers by remember { mutableStateOf<List<PayloadRenderer>>(emptyList()) }
 
     val snackbarHostState = remember { SnackbarHostState() }
+
+    var isFileDragOver by remember { mutableStateOf(false) }
+    val foldersOnlyDropMessage = stringResource(MR.string.chat_drop_files_none_usable)
 
     LaunchedEffect(uiState.isSearchActive) {
         if (uiState.isSearchActive) {
@@ -723,7 +737,22 @@ fun ConversationContent(
         LocalSavedContactIdentities provides uiState.savedContactIdentities,
     ) {
     Scaffold(
-        modifier = Modifier,
+        modifier = Modifier.fileDropTarget(
+            enabled = conversation.acceptsAttachments() && !uiState.isSearchActive,
+            onDragOverChanged = { isFileDragOver = it },
+            onFilesDropped = { files ->
+                if (files.isEmpty()) {
+                    coroutineScope.launch { snackbarHostState.showSnackbar(foldersOnlyDropMessage) }
+                } else {
+                    onUiAction(
+                        ConversationListUiAction.AttachPlatformFile(
+                            conversationId = conversation.conversation.id,
+                            files = files,
+                        )
+                    )
+                }
+            },
+        ),
         snackbarHost = { SnackbarHost(snackbarHostState) },
         topBar = {
             TopAppBar(
@@ -1771,6 +1800,11 @@ fun ConversationContent(
                     })
                 }
             } // AttachmentOptionsDisplay wrapper Box
+
+            FileDropOverlay(
+                visible = isFileDragOver,
+                modifier = Modifier.matchParentSize(),
+            )
         } // Box (clipToBounds)
     }
 

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
@@ -294,7 +294,7 @@ fun ConversationContent(
 
     val snackbarHostState = remember { SnackbarHostState() }
 
-    var isFileDragOver by remember { mutableStateOf(false) }
+    var dropPreview by remember { mutableStateOf<FileDropPreview?>(null) }
     val foldersOnlyDropMessage = stringResource(MR.string.chat_drop_files_none_usable)
 
     LaunchedEffect(uiState.isSearchActive) {
@@ -739,7 +739,7 @@ fun ConversationContent(
     Scaffold(
         modifier = Modifier.fileDropTarget(
             enabled = conversation.acceptsAttachments() && !uiState.isSearchActive,
-            onDragOverChanged = { isFileDragOver = it },
+            onDragPreviewChanged = { dropPreview = it },
             onFilesDropped = { files ->
                 if (files.isEmpty()) {
                     coroutineScope.launch { snackbarHostState.showSnackbar(foldersOnlyDropMessage) }
@@ -1802,7 +1802,7 @@ fun ConversationContent(
             } // AttachmentOptionsDisplay wrapper Box
 
             FileDropOverlay(
-                visible = isFileDragOver,
+                preview = dropPreview,
                 modifier = Modifier.matchParentSize(),
             )
         } // Box (clipToBounds)

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/FileDropTarget.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/FileDropTarget.kt
@@ -1,79 +1,209 @@
 package id.homebase.chat.widget
 
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.EaseOutBack
+import androidx.compose.animation.core.FastOutLinearInEasing
+import androidx.compose.animation.core.LinearOutSlowInEasing
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.FileUpload
+import androidx.compose.material.icons.outlined.FolderOff
+import androidx.compose.material.icons.outlined.Image
+import androidx.compose.material.icons.outlined.UploadFile
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathEffect
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.drawOutline
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import id.homebase.resources.MR
-import id.homebase.resources.chat_drop_files_hint
+import id.homebase.resources.chat_drop_files_count
+import id.homebase.resources.chat_drop_files_subtitle
+import id.homebase.resources.chat_drop_files_title
+import id.homebase.resources.chat_drop_folders_subtitle
+import id.homebase.resources.chat_drop_folders_title
+import id.homebase.resources.chat_drop_images_count
 import io.github.vinceglb.filekit.PlatformFile
+import org.jetbrains.compose.resources.pluralStringResource
 import org.jetbrains.compose.resources.stringResource
+
+@Immutable
+sealed interface FileDropPreview {
+    /** Over the target, but this platform only surrenders the payload on release (X11 does this). */
+    data object Unreadable : FileDropPreview
+
+    data class Attachable(val total: Int, val images: Int) : FileDropPreview
+
+    /** Readable, and nothing in it can be sent — folders, or entries we can't open. */
+    data object Rejected : FileDropPreview
+}
 
 // Desktop only; every other target has no external file-drag source and returns Modifier unchanged.
 @Composable
 expect fun Modifier.fileDropTarget(
     enabled: Boolean,
-    onDragOverChanged: (Boolean) -> Unit,
+    onDragPreviewChanged: (FileDropPreview?) -> Unit,
     onFilesDropped: (List<PlatformFile>) -> Unit,
 ): Modifier
 
 @Composable
-fun FileDropOverlay(visible: Boolean, modifier: Modifier = Modifier) {
+fun FileDropOverlay(preview: FileDropPreview?, modifier: Modifier = Modifier) {
+    // Retained so the card keeps its copy through the exit fade, after the drag reports null.
+    var shown by remember { mutableStateOf<FileDropPreview>(FileDropPreview.Unreadable) }
+    if (preview != null && preview != shown) shown = preview
+
+    val cardScale by animateFloatAsState(
+        targetValue = if (preview != null) 1f else 0.92f,
+        animationSpec = tween(durationMillis = 220, easing = EaseOutBack),
+        label = "fileDropCardScale",
+    )
+
+    val rejected = shown is FileDropPreview.Rejected
+    val accent = if (rejected) {
+        MaterialTheme.colorScheme.error
+    } else {
+        MaterialTheme.colorScheme.primary
+    }
+    val boundaryShape = MaterialTheme.shapes.extraLarge
+
     AnimatedVisibility(
-        visible = visible,
-        enter = fadeIn(),
-        exit = fadeOut(),
+        visible = preview != null,
+        enter = fadeIn(tween(durationMillis = 140, easing = LinearOutSlowInEasing)),
+        exit = fadeOut(tween(durationMillis = 90, easing = FastOutLinearInEasing)),
         modifier = modifier,
     ) {
         Box(
             modifier = Modifier.fillMaxSize()
-                .background(MaterialTheme.colorScheme.scrim.copy(alpha = 0.32f))
-                .padding(24.dp)
-                .border(
-                    width = 2.dp,
-                    color = MaterialTheme.colorScheme.primary,
-                    shape = RoundedCornerShape(16.dp),
-                ),
-            contentAlignment = Alignment.Center,
+                .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.78f)),
         ) {
-            Surface(
-                color = MaterialTheme.colorScheme.surfaceContainerHighest,
-                shape = RoundedCornerShape(16.dp),
+            Box(
+                modifier = Modifier.fillMaxSize()
+                    .padding(24.dp)
+                    .background(accent.copy(alpha = 0.07f), boundaryShape)
+                    .dashedBoundary(accent, boundaryShape, 2.dp),
+                contentAlignment = Alignment.Center,
             ) {
-                Column(
-                    modifier = Modifier.padding(horizontal = 24.dp, vertical = 20.dp),
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                    verticalArrangement = Arrangement.spacedBy(8.dp),
-                ) {
-                    Icon(
-                        imageVector = Icons.Default.FileUpload,
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.primary,
-                    )
-                    Text(
-                        text = stringResource(MR.string.chat_drop_files_hint),
-                        style = MaterialTheme.typography.titleSmall,
-                        color = MaterialTheme.colorScheme.onSurface,
-                    )
-                }
+                FileDropCard(
+                    preview = shown,
+                    modifier = Modifier.padding(24.dp).graphicsLayer {
+                        scaleX = cardScale
+                        scaleY = cardScale
+                    },
+                )
             }
         }
     }
+}
+
+@Composable
+private fun FileDropCard(preview: FileDropPreview, modifier: Modifier = Modifier) {
+    val rejected = preview is FileDropPreview.Rejected
+    val badgeColor = if (rejected) {
+        MaterialTheme.colorScheme.error
+    } else {
+        MaterialTheme.colorScheme.primary
+    }
+    val onBadgeColor = if (rejected) {
+        MaterialTheme.colorScheme.onError
+    } else {
+        MaterialTheme.colorScheme.onPrimary
+    }
+
+    Surface(
+        modifier = modifier,
+        shape = MaterialTheme.shapes.extraLarge,
+        color = MaterialTheme.colorScheme.surfaceContainerHigh,
+        shadowElevation = 6.dp,
+    ) {
+        Column(
+            modifier = Modifier.widthIn(min = 280.dp, max = 400.dp)
+                .padding(horizontal = 32.dp, vertical = 32.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Box(
+                modifier = Modifier.size(64.dp).background(badgeColor, CircleShape),
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    imageVector = preview.icon(),
+                    contentDescription = null,
+                    tint = onBadgeColor,
+                    modifier = Modifier.size(30.dp),
+                )
+            }
+            Text(
+                text = stringResource(
+                    if (rejected) MR.string.chat_drop_folders_title else MR.string.chat_drop_files_title
+                ),
+                style = MaterialTheme.typography.headlineSmall,
+                color = MaterialTheme.colorScheme.onSurface,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.padding(top = 12.dp),
+            )
+            Text(
+                text = preview.supportingText(),
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+            )
+        }
+    }
+}
+
+private fun FileDropPreview.icon(): ImageVector = when {
+    this is FileDropPreview.Rejected -> Icons.Outlined.FolderOff
+    this is FileDropPreview.Attachable && images == total -> Icons.Outlined.Image
+    else -> Icons.Outlined.UploadFile
+}
+
+@Composable
+private fun FileDropPreview.supportingText(): String = when {
+    this is FileDropPreview.Rejected -> stringResource(MR.string.chat_drop_folders_subtitle)
+    this is FileDropPreview.Attachable && images == total ->
+        pluralStringResource(MR.plurals.chat_drop_images_count, total, total)
+    this is FileDropPreview.Attachable ->
+        pluralStringResource(MR.plurals.chat_drop_files_count, total, total)
+    else -> stringResource(MR.string.chat_drop_files_subtitle)
+}
+
+private fun Modifier.dashedBoundary(color: Color, shape: Shape, width: Dp) = drawBehind {
+    drawOutline(
+        outline = shape.createOutline(size, layoutDirection, this),
+        color = color,
+        style = Stroke(
+            width = width.toPx(),
+            pathEffect = PathEffect.dashPathEffect(
+                floatArrayOf(14.dp.toPx(), 10.dp.toPx()),
+            ),
+        ),
+    )
 }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/FileDropTarget.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/FileDropTarget.kt
@@ -1,0 +1,79 @@
+package id.homebase.chat.widget
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.FileUpload
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import id.homebase.resources.MR
+import id.homebase.resources.chat_drop_files_hint
+import io.github.vinceglb.filekit.PlatformFile
+import org.jetbrains.compose.resources.stringResource
+
+// Desktop only; every other target has no external file-drag source and returns Modifier unchanged.
+@Composable
+expect fun Modifier.fileDropTarget(
+    enabled: Boolean,
+    onDragOverChanged: (Boolean) -> Unit,
+    onFilesDropped: (List<PlatformFile>) -> Unit,
+): Modifier
+
+@Composable
+fun FileDropOverlay(visible: Boolean, modifier: Modifier = Modifier) {
+    AnimatedVisibility(
+        visible = visible,
+        enter = fadeIn(),
+        exit = fadeOut(),
+        modifier = modifier,
+    ) {
+        Box(
+            modifier = Modifier.fillMaxSize()
+                .background(MaterialTheme.colorScheme.scrim.copy(alpha = 0.32f))
+                .padding(24.dp)
+                .border(
+                    width = 2.dp,
+                    color = MaterialTheme.colorScheme.primary,
+                    shape = RoundedCornerShape(16.dp),
+                ),
+            contentAlignment = Alignment.Center,
+        ) {
+            Surface(
+                color = MaterialTheme.colorScheme.surfaceContainerHighest,
+                shape = RoundedCornerShape(16.dp),
+            ) {
+                Column(
+                    modifier = Modifier.padding(horizontal = 24.dp, vertical = 20.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.FileUpload,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.primary,
+                    )
+                    Text(
+                        text = stringResource(MR.string.chat_drop_files_hint),
+                        style = MaterialTheme.typography.titleSmall,
+                        color = MaterialTheme.colorScheme.onSurface,
+                    )
+                }
+            }
+        }
+    }
+}

--- a/homebase-chat/src/jvmMain/kotlin/id/homebase/chat/widget/FileDropTarget.jvm.kt
+++ b/homebase-chat/src/jvmMain/kotlin/id/homebase/chat/widget/FileDropTarget.jvm.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.draganddrop.DragAndDropEvent
 import androidx.compose.ui.draganddrop.DragAndDropTarget
 import androidx.compose.ui.draganddrop.DragData
 import androidx.compose.ui.draganddrop.dragData
+import id.homebase.core.util.detectContentTypeFromExtensionOrHint
 import io.github.vinceglb.filekit.PlatformFile
 import java.io.File
 import java.net.URI
@@ -18,21 +19,22 @@ import java.net.URI
 @Composable
 actual fun Modifier.fileDropTarget(
     enabled: Boolean,
-    onDragOverChanged: (Boolean) -> Unit,
+    onDragPreviewChanged: (FileDropPreview?) -> Unit,
     onFilesDropped: (List<PlatformFile>) -> Unit,
 ): Modifier {
-    val dragOverChanged = rememberUpdatedState(onDragOverChanged)
+    val previewChanged = rememberUpdatedState(onDragPreviewChanged)
     val filesDropped = rememberUpdatedState(onFilesDropped)
     val target = remember {
         object : DragAndDropTarget {
-            override fun onEntered(event: DragAndDropEvent) = dragOverChanged.value(true)
+            override fun onEntered(event: DragAndDropEvent) =
+                previewChanged.value(event.previewDraggedFiles())
 
-            override fun onExited(event: DragAndDropEvent) = dragOverChanged.value(false)
+            override fun onExited(event: DragAndDropEvent) = previewChanged.value(null)
 
-            override fun onEnded(event: DragAndDropEvent) = dragOverChanged.value(false)
+            override fun onEnded(event: DragAndDropEvent) = previewChanged.value(null)
 
             override fun onDrop(event: DragAndDropEvent): Boolean {
-                dragOverChanged.value(false)
+                previewChanged.value(null)
                 filesDropped.value(event.droppedFiles())
                 return true
             }
@@ -49,11 +51,24 @@ actual fun Modifier.fileDropTarget(
 private fun DragAndDropEvent.filesList(): DragData.FilesList? =
     runCatching { dragData() }.getOrNull() as? DragData.FilesList
 
+// X11 refuses transfer data until the drop, and a cross-process source may refuse it too.
 @OptIn(ExperimentalComposeUiApi::class)
-private fun DragAndDropEvent.droppedFiles(): List<PlatformFile> {
-    val uris = filesList()?.let { runCatching { it.readFiles() }.getOrNull() } ?: return emptyList()
-    return uris
-        .mapNotNull { uri -> runCatching { File(URI(uri)) }.getOrNull() }
-        .filter { it.isFile && it.canRead() }
-        .map { PlatformFile(it) }
+private fun DragAndDropEvent.draggedFiles(): List<File> =
+    filesList()?.let { runCatching { it.readFiles() }.getOrNull() }
+        ?.mapNotNull { uri -> runCatching { File(URI(uri)) }.getOrNull() }
+        .orEmpty()
+
+private fun DragAndDropEvent.previewDraggedFiles(): FileDropPreview {
+    val dragged = draggedFiles().ifEmpty { return FileDropPreview.Unreadable }
+    val attachable = dragged.filter { it.isFile && it.canRead() }
+    if (attachable.isEmpty()) return FileDropPreview.Rejected
+    return FileDropPreview.Attachable(
+        total = attachable.size,
+        images = attachable.count {
+            detectContentTypeFromExtensionOrHint(it.name).startsWith("image/")
+        },
+    )
 }
+
+private fun DragAndDropEvent.droppedFiles(): List<PlatformFile> =
+    draggedFiles().filter { it.isFile && it.canRead() }.map { PlatformFile(it) }

--- a/homebase-chat/src/jvmMain/kotlin/id/homebase/chat/widget/FileDropTarget.jvm.kt
+++ b/homebase-chat/src/jvmMain/kotlin/id/homebase/chat/widget/FileDropTarget.jvm.kt
@@ -1,0 +1,59 @@
+package id.homebase.chat.widget
+
+import androidx.compose.foundation.draganddrop.dragAndDropTarget
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draganddrop.DragAndDropEvent
+import androidx.compose.ui.draganddrop.DragAndDropTarget
+import androidx.compose.ui.draganddrop.DragData
+import androidx.compose.ui.draganddrop.dragData
+import io.github.vinceglb.filekit.PlatformFile
+import java.io.File
+import java.net.URI
+
+@OptIn(ExperimentalComposeUiApi::class)
+@Composable
+actual fun Modifier.fileDropTarget(
+    enabled: Boolean,
+    onDragOverChanged: (Boolean) -> Unit,
+    onFilesDropped: (List<PlatformFile>) -> Unit,
+): Modifier {
+    val dragOverChanged = rememberUpdatedState(onDragOverChanged)
+    val filesDropped = rememberUpdatedState(onFilesDropped)
+    val target = remember {
+        object : DragAndDropTarget {
+            override fun onEntered(event: DragAndDropEvent) = dragOverChanged.value(true)
+
+            override fun onExited(event: DragAndDropEvent) = dragOverChanged.value(false)
+
+            override fun onEnded(event: DragAndDropEvent) = dragOverChanged.value(false)
+
+            override fun onDrop(event: DragAndDropEvent): Boolean {
+                dragOverChanged.value(false)
+                filesDropped.value(event.droppedFiles())
+                return true
+            }
+        }
+    }
+    if (!enabled) return this
+    return this.dragAndDropTarget(
+        shouldStartDragAndDrop = { it.filesList() != null },
+        target = target,
+    )
+}
+
+@OptIn(ExperimentalComposeUiApi::class)
+private fun DragAndDropEvent.filesList(): DragData.FilesList? =
+    runCatching { dragData() }.getOrNull() as? DragData.FilesList
+
+@OptIn(ExperimentalComposeUiApi::class)
+private fun DragAndDropEvent.droppedFiles(): List<PlatformFile> {
+    val uris = filesList()?.let { runCatching { it.readFiles() }.getOrNull() } ?: return emptyList()
+    return uris
+        .mapNotNull { uri -> runCatching { File(URI(uri)) }.getOrNull() }
+        .filter { it.isFile && it.canRead() }
+        .map { PlatformFile(it) }
+}

--- a/homebase-chat/src/nativeMain/kotlin/id/homebase/chat/widget/FileDropTarget.native.kt
+++ b/homebase-chat/src/nativeMain/kotlin/id/homebase/chat/widget/FileDropTarget.native.kt
@@ -7,6 +7,6 @@ import io.github.vinceglb.filekit.PlatformFile
 @Composable
 actual fun Modifier.fileDropTarget(
     enabled: Boolean,
-    onDragOverChanged: (Boolean) -> Unit,
+    onDragPreviewChanged: (FileDropPreview?) -> Unit,
     onFilesDropped: (List<PlatformFile>) -> Unit,
 ): Modifier = this

--- a/homebase-chat/src/nativeMain/kotlin/id/homebase/chat/widget/FileDropTarget.native.kt
+++ b/homebase-chat/src/nativeMain/kotlin/id/homebase/chat/widget/FileDropTarget.native.kt
@@ -1,0 +1,12 @@
+package id.homebase.chat.widget
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import io.github.vinceglb.filekit.PlatformFile
+
+@Composable
+actual fun Modifier.fileDropTarget(
+    enabled: Boolean,
+    onDragOverChanged: (Boolean) -> Unit,
+    onFilesDropped: (List<PlatformFile>) -> Unit,
+): Modifier = this

--- a/homebase-chat/src/wasmJsMain/kotlin/id/homebase/chat/widget/FileDropTarget.web.kt
+++ b/homebase-chat/src/wasmJsMain/kotlin/id/homebase/chat/widget/FileDropTarget.web.kt
@@ -7,6 +7,6 @@ import io.github.vinceglb.filekit.PlatformFile
 @Composable
 actual fun Modifier.fileDropTarget(
     enabled: Boolean,
-    onDragOverChanged: (Boolean) -> Unit,
+    onDragPreviewChanged: (FileDropPreview?) -> Unit,
     onFilesDropped: (List<PlatformFile>) -> Unit,
 ): Modifier = this

--- a/homebase-chat/src/wasmJsMain/kotlin/id/homebase/chat/widget/FileDropTarget.web.kt
+++ b/homebase-chat/src/wasmJsMain/kotlin/id/homebase/chat/widget/FileDropTarget.web.kt
@@ -1,0 +1,12 @@
+package id.homebase.chat.widget
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import io.github.vinceglb.filekit.PlatformFile
+
+@Composable
+actual fun Modifier.fileDropTarget(
+    enabled: Boolean,
+    onDragOverChanged: (Boolean) -> Unit,
+    onFilesDropped: (List<PlatformFile>) -> Unit,
+): Modifier = this

--- a/homebase-common/src/commonMain/composeResources/values/plurals.xml
+++ b/homebase-common/src/commonMain/composeResources/values/plurals.xml
@@ -20,4 +20,12 @@
         <item quantity="one">· %1$d member</item>
         <item quantity="other">· %1$d members</item>
     </plurals>
+    <plurals name="chat_drop_files_count">
+        <item quantity="one">%1$d file</item>
+        <item quantity="other">%1$d files</item>
+    </plurals>
+    <plurals name="chat_drop_images_count">
+        <item quantity="one">%1$d image</item>
+        <item quantity="other">%1$d images</item>
+    </plurals>
 </resources>

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -709,7 +709,10 @@
     <string name="chat_message_options">Message options</string>
     <string name="chat_message_attachment_options">Attachment options</string>
     <string name="chat_attach_file_failed">Failed to attach file(s): %s</string>
-    <string name="chat_drop_files_hint">Drop files to attach</string>
+    <string name="chat_drop_files_title">Drop to attach</string>
+    <string name="chat_drop_files_subtitle">Release to add them to this conversation</string>
+    <string name="chat_drop_folders_title">Folders can't be attached</string>
+    <string name="chat_drop_folders_subtitle">Drop individual files instead</string>
     <string name="chat_drop_files_none_usable">Folders can't be attached. Drop files instead.</string>
     <string name="chat_message_camera">Camera</string>
     <string name="chat_message_take_photo">Take photo</string>

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -709,6 +709,8 @@
     <string name="chat_message_options">Message options</string>
     <string name="chat_message_attachment_options">Attachment options</string>
     <string name="chat_attach_file_failed">Failed to attach file(s): %s</string>
+    <string name="chat_drop_files_hint">Drop files to attach</string>
+    <string name="chat_drop_files_none_usable">Folders can't be attached. Drop files instead.</string>
     <string name="chat_message_camera">Camera</string>
     <string name="chat_message_take_photo">Take photo</string>
     <string name="chat_message_record_video">Record video</string>


### PR DESCRIPTION
There was **no drag-and-drop anywhere in this repo** — `grep -rn "dragAndDropTarget\|onExternalDrag"` returned nothing. You could not drag a file from Finder onto a conversation, which is table stakes for a desktop chat client.

## Approach

Dropped files are routed into `ConversationListUiAction.AttachPlatformFile` — the exact action the FileKit picker, camera and gallery launchers already dispatch. It lands in `AttachmentHandler.handleAttachPlatformFile`, which types the file and opens the attachment editor. **No new upload path and no new dependency**; a dropped file and a picked file are indistinguishable downstream.

The target sits on `ConversationContent`'s `Scaffold` modifier, which both the single-pane and two-pane `ConversationMessagesPane` render, so a drop anywhere over the message list or composer works.

## Desktop scoping

`Modifier.fileDropTarget(...)` is an `expect` in `commonMain` following the existing `Modifier.pasteImageContextMenuItem` precedent. Only the `jvmMain` actual does anything; Android, native and wasmJs return `this` unchanged, and `commonMain` carries no desktop imports.

Two AWT details worth recording. `dragExit` delivers a bare `DropTargetEvent`, so `awtTransferable` throws there — the exit/end handlers only clear the preview and never touch it. `dragEnter`, by contrast, delivers a `DropTargetDragEvent` that *does* carry the transferable on macOS and Windows, which is what lets the overlay name the payload before the drop; X11 refuses transfer data until release, so the read is wrapped and falls back to generic copy.

## Drop affordance

The first pass was a flat 2dp border and one `titleSmall` line. Replaced with a designed
takeover of the message area:

- **Wash** — `surface` at 78% alpha rather than `scrim`. Black-at-32% over a light chat is
  a dead grey; the surface role inverts correctly, giving a frosted white in light and a
  proper dim in dark.
- **Boundary** — the drop-zone idiom: a dashed `primary` stroke (2dp, 14/10 dash) inset
  24dp, drawn from `shapes.extraLarge` via `drawOutline` so the radius agrees with the rest
  of the app and RTL is handled by `createOutline`. Interior carries a 7% `primary` tint.
- **Card** — `surfaceContainerHigh` at `shapes.extraLarge`, 6dp shadow, 32dp internal
  padding, 280–400dp wide. A solid 64dp `primary` badge (`onPrimary` glyph) — the
  `primaryContainer` pair was too close to the card in light theme to read.
- **Type** — `headlineSmall` action line over a `bodyLarge` `onSurfaceVariant` supporting
  line. Everything from `MaterialTheme.typography` / `colorScheme`; no literal colours or
  strings.
- **Motion** — 140ms `LinearOutSlowInEasing` fade in, 90ms out; the card scales 0.92 → 1
  over 220ms on `EaseOutBack`. Both go through `Transition`/`Animatable`, which read
  `MotionDurationScale` from the composition context, so a platform reporting reduce-motion
  snaps them. AWT exposes no reduce-motion signal on desktop (checked: no such
  `Toolkit` desktop property, no Compose API), which is why the durations stay short.

### It says what will happen

`FileDropOverlay` now takes a `FileDropPreview` instead of a `Boolean`:

| state | shown |
| --- | --- |
| `Attachable(total, images)`, all images | image glyph, "3 images" |
| `Attachable(total, images)`, mixed | upload glyph, "5 files" |
| `Rejected` (folders only) | `error` roles, "Folders can't be attached / Drop individual files instead" |
| `Unreadable` (payload withheld until drop) | generic "Release to add them to this conversation" |

The folders-only case is now caught on drag-*enter* and shown in the error role, instead of
only surfacing as a snackbar after a drop that does nothing. The snackbar stays as the
fallback for platforms that withhold the payload.

Drop behaviour, `AttachPlatformFile` routing and the folder/unreadable filtering are
unchanged.

## Edge cases

- **Folders / unreadable entries** — filtered on `isFile && canRead`. A drop of nothing but folders shows a snackbar rather than failing silently.
- **Unsupported types** — nothing is type-filtered; a dropped file keeps its real name so `resolveContentType` types it, and non-media becomes a generic file attachment, same as the picker's "File" option.
- **Many files** — not capped, deliberately: one drop of N is identical to one `FileKitMode.Multiple()` pick of N through the same handler. If a cap is wanted it belongs in `handleAttachPlatformFile` so both paths get it.
- **Non-file drags** (text, an image from another app) never start a session, so there is no overlay flash.
- **Composer-hidden states** — disabled when the composer is replaced by a banner (Left / Removed / RejoinPending / NotConnected / Outgoing / Incoming) or during search.

## Verified

Compiles on JVM, Android, wasmJs, and iosSimulatorArm64; `:desktopApp:compileKotlinJvm` and `:homebase-chat:jvmTest` green. `ArchitectureTest` passes — Konsist uses `scopeFromProject()` so it saw the new files.

The overlay itself was rendered off-screen through `runDesktopComposeUiTest` + `captureToImage` in both themes, in all four preview states, at wide (1100dp) and narrow (420dp) pane widths, and across the enter animation frames — a throwaway harness, not committed. That is how the light-theme wash, the badge contrast and the card-vs-boundary spacing at narrow widths were caught.

## NOT verified — needs a human

**No actual drop was exercised.** A Finder drag cannot be simulated headlessly (AWT DnD needs a real drag source; Robot and `screencapture` are blocked by missing macOS permissions). Please confirm manually:

1. Drag 3 JPEGs over the message area → frosted wash, dashed blue boundary, card reading "Drop to attach" / "3 images". Drag out → it clears. Check light **and** dark.
2. Drop it → attachment editor opens with the image, not a generic file chip.
3. Drop a PDF and a `.zip` → generic file attachments. Drop 3 at once → three pending attachments.
4. Drag a **folder** in → the card turns red and says folders can't be attached, before you release. Release anyway → no attachment, snackbar explains why.
5. A group you have left, or an unconnected 1:1 → no highlight, drop does nothing.

## Known gap

While the attachment editor overlay is already open, `ConversationContent` is not composed, so a second drop onto the editor does nothing. Adding files there needs a separate target on the editor — deliberately out of scope.

## Maintenance note

`acceptsAttachments()` mirrors the composer's banner `if`-chain. If those conditions drift, a drop could land in a conversation with nothing to send it from. Folding both onto one hoisted value would mean refactoring that chain, so the duplication carries a comment instead.

