### PR TITLE
Add a desktop menu bar and keyboard shortcuts

### DIFF
--- a/desktopApp/src/jvmMain/kotlin/id/homebase/app/Main.kt
+++ b/desktopApp/src/jvmMain/kotlin/id/homebase/app/Main.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyShortcut
@@ -45,7 +46,6 @@ import id.homebase.core.logging.CrashLogger
 import id.homebase.core.logging.LoggerConfig
 import id.homebase.core.logging.StartupLogger
 import id.homebase.core.logging.crashlyticsRecordException
-import id.homebase.core.settings.ThemeState
 import id.homebase.core.settings.UserPreferences
 import id.homebase.core.settings.applyStoredLocale
 import id.homebase.core.ui.navigation.Route
@@ -60,11 +60,9 @@ import id.homebase.resources.chat_new_conversation
 import id.homebase.resources.desktop_menu_close_window
 import id.homebase.resources.desktop_menu_file
 import id.homebase.resources.desktop_menu_quit
-import id.homebase.resources.desktop_menu_view
 import id.homebase.resources.desktop_tray_show_window
 import id.homebase.resources.desktop_tray_version
 import id.homebase.resources.homebase_icon_round
-import id.homebase.resources.settings
 import id.homebase.resources.theme
 import id.homebase.resources.update_available
 import io.github.vinceglb.filekit.FileKit
@@ -245,8 +243,10 @@ fun main() {
             return@application
         }
 
-        // macOS resolves the app-menu Quit (and its Cmd+Q) itself, above the JMenuBar, so
-        // without this handler that path exits without persisting the window geometry.
+        // Quit and Settings belong to the macOS app menu, which AppKit owns above the
+        // JMenuBar — the app-menu Quit would otherwise exit without persisting geometry,
+        // and no Preferences item appears at all until a handler is registered.
+        val currentNavigate = rememberUpdatedState(navigateTo)
         DisposableEffect(Unit) {
             val awtDesktop = if (Desktop.isDesktopSupported()) Desktop.getDesktop() else null
             val quitHandlerDesktop =
@@ -255,7 +255,15 @@ fun main() {
                 saveWindowGeometry()
                 response.performQuit()
             }
-            onDispose { quitHandlerDesktop?.setQuitHandler(null) }
+            val prefsDesktop =
+                awtDesktop?.takeIf { it.isSupported(Desktop.Action.APP_PREFERENCES) }
+            prefsDesktop?.setPreferencesHandler {
+                currentNavigate.value?.invoke(Route.Settings)
+            }
+            onDispose {
+                quitHandlerDesktop?.setQuitHandler(null)
+                prefsDesktop?.setPreferencesHandler(null)
+            }
         }
 
         Tray(
@@ -314,36 +322,12 @@ fun main() {
                         shortcut = menuShortcut(Key.N),
                         onClick = { navigateTo?.invoke(Route.CreateConversation) },
                     )
-                    Item(
-                        text = stringResource(MR.string.settings),
-                        enabled = canNavigate,
-                        shortcut = menuShortcut(Key.Comma),
-                        onClick = { navigateTo?.invoke(Route.Settings) },
-                    )
                     Separator()
                     Item(
                         text = stringResource(MR.string.desktop_menu_close_window),
                         shortcut = menuShortcut(Key.W),
                         onClick = hideWindow,
                     )
-                    Item(
-                        text = stringResource(MR.string.desktop_menu_quit),
-                        shortcut = menuShortcut(Key.Q),
-                        onClick = quitApplication,
-                    )
-                }
-                Menu(stringResource(MR.string.desktop_menu_view)) {
-                    Menu(stringResource(MR.string.theme)) {
-                        ThemeState.entries.forEach { option ->
-                            RadioButtonItem(
-                                text = option.getStringResourceForTheme(),
-                                selected = uiState.theme == option,
-                                onClick = {
-                                    viewModel.onUiAction(DesktopUiAction.SetTheme(option))
-                                },
-                            )
-                        }
-                    }
                 }
             }
 

--- a/desktopApp/src/jvmMain/kotlin/id/homebase/app/Main.kt
+++ b/desktopApp/src/jvmMain/kotlin/id/homebase/app/Main.kt
@@ -3,12 +3,16 @@ package id.homebase.app
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Update
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyShortcut
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.MenuBar
 import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.application
 import androidx.compose.ui.window.rememberWindowState
@@ -25,6 +29,8 @@ import id.homebase.api.client.eventbus.EventBus
 import id.homebase.api.file.JvmFileSystemUtil
 import id.homebase.api.sync.database.DatabaseDriverFactory
 import id.homebase.api.sync.database.DatabaseManager
+import id.homebase.api.youauth.YouAuthFlowManager
+import id.homebase.api.youauth.YouAuthState
 import id.homebase.app.lifecycle.rememberDesktopLifecycleOwner
 import id.homebase.core.App
 import id.homebase.core.auth.AuthConnectionCoordinator
@@ -39,8 +45,10 @@ import id.homebase.core.logging.CrashLogger
 import id.homebase.core.logging.LoggerConfig
 import id.homebase.core.logging.StartupLogger
 import id.homebase.core.logging.crashlyticsRecordException
+import id.homebase.core.settings.ThemeState
 import id.homebase.core.settings.UserPreferences
 import id.homebase.core.settings.applyStoredLocale
+import id.homebase.core.ui.navigation.Route
 import id.homebase.core.ui.screens.appearance.getIconForTheme
 import id.homebase.core.ui.screens.appearance.getStringResourceForTheme
 import id.homebase.core.ui.screens.desktop.DesktopUiAction
@@ -48,7 +56,16 @@ import id.homebase.core.ui.screens.desktop.DesktopViewModel
 import id.homebase.core.util.PlatformInfo
 import id.homebase.resources.MR
 import id.homebase.resources.app_name
+import id.homebase.resources.chat_new_conversation
+import id.homebase.resources.desktop_menu_close_window
+import id.homebase.resources.desktop_menu_file
+import id.homebase.resources.desktop_menu_quit
+import id.homebase.resources.desktop_menu_view
+import id.homebase.resources.desktop_tray_show_window
+import id.homebase.resources.desktop_tray_version
 import id.homebase.resources.homebase_icon_round
+import id.homebase.resources.settings
+import id.homebase.resources.theme
 import id.homebase.resources.update_available
 import io.github.vinceglb.filekit.FileKit
 import kotlinx.coroutines.runBlocking
@@ -57,6 +74,7 @@ import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 import org.koin.core.context.GlobalContext
 import org.koin.core.context.GlobalContext.startKoin
+import java.awt.Desktop
 import java.io.File
 
 fun main() {
@@ -161,6 +179,7 @@ fun main() {
     // Apply saved locale
     val koin = GlobalContext.get()
     val userPreferences = koin.get<UserPreferences>()
+    val youAuthFlowManager = koin.get<YouAuthFlowManager>()
 
     runBlocking { applyStoredLocale(userPreferences) }
     StartupLogger.checkpoint("locale applied")
@@ -176,7 +195,14 @@ fun main() {
         val uiState by viewModel.uiState.collectAsState()
         val icon = painterResource(MR.drawable.homebase_icon_round)
         var isWindowVisible by remember { mutableStateOf(true) }
+        // compose-native-tray composes its menu in a detached composition, so every tray
+        // label has to be resolved out here.
+        val appName = stringResource(MR.string.app_name)
         val updateAvailable = stringResource(MR.string.update_available)
+        val showWindowLabel = stringResource(MR.string.desktop_tray_show_window)
+        val themeMenuLabel = stringResource(MR.string.theme)
+        val quitLabel = stringResource(MR.string.desktop_menu_quit)
+        val versionLabel = stringResource(MR.string.desktop_tray_version, uiState.version)
         val state = rememberWindowState(
             placement = config.windowPlacement,
             position = config.windowPosition,
@@ -184,6 +210,29 @@ fun main() {
             height = maxOf(config.windowHeightDp, minHeight.dp), // Minimum height
         )
         val themeLabel = uiState.theme.getStringResourceForTheme()
+
+        val authState by youAuthFlowManager.authState.collectAsState()
+        var navigateTo by remember { mutableStateOf<((Route) -> Unit)?>(null) }
+        val canNavigate = navigateTo != null && authState is YouAuthState.Authenticated
+
+        val saveWindowGeometry = {
+            try {
+                config.windowPlacement = state.placement
+                config.windowPosition = state.position
+                config.windowWidthDp = maxOf(state.size.width, minWidth.dp)
+                config.windowHeightDp = maxOf(state.size.height, minHeight.dp)
+            } catch (_: Exception) {
+                // ignore
+            }
+        }
+        val hideWindow = {
+            saveWindowGeometry()
+            isWindowVisible = false
+        }
+        val quitApplication = {
+            saveWindowGeometry()
+            exitApplication()
+        }
 
         val isSingleInstance = SingleInstanceManager.isSingleInstance(
             onRestoreRequest = {
@@ -196,19 +245,32 @@ fun main() {
             return@application
         }
 
+        // macOS resolves the app-menu Quit (and its Cmd+Q) itself, above the JMenuBar, so
+        // without this handler that path exits without persisting the window geometry.
+        DisposableEffect(Unit) {
+            val awtDesktop = if (Desktop.isDesktopSupported()) Desktop.getDesktop() else null
+            val quitHandlerDesktop =
+                awtDesktop?.takeIf { it.isSupported(Desktop.Action.APP_QUIT_HANDLER) }
+            quitHandlerDesktop?.setQuitHandler { _, response ->
+                saveWindowGeometry()
+                response.performQuit()
+            }
+            onDispose { quitHandlerDesktop?.setQuitHandler(null) }
+        }
+
         Tray(
             icon = icon,
-            tooltip = stringResource(MR.string.app_name),
+            tooltip = appName,
             primaryAction = {
                 isWindowVisible = !isWindowVisible
             },
         ) {
-            Item(label = "Show Window") {
+            Item(label = showWindowLabel) {
                 isWindowVisible = true
             }
 
             Divider()
-            Item(label = "Theme", isEnabled = false)
+            Item(label = themeMenuLabel, isEnabled = false)
             Item(
                 label = themeLabel,
                 icon = uiState.theme.getIconForTheme(),
@@ -218,17 +280,8 @@ fun main() {
 
             Divider()
 
-            // Reactive checkable item
-//            CheckableItem(
-//                label = "Notifications",
-//                checked = notificationsEnabled,
-//                onCheckedChange = { notificationsEnabled = it }
-//            )
-//
-//            Divider()
-
-            Item(label = "Homebase Chat", isEnabled = false)
-            Item(label = "Version ${uiState.version}", isEnabled = false)
+            Item(label = appName, isEnabled = false)
+            Item(label = versionLabel, isEnabled = false)
             if (uiState.updateAvailable) {
                 Item(
                     label = updateAvailable,
@@ -240,49 +293,77 @@ fun main() {
 
             Divider()
 
-            // Quit option
-            Item(label = "Quit") {
-                try {
-                    config.windowPlacement = state.placement
-                    config.windowPosition = state.position
-                    config.windowWidthDp = maxOf(state.size.width, minWidth.dp)
-                    config.windowHeightDp = maxOf(state.size.height, minHeight.dp)
-                } catch (_: Exception) {
-                    // ignore
-                }
-                exitApplication()  // This properly exits the application
+            Item(label = quitLabel) {
+                quitApplication()
             }
         }
 
         Window(
-            onCloseRequest = {
-                try {
-                    config.windowPlacement = state.placement
-                    config.windowPosition = state.position
-                    config.windowWidthDp = maxOf(state.size.width, minWidth.dp)
-                    config.windowHeightDp = maxOf(state.size.height, minHeight.dp)
-                } catch (_: Exception) {
-                    // ignore
-                }
-                isWindowVisible = false
-            },
+            onCloseRequest = hideWindow,
             alwaysOnTop = false,
-            title = stringResource(MR.string.app_name),
+            title = appName,
             icon = icon,
             state = state,
             visible = isWindowVisible
         ) {
+            MenuBar {
+                Menu(stringResource(MR.string.desktop_menu_file)) {
+                    Item(
+                        text = stringResource(MR.string.chat_new_conversation),
+                        enabled = canNavigate,
+                        shortcut = menuShortcut(Key.N),
+                        onClick = { navigateTo?.invoke(Route.CreateConversation) },
+                    )
+                    Item(
+                        text = stringResource(MR.string.settings),
+                        enabled = canNavigate,
+                        shortcut = menuShortcut(Key.Comma),
+                        onClick = { navigateTo?.invoke(Route.Settings) },
+                    )
+                    Separator()
+                    Item(
+                        text = stringResource(MR.string.desktop_menu_close_window),
+                        shortcut = menuShortcut(Key.W),
+                        onClick = hideWindow,
+                    )
+                    Item(
+                        text = stringResource(MR.string.desktop_menu_quit),
+                        shortcut = menuShortcut(Key.Q),
+                        onClick = quitApplication,
+                    )
+                }
+                Menu(stringResource(MR.string.desktop_menu_view)) {
+                    Menu(stringResource(MR.string.theme)) {
+                        ThemeState.entries.forEach { option ->
+                            RadioButtonItem(
+                                text = option.getStringResourceForTheme(),
+                                selected = uiState.theme == option,
+                                onClick = {
+                                    viewModel.onUiAction(DesktopUiAction.SetTheme(option))
+                                },
+                            )
+                        }
+                    }
+                }
+            }
+
             DesktopAppFocusManager.registerWindowProvider { window }
             window.minimumSize = java.awt.Dimension(minWidth, minHeight)
 
             // Provide Desktop-specific LifecycleOwner to the composition tree
             val desktopLifecycleOwner = rememberDesktopLifecycleOwner(isWindowVisible)
             CompositionLocalProvider(LocalLifecycleOwner provides desktopLifecycleOwner) {
-                App()
+                App(onNavigatorReady = { navigateTo = it })
             }
         }
     }
 }
+
+private val usesCommandKey =
+    System.getProperty("os.name").orEmpty().startsWith("Mac", ignoreCase = true)
+
+private fun menuShortcut(key: Key) =
+    KeyShortcut(key, ctrl = !usesCommandKey, meta = usesCommandKey)
 
 private fun setupCrashHandler() {
     Thread.setDefaultUncaughtExceptionHandler { thread, throwable ->

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -1953,7 +1953,6 @@
     <string name="settings_notification_content_name_only">Name Only</string>
     <string name="settings_notification_content_no_name_or_content">No Name or Content</string>
     <string name="desktop_menu_file">File</string>
-    <string name="desktop_menu_view">View</string>
     <string name="desktop_menu_close_window">Close Window</string>
     <string name="desktop_menu_quit">Quit</string>
     <string name="desktop_tray_show_window">Show Window</string>

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -1952,4 +1952,10 @@
     <string name="settings_notification_content_name_content_actions">Name, Content, and Actions</string>
     <string name="settings_notification_content_name_only">Name Only</string>
     <string name="settings_notification_content_no_name_or_content">No Name or Content</string>
+    <string name="desktop_menu_file">File</string>
+    <string name="desktop_menu_view">View</string>
+    <string name="desktop_menu_close_window">Close Window</string>
+    <string name="desktop_menu_quit">Quit</string>
+    <string name="desktop_tray_show_window">Show Window</string>
+    <string name="desktop_tray_version">Version %1$s</string>
 </resources>

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/App.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/App.kt
@@ -15,6 +15,7 @@ import id.homebase.core.settings.ThemeState
 import id.homebase.core.settings.UserPreferences
 import id.homebase.core.ui.navigation.AppNavHost
 import id.homebase.core.ui.navigation.AppViewModel
+import id.homebase.core.ui.navigation.Route
 import id.homebase.core.ui.theme.HomebaseTheme
 import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
@@ -24,6 +25,7 @@ import org.koin.compose.viewmodel.koinViewModel
 @Composable
 fun App(
     onNavHostReady: suspend (NavController) -> Unit = {},
+    onNavigatorReady: ((Route) -> Unit) -> Unit = {},
 ) {
     remember { StartupLogger.checkpoint("App() first composition") }
     val navController = rememberNavController()
@@ -55,6 +57,9 @@ fun App(
             navController = navController,
             youAuthFlowManager = youAuthFlowManager
         )
-        LaunchedEffect(navController) { onNavHostReady(navController) }
+        LaunchedEffect(navController) {
+            onNavigatorReady { route -> navController.navigate(route) { launchSingleTop = true } }
+            onNavHostReady(navController)
+        }
     }
 }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/desktop/DesktopViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/desktop/DesktopViewModel.kt
@@ -47,6 +47,10 @@ class DesktopViewModel(
                 userPreferences.theme = newTheme
             }
 
+            is DesktopUiAction.SetTheme -> {
+                userPreferences.theme = action.theme
+            }
+
             is DesktopUiAction.TriggerUpdate -> {
                 triggerUpdate()
             }
@@ -82,5 +86,6 @@ data class DesktopUiState(
 
 sealed interface DesktopUiAction {
     data object ToggleTheme : DesktopUiAction
+    data class SetTheme(val theme: ThemeState) : DesktopUiAction
     data object TriggerUpdate : DesktopUiAction
 }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/desktop/DesktopViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/desktop/DesktopViewModel.kt
@@ -47,9 +47,6 @@ class DesktopViewModel(
                 userPreferences.theme = newTheme
             }
 
-            is DesktopUiAction.SetTheme -> {
-                userPreferences.theme = action.theme
-            }
 
             is DesktopUiAction.TriggerUpdate -> {
                 triggerUpdate()
@@ -86,6 +83,5 @@ data class DesktopUiState(
 
 sealed interface DesktopUiAction {
     data object ToggleTheme : DesktopUiAction
-    data class SetTheme(val theme: ThemeState) : DesktopUiAction
     data object TriggerUpdate : DesktopUiAction
 }


### PR DESCRIPTION
The desktop app had **no `MenuBar` at all**. On macOS that means no discoverable shortcuts and nothing but the system app menu.

## Menu

**App menu** (AppKit-owned) — About · **Settings… (⌘,)** · Services · Hide · **Quit (⌘Q)**

**File** — New conversation (⌘N) · separator · Close Window (⌘W)

That is the whole menu bar, deliberately.

Settings goes through `Desktop.setPreferencesHandler`, which fills the reserved Preferences slot that otherwise stays empty. Quit is AppKit's own, wired to `Desktop.setQuitHandler` so it persists window geometry — without it that path exits without saving. Both handlers read the navigator through `rememberUpdatedState`, since `navigateTo` is null at first composition and capturing it directly would leave a permanently dead item.

`Close Window` hides rather than exits, matching the existing `onCloseRequest` — this is a tray-resident app.

Shortcuts map to `meta` on macOS and `ctrl` elsewhere.

## Deliberately not included

- **A View menu.** It would only have held a theme submenu duplicating Settings → Appearance and the tray. Dropped, along with the `DesktopUiAction.SetTheme` added for it.
- **A second Quit in File.** AppKit already provides one and was stripping the accelerator from ours, so users saw two Quits and one of them had no shortcut.
- **Edit (Undo/Cut/Copy/Paste/Select All).** Compose Desktop text fields already handle ⌘C/⌘V/⌘X/⌘A. A `MenuBar` item with those accelerators becomes a native NSMenu key equivalent that intercepts the keystroke *before* Compose sees it — adding them would **break** copy/paste rather than extend it. Without accelerators the items are dead.
- **Search (⌘F).** `ConversationListViewModel` is a Koin factory built with `koinViewModel()` inside the NavHost back-stack entry, so `koin.get()` from `Main.kt` yields a different instance and toggles nothing. Needs new cross-module event plumbing.

## Also cleaned up in the same file

- Tray labels `"Show Window"` / `"Theme"` / `"Homebase Chat"` / `"Version …"` / `"Quit"` were hardcoded English, bypassing `stringResource()`. Now Compose resources, resolved outside the tray content lambda because compose-native-tray composes detached.
- Deleted the commented-out dead `CheckableItem` block.
- The window-geometry save was copy-pasted three times; now one `saveWindowGeometry` lambda.

## Navigation plumbing

`desktopApp` does not have `navigation-compose` on its compile classpath (it is `implementation` in `homebase-core`), so `App()` gained a defaulted `onNavigatorReady: ((Route) -> Unit) -> Unit` returning a route-level navigator rather than the `NavController`. No build-file change, no new dependency, and every existing call site is unaffected by the default.

## Verification

`:desktopApp:compileKotlinJvm` clean — this module has `allWarningsAsErrors = true`. `ArchitectureTest` passes.

Read back from the macOS accessibility tree on a running app:

```
MENU BAR:  Apple, MainKt, File
FILE:      New conversation, —, Close Window
APP MENU:  About, —, Settings…, —, Services, —, Hide, …, Quit
```

Earlier revision was also click-verified: Settings opens the real Settings screen, New conversation opens the real CreateConversation screen, ⌘W hides with the process alive (`onWindowHidden -> CREATED`), ⌘Q exits cleanly.

Note: the app menu reads "MainKt" under `desktopApp:run` because that is the main class name. The packaged build sets `packageName = "Homebase Chat"` (`desktopApp/build.gradle.kts:203`), so shipped users see the correct name.

## Note

Touches `strings.xml`, as does #1345. Additions are at different points in the file so they should merge cleanly, but whichever lands second is worth a glance.