### PR TITLE
Security: generate key material from a CSPRNG, not kotlin.random.Random

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -180,6 +180,7 @@ sqldelight-sqlite338-dialect = { module = "app.cash.sqldelight:sqlite-3-38-diale
 android-database-sqlcipher = { module = "net.zetetic:sqlcipher-android", version.ref = "sqlcipher" }
 cryptography-core = { module = "dev.whyoleg.cryptography:cryptography-core", version.ref = "cryptography" }
 cryptography-provider-optimal = { module = "dev.whyoleg.cryptography:cryptography-provider-optimal", version.ref = "cryptography" }
+cryptography-random = { module = "dev.whyoleg.cryptography:cryptography-random", version.ref = "cryptography" }
 kotlinx-coroutinesSwing = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-swing", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "kotlinx-coroutines" }

--- a/homebase-api/build.gradle.kts
+++ b/homebase-api/build.gradle.kts
@@ -209,6 +209,7 @@ kotlin {
             implementation(libs.kotlinx.coroutines.core)
             implementation(libs.cryptography.core)
             implementation(libs.cryptography.provider.optimal)
+            implementation(libs.cryptography.random)
             implementation(libs.sqldelight.runtime)
             implementation(libs.sqldelight.coroutines.extensions)
             implementation(libs.navigation.compose)

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/crypto/ByteArrayUtil.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/crypto/ByteArrayUtil.kt
@@ -1,6 +1,5 @@
 package id.homebase.api.crypto
 
-import kotlin.random.Random
 import kotlin.uuid.Uuid
 
 /**
@@ -259,10 +258,14 @@ object ByteArrayUtil {
     }
 
     /**
-     * Generates a cryptographically safe array of random bytes
+     * Generates a cryptographically safe array of random bytes.
+     *
+     * Delegates to [OdinSecureRandom] — the platform CSPRNG. This used to call
+     * kotlin.random.Random, which is a seeded xorshift PRNG and produces predictable
+     * AES keys, IVs and GCM nonces.
      */
     fun getRndByteArray(nCount: Int): ByteArray {
-        return Random.Default.nextBytes(nCount)
+        return OdinSecureRandom.nextBytes(nCount)
     }
 
     /**

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/crypto/OdinSecureRandom.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/crypto/OdinSecureRandom.kt
@@ -1,0 +1,20 @@
+package id.homebase.api.crypto
+
+import dev.whyoleg.cryptography.random.CryptographyRandom
+
+/**
+ * The one random source for key material in this codebase.
+ *
+ * Backed by cryptography-kotlin's platform-native generators — `java.security.SecureRandom`
+ * on JVM/Android, `CCRandomGenerateBytes` on Apple, `crypto.getRandomValues` on wasmJs.
+ *
+ * Never `kotlin.random.Random`: that is a seeded xorshift PRNG, so an observer who learns
+ * its state can reproduce every subsequent draw. Everything downstream of here is key
+ * material — AES keys, CBC IVs and GCM nonces — where that is fatal.
+ */
+internal object OdinSecureRandom {
+    fun nextBytes(count: Int): ByteArray {
+        require(count >= 0) { "count must be non-negative, was $count" }
+        return CryptographyRandom.nextBytes(count)
+    }
+}

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/crypto/OdinSecureRandomTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/crypto/OdinSecureRandomTest.kt
@@ -1,0 +1,97 @@
+package id.homebase.api.crypto
+
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+/**
+ * Guards the CSPRNG behind every AES key, IV and GCM nonce in the app.
+ *
+ * The regression these exist for: [ByteArrayUtil.getRndByteArray] used to return
+ * `kotlin.random.Random.Default.nextBytes(n)` while documenting itself as
+ * cryptographically safe.
+ */
+class OdinSecureRandomTest {
+
+    @Test
+    fun zeroLengthIsEmpty() {
+        assertEquals(0, ByteArrayUtil.getRndByteArray(0).size)
+    }
+
+    @Test
+    fun negativeLengthThrows() {
+        assertFailsWith<IllegalArgumentException> { ByteArrayUtil.getRndByteArray(-1) }
+    }
+
+    @Test
+    fun requestedSizeIsHonoured() {
+        for (size in listOf(1, 12, 16, 32, 64, 128)) {
+            assertEquals(size, ByteArrayUtil.getRndByteArray(size).size)
+        }
+    }
+
+    @Test
+    fun drawsDoNotRepeat() {
+        val seen = HashSet<String>()
+        repeat(1000) {
+            val draw = ByteArrayUtil.getRndByteArray(32).toHexString()
+            assertTrue(seen.add(draw), "duplicate 32-byte draw — the generator is not random")
+        }
+    }
+
+    /**
+     * The real regression guard: a seeded PRNG produces the same first draw in every
+     * process, so a fixed-seed sequence must never match what we hand out.
+     */
+    @Test
+    fun outputDoesNotMatchASeededPrng() {
+        for (seed in listOf(0, 1, 42, 12345)) {
+            assertNotEquals(
+                Random(seed).nextBytes(32).toHexString(),
+                ByteArrayUtil.getRndByteArray(32).toHexString(),
+                "output matches kotlin.random.Random($seed) — the CSPRNG delegation is gone",
+            )
+        }
+    }
+
+    /** Every byte value should show up across 100 KB; a stub returning zeros would not. */
+    @Test
+    fun outputCoversTheWholeByteRange() {
+        val counts = IntArray(256)
+        repeat(100) {
+            for (b in ByteArrayUtil.getRndByteArray(1024)) {
+                counts[b.toInt() and 0xFF]++
+            }
+        }
+        assertEquals(0, counts.count { it == 0 }, "some byte values never appeared")
+    }
+
+    @Test
+    fun outputPassesTheExistingStrongKeyCheck() {
+        repeat(1000) {
+            assertTrue(ByteArrayUtil.isStrongKey(ByteArrayUtil.getRndByteArray(16)))
+        }
+    }
+
+    @Test
+    fun randomGuidsAreDistinct() {
+        val seen = HashSet<String>()
+        repeat(1000) {
+            assertTrue(seen.add(ByteArrayUtil.getRandomCryptoGuid().toString()))
+        }
+    }
+
+    @Test
+    fun wipeStillClears() {
+        val bytes = ByteArrayUtil.getRndByteArray(32)
+        ByteArrayUtil.wipeByteArray(bytes)
+        assertContentEquals(ByteArray(32), bytes)
+    }
+
+    private fun ByteArray.toHexString(): String =
+        joinToString("") { (it.toInt() and 0xFF).toString(16).padStart(2, '0') }
+}


### PR DESCRIPTION
`ByteArrayUtil.getRndByteArray` documents itself as "cryptographically safe" while returning `kotlin.random.Random.Default.nextBytes(n)` — a seeded xorshift PRNG, not a CSPRNG.

It is the source for every drive `KeyHeader` AES key and IV, every AES-CBC IV, **every AES-GCM nonce**, upload transfer IVs, WebSocket frame IVs, and `getRandomCryptoGuid` — 36 call sites.

### The fix

Route it through the platform CSPRNG. No `expect`/`actual` needed: cryptography-kotlin's `CryptographyRandom` is already on the compile classpath and already used by `DatabaseKeyManager`, and its actuals are `java.security.SecureRandom` (JVM/Android), `CCRandomGenerateBytes` (Apple) and `crypto.getRandomValues` (wasmJs). The dependency is now declared explicitly rather than arriving transitively.

### Tests

Size and argument handling, non-repetition across 1000 draws, byte-range coverage, and a regression guard asserting the output does **not** match `Random(seed).nextBytes` — which is what would fail if anyone routes this back through the seeded PRNG.

`:homebase-api:jvmTest` green.

### Scope

Split out of the email work and rebased onto current `main`, because it stands entirely on its own — it is not email-specific and affects all client-side key material.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EcPf3xgN4BoFfMkgmqgrxG