### PR TITLE
Add the Email setup add-on shell

### DIFF
--- a/EMAIL_APP.md
+++ b/EMAIL_APP.md
@@ -30,14 +30,21 @@ Stalwart directly. An in-app reader may come later; nothing here precludes it.
 
 1. Extend-permissions dialog (standard add-on step) — includes the email drive.
 2. Create the **email drive**.
-3. Generate the **E2E encryption keypair on the device**, store it encrypted on the
-   email drive (⇒ Shamir-recoverable, multi-device via drive sync; the private key
-   never exists outside owner-locked storage — keys doc custody table).
-4. Choose the **primary address** (below).
-5. Call the server's `POST /api/owner/v1/mail/activate` — the server does the rest
-   (DKIM generation, DNS records, DID/WKD publication, Stalwart provisioning).
+3. Choose the **primary address** (defaults to `mail@<identity>`) and call
+   `POST /api/v2/mail/setup/mailbox` — DKIM generation, DNS records and the mailbox itself.
+4. Generate the **encryption keypair** LAST, via `POST /api/v2/mail/setup/keys`. The server
+   generates it — chat-kmp has no OpenPGP implementation, and cryptography-kotlin cannot be
+   seeded — mixing in entropy the app collects from the phone's accelerometer, and writes the
+   keyring straight to the email drive before publishing its certificate. The app reads it back
+   by the returned unique id. (⇒ Shamir-recoverable, multi-device via drive sync.)
+5. Issue an **app password** (`POST /api/v2/mail/app-passwords`) — only possible once a key is
+   published, so it comes after step 4, not before.
 6. Show the address as live; delegated vs manual-records domains may surface a
-   "records pending" state fed by the owner API status endpoints.
+   "records pending" state fed by the status endpoint.
+
+Every step is idempotent and its completion is observable (drive mounted, server status,
+credential files on the drive), so setup resumes after the app is killed without the client
+keeping a progress file.
 
 Deactivation/uninstall hides the app but deletes nothing; teardown is a separate,
 deliberately heavy destructive action (mail and keys are on the line).

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/mail/MailModels.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/mail/MailModels.kt
@@ -1,0 +1,54 @@
+package id.homebase.api.client.mail
+
+import id.homebase.api.serialization.UuidSerializer
+import kotlinx.serialization.Serializable
+import kotlin.uuid.Uuid
+
+/**
+ * Wire models for /api/v2/mail. Mirrors odin-core `Odin.Services.Email.MailAppStatusResult`
+ * and friends — the server's naming strategy is camelCase, so field names must match exactly.
+ * `ignoreUnknownKeys` is on, so a misspelling here fails SILENTLY as a null/default rather
+ * than an error; MailModelsSerializationTest is the guard.
+ */
+@Serializable
+data class MailAppStatus(
+    /** Whether this host runs tenant mail at all. False on every host today. */
+    val tenantMailEnabled: Boolean = false,
+    /** The email drive exists and this app holds Read+Write on it. */
+    val driveProvisioned: Boolean = false,
+    val mailboxProvisioned: Boolean = false,
+    val primaryEmailAddress: String? = null,
+    /** A public certificate is published — the server-side "email is on" signal. */
+    val activated: Boolean = false,
+    val publicKeyFingerprint: String? = null,
+    val publishedAt: Long? = null,
+    val dkimRecords: List<MailDnsRecord> = emptyList(),
+    /** The drive file holding the current secret keyring, once one exists. */
+    @Serializable(with = UuidSerializer::class)
+    val currentKeyFileUniqueId: Uuid? = null,
+)
+
+/**
+ * A DNS record the identity's zone needs. Shaped by the server's DnsConfig; only the fields the
+ * app actually shows are declared.
+ */
+@Serializable
+data class MailDnsRecord(
+    val type: String = "",
+    /** The record's label, e.g. "s1._domainkey". */
+    val name: String = "",
+    /** The fully-qualified name the record is published at — what you paste into a DNS provider. */
+    val domain: String = "",
+    val value: String = "",
+    val description: String = "",
+)
+
+/**
+ * Server half of the encrypt/decrypt round-trip check: decrypt [encryptedNonceBase64] with the
+ * keyring from the email drive and compare its SHA-256 against [nonceSha256Base64].
+ */
+@Serializable
+data class MailRoundTripChallenge(
+    val encryptedNonceBase64: String = "",
+    val nonceSha256Base64: String = "",
+)

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/mail/MailProvider.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/mail/MailProvider.kt
@@ -1,0 +1,62 @@
+package id.homebase.api.client.mail
+
+import co.touchlab.kermit.Logger
+import id.homebase.api.client.OdinApiProviderBase
+import id.homebase.api.client.auth.CredentialsManager
+import io.ktor.client.HttpClient
+
+/**
+ * The Email setup app's server surface, /api/v2/mail.
+ *
+ * Reachable on a plain app token: the server authorizes these calls by the app's Read+Write
+ * access to the email drive rather than by a permission key, so nothing here needs the owner
+ * console. Bodies ride the usual shared-secret envelope.
+ */
+class MailProvider(
+    httpClient: HttpClient,
+    credentialsManager: CredentialsManager,
+) : OdinApiProviderBase(httpClient, credentialsManager) {
+
+    companion object {
+        private const val TAG = "MailProvider"
+        private const val BASE = "/mail"
+    }
+
+    /**
+     * Everything the app's entry flow branches on. Never gated: it answers before the email drive
+     * exists, which is what lets the app tell "this server has no email" apart from "you have not
+     * set it up yet".
+     */
+    suspend fun getStatus(): MailAppStatus {
+        val creds = requireCreds()
+        val response = encryptedGet(
+            url = apiUrl(creds.domain, "$BASE/status"),
+            token = creds.accessToken,
+            secret = creds.secret,
+        )
+        throwForFailure(response)
+        val status = deserialize<MailAppStatus>(response.body)
+        Logger.d(tag = TAG) {
+            "status: enabled=${status.tenantMailEnabled} drive=${status.driveProvisioned} " +
+                "mailbox=${status.mailboxProvisioned} activated=${status.activated}"
+        }
+        return status
+    }
+
+    /**
+     * Asks for a message encrypted to the published key, to prove this device's keyring can still
+     * read incoming mail. Requires Read+Write on the email drive (403 otherwise) and a published
+     * key (400 otherwise).
+     */
+    suspend fun createRoundTripChallenge(): MailRoundTripChallenge {
+        val creds = requireCreds()
+        val response = encryptedPostJson(
+            url = apiUrl(creds.domain, "$BASE/challenge"),
+            token = creds.accessToken,
+            jsonBody = "{}",
+            secret = creds.secret,
+        )
+        throwForFailure(response)
+        return deserialize<MailRoundTripChallenge>(response.body)
+    }
+}

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/di/ApiModule.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/di/ApiModule.kt
@@ -28,6 +28,7 @@ import id.homebase.api.client.drives.query.DriveQueryProvider
 import id.homebase.api.client.drives.upload.DriveUploadProvider
 import id.homebase.api.client.eventbus.EventBus
 import id.homebase.api.client.follow.FollowProvider
+import id.homebase.api.client.mail.MailProvider
 import id.homebase.api.client.identity.PublicIdentityRepository
 import id.homebase.api.client.link.LinkPreviewProvider
 import id.homebase.api.client.location.LocationPreviewProvider
@@ -115,6 +116,7 @@ val apiModule = module {
     factoryOf(::DriveFileOperationsProvider)
     factoryOf(::DriveFileGroupReactionProvider)
     factoryOf(::FollowProvider)
+    factoryOf(::MailProvider)
 
     factoryOf(::ConnectionNetworkProvider)
     factoryOf(::PeerDriveQueryProvider)

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/client/mail/MailModelsSerializationTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/client/mail/MailModelsSerializationTest.kt
@@ -1,0 +1,115 @@
+package id.homebase.api.client.mail
+
+import id.homebase.api.serialization.OdinSystemSerializer
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.uuid.Uuid
+
+/**
+ * `ignoreUnknownKeys` is on for every wire model in this app, so a field named differently from
+ * the server's is not an error — it silently stays at its default. For mail that would be quiet
+ * and nasty: `activated` reading false forever would send a set-up identity back through
+ * onboarding.
+ *
+ * The JSON below is written by hand to match what odin-core's
+ * `Odin.Services.Email.MailAppStatusResult` serializes (camelCase naming strategy). If the
+ * server shape changes, this test is where it should break.
+ */
+class MailModelsSerializationTest {
+
+    @Test
+    fun statusParsesTheServerShape() {
+        val json = """
+            {
+              "tenantMailEnabled": true,
+              "driveProvisioned": true,
+              "mailboxProvisioned": true,
+              "primaryEmailAddress": "mail@frodo.dotyou.cloud",
+              "activated": true,
+              "publicKeyFingerprint": "9F3C21A8B45D0E117C6290AF3B18D5E44E70DD12",
+              "publishedAt": 1755763200000,
+              "dkimRecords": [
+                { "type": "TXT", "name": "s1._domainkey", "domain": "s1._domainkey.frodo.dotyou.cloud", "value": "v=DKIM1; k=ed25519; p=abc", "description": "DKIM" }
+              ],
+              "currentKeyFileUniqueId": "3f1b6d4e-8a02-4c77-9e51-2b90ad63c8f1"
+            }
+        """.trimIndent()
+
+        val status = OdinSystemSerializer.deserialize<MailAppStatus>(json)
+
+        assertTrue(status.tenantMailEnabled)
+        assertTrue(status.driveProvisioned)
+        assertTrue(status.mailboxProvisioned)
+        assertEquals("mail@frodo.dotyou.cloud", status.primaryEmailAddress)
+        assertTrue(status.activated)
+        assertEquals("9F3C21A8B45D0E117C6290AF3B18D5E44E70DD12", status.publicKeyFingerprint)
+        assertEquals(1755763200000L, status.publishedAt)
+        assertEquals(Uuid.parse("3f1b6d4e-8a02-4c77-9e51-2b90ad63c8f1"), status.currentKeyFileUniqueId)
+
+        assertEquals(1, status.dkimRecords.size)
+        assertEquals("s1._domainkey", status.dkimRecords[0].name)
+        assertEquals("TXT", status.dkimRecords[0].type)
+        assertEquals("s1._domainkey.frodo.dotyou.cloud", status.dkimRecords[0].domain)
+        assertEquals("v=DKIM1; k=ed25519; p=abc", status.dkimRecords[0].value)
+    }
+
+    /** The flag-off, nothing-set-up answer every host gives today. */
+    @Test
+    fun statusParsesTheEmptyServerShape() {
+        val json = """
+            {
+              "tenantMailEnabled": false,
+              "driveProvisioned": false,
+              "mailboxProvisioned": false,
+              "activated": false,
+              "dkimRecords": []
+            }
+        """.trimIndent()
+
+        val status = OdinSystemSerializer.deserialize<MailAppStatus>(json)
+
+        assertEquals(false, status.tenantMailEnabled)
+        assertNull(status.primaryEmailAddress)
+        assertNull(status.publishedAt)
+        assertNull(status.currentKeyFileUniqueId)
+        assertTrue(status.dkimRecords.isEmpty())
+    }
+
+    /**
+     * Guards the silent-failure mode itself: a payload whose keys are all wrong must NOT read as
+     * a plausible status. If someone renames a field on one side only, this is what catches it.
+     */
+    @Test
+    fun misnamedFieldsDoNotSilentlyPopulate() {
+        val json = """
+            {
+              "tenant_mail_enabled": true,
+              "DriveProvisioned": true,
+              "isActivated": true
+            }
+        """.trimIndent()
+
+        val status = OdinSystemSerializer.deserialize<MailAppStatus>(json)
+
+        assertEquals(false, status.tenantMailEnabled)
+        assertEquals(false, status.driveProvisioned)
+        assertEquals(false, status.activated)
+    }
+
+    @Test
+    fun challengeParsesTheServerShape() {
+        val json = """
+            {
+              "encryptedNonceBase64": "wcDMA0hp0m8AAAAB",
+              "nonceSha256Base64": "n4bQgYhMfWWaL+qgxVrQFaO/TxsrC4Is0V1sFbDwCgg="
+            }
+        """.trimIndent()
+
+        val challenge = OdinSystemSerializer.deserialize<MailRoundTripChallenge>(json)
+
+        assertEquals("wcDMA0hp0m8AAAAB", challenge.encryptedNonceBase64)
+        assertEquals("n4bQgYhMfWWaL+qgxVrQFaO/TxsrC4Is0V1sFbDwCgg=", challenge.nonceSha256Base64)
+    }
+}

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -1079,6 +1079,35 @@
     <string name="upload_failed_action_delete">Delete moment</string>
     <string name="upload_failed_action_dismiss">Dismiss</string>
 
+    <!-- Email setup — the add-on that turns email on for this identity and manages its
+         keys. Not a mail reader: reading happens in Thunderbird-class clients. -->
+    <string name="email_label">Email setup</string>
+    <string name="email_home_subtitle">Set up and manage your email</string>
+    <string name="email_onboarding_title">Email on your own identity</string>
+    <string name="email_onboarding_body_1">Set up an address that belongs to your Homebase identity, and keep the keys to it on your own drive.</string>
+    <string name="email_onboarding_body_2">You read and write mail in the app you already use. This screen is where you set it up and manage your keys.</string>
+    <string name="email_onboarding_setup">Set it up</string>
+    <string name="email_onboarding_dismiss">Dismiss</string>
+    <string name="email_onboarding_dismiss_hint">Dismissing hides the icon — find Email setup again under Home.</string>
+    <string name="email_permission_dialog_title">Extend Permissions</string>
+    <string name="email_permission_dialog_text">To set up email we need a drive to keep your mail keys and app passwords on.</string>
+    <string name="email_permission_extend">Extend</string>
+    <string name="email_permission_cancel">Cancel</string>
+    <string name="email_no_server_title">This server has no email yet</string>
+    <string name="email_no_server_body_1">Your Homebase server hasn't turned on email for its identities. There is nothing to set up here for now.</string>
+    <string name="email_no_server_body_2">When your server operator enables it, come back and this screen will offer setup.</string>
+    <string name="email_no_server_note">We asked your server and it answered no — this isn't a network problem, and there is nothing wrong with your identity.</string>
+    <string name="email_no_server_retry">Check again</string>
+    <string name="email_no_server_close">Close</string>
+    <string name="email_checking">Checking with your server…</string>
+    <string name="email_settings_section">Email setup</string>
+    <string name="email_settings_open">Open Email setup</string>
+    <string name="email_settings_show_icon">Show Email setup icon in bottom bar</string>
+    <string name="email_settings_biometrics">Biometrics protection</string>
+    <string name="email_biometric_prompt_title">Unlock Email setup</string>
+    <string name="email_biometric_prompt_subtitle">Authenticate to access your mail keys</string>
+    <string name="settings_email_desc">Your address, keys and mail app passwords</string>
+
     <!-- Vault -->
     <string name="vault_label">Vault</string>
     <string name="vault_home_subtitle">Your secure document store</string>

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/config/AppConfig.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/config/AppConfig.kt
@@ -133,6 +133,22 @@ val vaultLabeledDrive = LabeledDrive(
     label = "Vault",
 )
 
+// Email setup drive — holds the identity's OpenPGP secret keyrings, the pointer to the
+// current one, and the app-password credential files. Optional drive (not in
+// [mandatorySyncDrives]); requested through extend-permissions when the user sets email up.
+//
+// These GUIDs are NOT placeholders and must never change: the server names the same drive to
+// authorize every /api/v2/mail call, and the alias IS the drive's storage id. The mirror lives
+// in odin-core `src/services/Odin.Services/Drives/WellKnownAppDrives.cs` — change one, change
+// both. Read+Write on this drive is what makes this app the identity's email app.
+val emailLabeledDrive = LabeledDrive(
+    drive = TargetDrive(
+        alias = Uuid.parse("92bbcad8-3558-417b-9376-9976c086a674"),
+        type = Uuid.parse("37e3480a-4cd7-4a41-a421-ed49866bf07e"),
+    ),
+    label = "Email",
+)
+
 // Stickers drive — modeled exactly on [vaultLabeledDrive] (alias + distinct type
 // GUID). The user's saved "My Stickers" tray is one HomebaseFile per sticker on this
 // dedicated, synced drive, so the library follows the user across devices via the
@@ -234,6 +250,18 @@ val vaultTargetDriveAccessRequest: List<TargetDriveAccessRequest> = listOf(
         type = vaultLabeledDrive.drive.type.toString(),
         name = vaultLabeledDrive.label,
         description = "Drive to store your personal documents",
+        permissions = listOf(DrivePermission.Read, DrivePermission.Write),
+    )
+)
+
+// Read AND Write: the server requires both. Every mail action writes key material to this
+// drive and reads it back, so a half grant is refused (403) rather than half-working.
+val emailTargetDriveAccessRequest: List<TargetDriveAccessRequest> = listOf(
+    TargetDriveAccessRequest(
+        alias = emailLabeledDrive.drive.alias.toString(),
+        type = emailLabeledDrive.drive.type.toString(),
+        name = emailLabeledDrive.label,
+        description = "Drive to store your email keys and mail app passwords",
         permissions = listOf(DrivePermission.Read, DrivePermission.Write),
     )
 )
@@ -363,6 +391,16 @@ fun getVaultPermissionExtensionConfig(): PermissionExtensionConfig {
         appId = AppConfig.APP_ID,
         appName = AppConfig.APP_NAME,
         drives = vaultTargetDriveAccessRequest,
+        permissions = emptyList(),
+        returnUrl = ::returnUrl
+    )
+}
+
+fun getEmailPermissionExtensionConfig(): PermissionExtensionConfig {
+    return PermissionExtensionConfig(
+        appId = AppConfig.APP_ID,
+        appName = AppConfig.APP_NAME,
+        drives = emailTargetDriveAccessRequest,
         permissions = emptyList(),
         returnUrl = ::returnUrl
     )

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/email/EmailPreferences.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/email/EmailPreferences.kt
@@ -1,0 +1,136 @@
+package id.homebase.core.email
+
+import id.homebase.api.sync.database.DatabaseManager
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlin.time.Clock
+import kotlin.uuid.Uuid
+
+/**
+ * Device-local flags for the Email setup add-on, plus its biometric session clock.
+ *
+ * There is deliberately no `activated` flag: activation is the email drive's mount state, read
+ * through `OptionalDriveActivation`. A local flag diverges across devices — see
+ * ADDING_ADDON_APPS.md.
+ *
+ * The biometric session mirrors [id.homebase.core.vault.VaultPreferences] because this app holds
+ * the identity's mail keys and app passwords, which is the same class of secret the Vault gate
+ * exists for. (Both copies are a candidate for extraction — see the follow-up in the plan.)
+ */
+class EmailPreferences(
+    private val databaseManager: DatabaseManager,
+    private val clock: Clock = Clock.System,
+) {
+
+    private val keyValue get() = databaseManager.keyValue
+
+    private val _iconVisible = MutableStateFlow(readBoolean(ICON_VISIBLE_KEY, default = true))
+    val iconVisible: StateFlow<Boolean> = _iconVisible.asStateFlow()
+
+    private val _biometricsEnabled = MutableStateFlow(readBoolean(BIOMETRICS_KEY, default = true))
+    val biometricsEnabled: StateFlow<Boolean> = _biometricsEnabled.asStateFlow()
+
+    /** The mail client the user picked, so their setup steps stay one tap away. */
+    private val _selectedMailClientId = MutableStateFlow(readString(SELECTED_CLIENT_KEY))
+    val selectedMailClientId: StateFlow<String?> = _selectedMailClientId.asStateFlow()
+
+    // In-memory biometric session tracking — not persisted, resets on app restart.
+    private var lastAuthTimeMs: Long = 0L
+    private var lastBackgroundTimeMs: Long = 0L
+    private var lastActionTimeMs: Long = 0L
+
+    var isEmailScreenActive: Boolean = false
+        private set
+
+    fun setEmailScreenActive(active: Boolean) {
+        isEmailScreenActive = active
+    }
+
+    fun reset() {
+        _iconVisible.value = readBoolean(ICON_VISIBLE_KEY, default = true)
+        _biometricsEnabled.value = readBoolean(BIOMETRICS_KEY, default = true)
+        _selectedMailClientId.value = readString(SELECTED_CLIENT_KEY)
+        lastAuthTimeMs = 0L
+        lastBackgroundTimeMs = 0L
+        lastActionTimeMs = 0L
+        isEmailScreenActive = false
+    }
+
+    fun recordAuthSuccess() {
+        val now = clock.now().toEpochMilliseconds()
+        lastAuthTimeMs = now
+        lastActionTimeMs = now
+    }
+
+    fun recordAppBackgrounded() {
+        val now = clock.now().toEpochMilliseconds()
+        // The biometric prompt itself stops the Activity briefly around a successful unlock on
+        // some devices; that churn is not a genuine app-background.
+        if (lastAuthTimeMs != 0L && now - lastAuthTimeMs in 0..POST_AUTH_SETTLE_MS) return
+        lastBackgroundTimeMs = now
+    }
+
+    fun recordUserAction() {
+        lastActionTimeMs = clock.now().toEpochMilliseconds()
+    }
+
+    fun isAuthSessionValid(): Boolean {
+        if (lastAuthTimeMs == 0L) return false
+        val now = clock.now().toEpochMilliseconds()
+        if (lastBackgroundTimeMs > lastAuthTimeMs &&
+            now - lastBackgroundTimeMs > BACKGROUND_THRESHOLD_MS
+        ) return false
+        if (!isEmailScreenActive && now - lastActionTimeMs > AUTH_SESSION_DURATION_MS) return false
+        return true
+    }
+
+    suspend fun setIconVisible(value: Boolean) {
+        if (_iconVisible.value == value) return
+        keyValue.upsertValue(ICON_VISIBLE_KEY, encode(value))
+        _iconVisible.value = value
+    }
+
+    suspend fun setBiometricsEnabled(value: Boolean) {
+        if (_biometricsEnabled.value == value) return
+        keyValue.upsertValue(BIOMETRICS_KEY, encode(value))
+        _biometricsEnabled.value = value
+    }
+
+    suspend fun setSelectedMailClientId(value: String?) {
+        if (_selectedMailClientId.value == value) return
+        keyValue.upsertValue(SELECTED_CLIENT_KEY, value?.encodeToByteArray() ?: ByteArray(0))
+        _selectedMailClientId.value = value
+    }
+
+    private fun readBoolean(key: Uuid, default: Boolean): Boolean {
+        // Bootstrap-only sync read — seeds the StateFlow at construction. See
+        // KeyValueWrapper.selectByKeyBootstrapSync (commonMain has no runBlocking on wasmJs).
+        val bytes: ByteArray = runCatching {
+            keyValue.selectByKeyBootstrapSync(key) { _, data -> data }
+        }.getOrNull() ?: return default
+        return if (bytes.isEmpty()) default else bytes[0].toInt() != 0
+    }
+
+    private fun readString(key: Uuid): String? {
+        val bytes: ByteArray = runCatching {
+            keyValue.selectByKeyBootstrapSync(key) { _, data -> data }
+        }.getOrNull() ?: return null
+        return if (bytes.isEmpty()) null else bytes.decodeToString()
+    }
+
+    private fun encode(value: Boolean): ByteArray = byteArrayOf(if (value) 1 else 0)
+
+    companion object {
+        // Namespace 0a07xx. 0a01 Vault, 0a02 Moments, 0a03 Location, 0a04 Contact Book,
+        // 0a05 ServerIpStore, 0a06 EventReminder. 0a0701 is the retired ACTIVATED slot —
+        // activation is the drive's mount state — so it stays unused.
+        val ICON_VISIBLE_KEY: Uuid = Uuid.parse("00000000-0000-0000-0000-0000000a0702")
+        val BIOMETRICS_KEY: Uuid = Uuid.parse("00000000-0000-0000-0000-0000000a0703")
+        val SELECTED_CLIENT_KEY: Uuid = Uuid.parse("00000000-0000-0000-0000-0000000a0704")
+
+        private const val AUTH_SESSION_DURATION_MS = 5 * 60 * 1000L  // 5 minutes
+        private const val BACKGROUND_THRESHOLD_MS = 30 * 1000L       // 30 seconds
+        private const val POST_AUTH_SETTLE_MS = 2 * 1000L
+    }
+}

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/settings/UserPreferences.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/settings/UserPreferences.kt
@@ -10,6 +10,7 @@ class UserPreferences(private val settings: Settings) {
         PreferenceState(
             theme = theme,
             hapticsEnabled = hapticsEnabled,
+            showDeveloperMenu = showDeveloperMenu,
         )
     )
     val preferenceState: StateFlow<PreferenceState> = _preferenceState
@@ -28,9 +29,17 @@ class UserPreferences(private val settings: Settings) {
             _preferenceState.value = _preferenceState.value.copy(theme = value)
         }
 
+    /**
+     * Mirrored into [preferenceState] because it now gates UI chrome that must react immediately:
+     * the Email setup toolbar entry is built from this in AppNavHost, and reading the plain
+     * property there would leave the icon missing until the next app start.
+     */
     var showDeveloperMenu: Boolean
         get() = settings.getBoolean("show_developer_menu", false)
-        set(value) = settings.putBoolean("show_developer_menu", value)
+        set(value) {
+            settings.putBoolean("show_developer_menu", value)
+            _preferenceState.value = _preferenceState.value.copy(showDeveloperMenu = value)
+        }
 
     /**
      * Feed tab mode: the native KMP feed (default) vs the legacy WebView feed. Lets users opt back
@@ -113,6 +122,7 @@ class UserPreferences(private val settings: Settings) {
 data class PreferenceState(
     val theme: ThemeState,
     val hapticsEnabled: Boolean,
+    val showDeveloperMenu: Boolean = false,
 )
 
 enum class ThemeState {

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/ui/navigation/Routes.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/ui/navigation/Routes.kt
@@ -108,6 +108,14 @@ sealed class Route {
     data object Defragmenter : Route()
 
     @Serializable
+    @SerialName("email")
+    data object Email : Route()
+
+    @Serializable
+    @SerialName("email-settings")
+    data object EmailSettings : Route()
+
+    @Serializable
     @SerialName("vault")
     data object Vault : Route()
 

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
@@ -2,6 +2,10 @@
 
 package id.homebase.core.di
 
+import id.homebase.core.config.getEmailPermissionExtensionConfig
+import id.homebase.core.ui.screens.email.settings.EmailSettingsViewModel
+import id.homebase.core.ui.screens.email.EmailViewModel
+import id.homebase.core.email.EmailPreferences
 import co.touchlab.kermit.Logger
 import coil3.ImageLoader
 import id.homebase.api.di.apiModule
@@ -212,6 +216,7 @@ import id.homebase.core.ui.screens.location.livelocation.LiveLocationViewModel
 import id.homebase.core.ui.screens.location.share.ShareLocationViewModel
 
 val VaultPermissionQualifier = named("vaultPermission")
+val EmailPermissionQualifier = named("emailPermission")
 
 val FeedPermissionQualifier = named("feedPermission")
 val MomentsPermissionQualifier = named("momentsPermission")
@@ -270,6 +275,7 @@ val appModule = module {
 
     single { MomentCreateFlowState() }
     single { VaultPreferences(get()) }
+    single { EmailPreferences(get()) }
 
     // Contact Book add-on (contact manager). Reads from the mandatory Contacts
     // drive; writes through the api-layer ContactsProvider. No optional-drive
@@ -640,6 +646,7 @@ val appModule = module {
                 // endregion
 
                 get<VaultPreferences>().reset()
+            get<EmailPreferences>().reset()
                 get<VaultStream>().apply { reset(); start() }
                 // Contact Book: re-seed prefs + reload the contact list for the new
                 // identity (singletons survive logout — clear stale in-memory state).
@@ -1103,6 +1110,15 @@ val appModule = module {
             autoCheck = false,
         )
     }
+    viewModel(EmailPermissionQualifier) {
+        ExtendPermissionViewModel(
+            get(),
+            get(),
+            get(),
+            getEmailPermissionExtensionConfig(),
+            autoCheck = false,
+        )
+    }
     viewModel(FeedPermissionQualifier) {
         ExtendPermissionViewModel(
             get(),
@@ -1142,6 +1158,16 @@ val appModule = module {
         )
     }
     viewModelOf(::VaultSettingsViewModel)
+
+    viewModel {
+        EmailViewModel(
+            emailPreferences = get(),
+            emailPermissionViewModel = get(EmailPermissionQualifier),
+            optionalDriveActivation = get(),
+            mailProvider = get(),
+        )
+    }
+    viewModelOf(::EmailSettingsViewModel)
     viewModel { params ->
         VaultNoteEditorViewModel(
             sectionId = params[0],

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
@@ -1,5 +1,12 @@
 package id.homebase.core.ui.navigation
 
+import id.homebase.resources.email_label
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.material.icons.outlined.MailOutline
+import id.homebase.core.ui.screens.email.settings.EmailSettingsScreen
+import id.homebase.core.ui.screens.email.EmailViewModel
+import id.homebase.core.ui.screens.email.EmailScreen
+import id.homebase.core.email.EmailPreferences
 import androidx.compose.animation.AnimatedContentTransitionScope
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
@@ -228,7 +235,21 @@ fun AppNavHost(
     val contactBookIconVisible by contactBookPreferences.iconVisible.collectAsStateWithLifecycle()
     val contactBookOnboardingComplete by contactBookPreferences.onboardingComplete.collectAsStateWithLifecycle()
     val contactBookViewModel: ContactBookViewModel = koinViewModel()
-    val topLevelRoutes = remember(momentsIconVisible, vaultIconVisible, locationIconVisible, contactBookIconVisible) {
+    val emailPreferences = koinInject<EmailPreferences>()
+    val emailIconVisible by emailPreferences.iconVisible.collectAsStateWithLifecycle()
+    val emailViewModel: EmailViewModel = koinViewModel()
+    // Reactive so flipping the developer menu shows/hides the entry without an app restart.
+    val showDeveloperMenu by koinInject<UserPreferences>().preferenceState
+        .collectAsStateWithLifecycle()
+        .let { state -> remember { derivedStateOf { state.value.showDeveloperMenu } } }
+    val topLevelRoutes = remember(
+        momentsIconVisible,
+        vaultIconVisible,
+        locationIconVisible,
+        contactBookIconVisible,
+        emailIconVisible,
+        showDeveloperMenu,
+    ) {
         buildList {
             add(TopLevelRoute.Chat)
             add(TopLevelRoute.Feed)
@@ -236,7 +257,17 @@ fun AppNavHost(
             if (vaultIconVisible) add(TopLevelRoute.Vault)
             if (locationIconVisible) add(TopLevelRoute.Location)
             if (contactBookIconVisible) add(TopLevelRoute.ContactBook)
+            // Email setup rides the developer menu until the feature flag can be turned on
+            // anywhere — today every host answers "no email here".
+            if (showDeveloperMenu && emailIconVisible) add(TopLevelRoute.Email)
             add(TopLevelRoute.Home)
+        }
+    }
+    val openEmail: () -> Unit = {
+        navController.navigate(Route.Email) {
+            popUpTo(Route.ChatList) { saveState = true }
+            launchSingleTop = true
+            restoreState = true
         }
     }
     val openContactBook: () -> Unit = {
@@ -637,6 +668,7 @@ fun AppNavHost(
 
                                     topLevelRoute is TopLevelRoute.Moments -> openMoments()
                                     topLevelRoute is TopLevelRoute.Vault -> openVault()
+                                    topLevelRoute is TopLevelRoute.Email -> openEmail()
                                     topLevelRoute is TopLevelRoute.Location -> openLocation()
                                     topLevelRoute is TopLevelRoute.ContactBook -> openContactBook()
                                     else -> navController.navigate(topLevelRoute.route) {
@@ -677,6 +709,7 @@ fun AppNavHost(
 
                                         topLevelRoute is TopLevelRoute.Moments -> openMoments()
                                         topLevelRoute is TopLevelRoute.Vault -> openVault()
+                                    topLevelRoute is TopLevelRoute.Email -> openEmail()
                                         topLevelRoute is TopLevelRoute.Location -> openLocation()
                                         else -> navController.navigate(topLevelRoute.route) {
                                             popUpTo(Route.ChatList) { saveState = true }
@@ -1365,6 +1398,7 @@ fun AppNavHost(
                             if (isAuthenticated) {
                                 SettingsScreen(
                                     viewModel = koinViewModel(),
+                                    showDeveloperMenu = showDeveloperMenu,
                                     actions = SettingsActions(
                                         onBack = { navController.popBackStack() },
                                         onNotifications = {
@@ -1384,6 +1418,9 @@ fun AppNavHost(
                                         },
                                         onVaultSettings = {
                                             navController.navigate(Route.VaultSettings)
+                                        },
+                                        onEmailSettings = {
+                                            navController.navigate(Route.EmailSettings)
                                         },
                                         onLocation = openLocation,
                                         onContactBookSettings = {
@@ -1750,6 +1787,25 @@ fun AppNavHost(
                             }
                         }
 
+                        composable<Route.Email> {
+                            if (isAuthenticated) {
+                                EmailScreen(
+                                    viewModel = emailViewModel,
+                                    onNavigateBack = { navController.popBackStack() },
+                                )
+                            }
+                        }
+
+                        composable<Route.EmailSettings> {
+                            if (isAuthenticated) {
+                                EmailSettingsScreen(
+                                    viewModel = koinViewModel(),
+                                    onBackClick = { navController.popBackStack() },
+                                    onOpenEmail = openEmail,
+                                )
+                            }
+                        }
+
                         composable<Route.VaultSettings> {
                             if (isAuthenticated) {
                                 val fromVault = navController.previousBackStackEntry
@@ -1917,6 +1973,7 @@ private fun NavDestination?.isTopLevelRoute(): Boolean {
             this?.hasRoute(Route.Moments::class) == true ||
             this?.hasRoute(Route.Home::class) == true ||
             this?.hasRoute(Route.Vault::class) == true ||
+            this?.hasRoute(Route.Email::class) == true ||
             this?.hasRoute(Route.Location::class) == true ||
             this?.hasRoute(Route.ContactBook::class) == true
 }
@@ -1939,6 +1996,7 @@ sealed class TopLevelRoute(
     data object Moments : TopLevelRoute(Route.Moments, MR.string.nav_moments, Icons.Outlined.AutoAwesome)
     data object Home : TopLevelRoute(Route.Home, MR.string.nav_home, Icons.Default.Home)
     data object Vault : TopLevelRoute(Route.Vault, MR.string.vault_label, Icons.Outlined.Lock)
+    data object Email : TopLevelRoute(Route.Email, MR.string.email_label, Icons.Outlined.MailOutline)
     data object Location : TopLevelRoute(Route.Location, MR.string.location_label, Icons.Outlined.LocationOn)
     data object ContactBook : TopLevelRoute(Route.ContactBook, MR.string.contactbook_label, Icons.Outlined.People)
 }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/email/EmailScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/email/EmailScreen.kt
@@ -1,0 +1,153 @@
+package id.homebase.core.ui.screens.email
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.consumeWindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import id.homebase.chat.widget.ExtendPermissionDialog
+import id.homebase.core.ui.screens.email.components.EmailNoServerContent
+import id.homebase.core.ui.screens.email.onboarding.EmailOnboardingContent
+import id.homebase.resources.MR
+import id.homebase.resources.email_checking
+import id.homebase.resources.email_home_subtitle
+import id.homebase.resources.email_label
+import id.homebase.resources.email_no_server_retry
+import org.jetbrains.compose.resources.stringResource
+
+/**
+ * The add-on's single entry screen. Which body it shows is derived, never stored:
+ *
+ *  - still asking            -> spinner
+ *  - the status call failed  -> retry (NOT "your server has no email" — a different answer)
+ *  - server says no email    -> [EmailNoServerContent]
+ *  - drive not mounted yet   -> onboarding
+ *  - drive mounted           -> setup, which continues in the steps that follow
+ *
+ * Following Vault, onboarding lives inside this route rather than in one of its own, so the
+ * screen swaps declaratively as activation resolves instead of navigating.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun EmailScreen(
+    viewModel: EmailViewModel,
+    onNavigateBack: () -> Unit,
+) {
+    ExtendPermissionDialog(viewModel = viewModel.emailExtendPermissionViewModel)
+
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(title = { Text(stringResource(MR.string.email_label)) })
+        },
+    ) { innerPadding ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .consumeWindowInsets(innerPadding)
+                .padding(innerPadding),
+        ) {
+            when {
+                uiState.isResolving || uiState.driveActivated == null -> EmailBusy()
+
+                uiState.statusError != null -> EmailStatusUnavailable(
+                    onRetry = { viewModel.onAction(EmailUiAction.RefreshStatusClicked) },
+                )
+
+                uiState.serverHasNoEmail -> EmailNoServerContent(
+                    onRetry = { viewModel.onAction(EmailUiAction.RefreshStatusClicked) },
+                    onClose = onNavigateBack,
+                )
+
+                uiState.driveActivated == false -> EmailOnboardingContent(
+                    onAction = viewModel::onAction,
+                )
+
+                else -> EmailSetupInProgress()
+            }
+        }
+    }
+}
+
+@Composable
+private fun EmailBusy() {
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        CircularProgressIndicator()
+        Spacer(modifier = Modifier.height(16.dp))
+        Text(
+            text = stringResource(MR.string.email_checking),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+/**
+ * The call failed. Deliberately distinct from "this server has no email": telling someone their
+ * server lacks a feature because a request timed out would be a lie they might act on.
+ */
+@Composable
+private fun EmailStatusUnavailable(onRetry: () -> Unit) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(horizontal = 32.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Text(
+            text = stringResource(MR.string.email_checking),
+            style = MaterialTheme.typography.titleMedium,
+            textAlign = TextAlign.Center,
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        TextButton(onClick = onRetry, modifier = Modifier.fillMaxWidth()) {
+            Text(stringResource(MR.string.email_no_server_retry))
+        }
+    }
+}
+
+/**
+ * Placeholder for the drive-mounted case. The mailbox, app-password and key steps land in the
+ * following steps of this arc; until the server endpoints exist there is genuinely nothing more
+ * to show, and inventing a fake progress screen would be worse than saying so.
+ */
+@Composable
+private fun EmailSetupInProgress() {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(horizontal = 32.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Text(
+            text = stringResource(MR.string.email_home_subtitle),
+            style = MaterialTheme.typography.titleMedium,
+            textAlign = TextAlign.Center,
+        )
+    }
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/email/EmailUiState.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/email/EmailUiState.kt
@@ -1,0 +1,54 @@
+package id.homebase.core.ui.screens.email
+
+import id.homebase.api.client.mail.MailAppStatus
+
+/**
+ * What the Email setup screen renders from.
+ *
+ * Two independent facts decide the screen, and both can be unknown at first paint:
+ *  - [serverStatus] — does this host run email at all, and how far has setup got. Server-owned.
+ *  - [driveActivated] — is the email drive mounted on this device. Drive-owned.
+ *
+ * Neither is a local flag, deliberately: a device-local "activated" boolean diverges across a
+ * user's devices (ADDING_ADDON_APPS.md), and setup progress that lives only on one device cannot
+ * survive the app being killed.
+ */
+data class EmailUiState(
+    /** null while the first status call is still in flight. */
+    val serverStatus: MailAppStatus? = null,
+    val isCheckingServer: Boolean = false,
+    val statusError: EmailError? = null,
+    /** null while the drive mount state is still resolving. */
+    val driveActivated: Boolean? = null,
+) {
+    /** The server answered, and answered no. Nothing to set up here. */
+    val serverHasNoEmail: Boolean
+        get() = serverStatus?.tenantMailEnabled == false
+
+    /** Waiting on the first answer — show a spinner rather than guessing. */
+    val isResolving: Boolean
+        get() = serverStatus == null && statusError == null
+}
+
+sealed interface EmailUiAction {
+    /** "Set it up" — opens the extend-permissions dialog. */
+    data object SetupClicked : EmailUiAction
+
+    /** "Dismiss" on onboarding: hide the toolbar icon; Home keeps the entry. */
+    data object DismissOnboardingClicked : EmailUiAction
+
+    /** Re-ask the server; used by the retry on the no-email screen and on resume. */
+    data object RefreshStatusClicked : EmailUiAction
+}
+
+sealed interface EmailUiEvent {
+    /** The email drive is mounted — setup can proceed. */
+    data object Activated : EmailUiEvent
+
+    data object CloseOnboarding : EmailUiEvent
+}
+
+sealed interface EmailError {
+    /** The status call failed. Distinct from "the server says it has no email". */
+    data object StatusUnavailable : EmailError
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/email/EmailViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/email/EmailViewModel.kt
@@ -1,0 +1,113 @@
+package id.homebase.core.ui.screens.email
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import co.touchlab.kermit.Logger
+import id.homebase.api.client.mail.MailProvider
+import id.homebase.chat.conversationlist.ExtendPermissionViewModel
+import id.homebase.core.config.emailLabeledDrive
+import id.homebase.core.email.EmailPreferences
+import id.homebase.core.sync.OptionalDriveActivation
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+/**
+ * Email setup's entry screen. Its whole job in this state is deciding which of three things the
+ * user sees — "this server has no email", onboarding, or setup-in-progress — and getting the
+ * email drive mounted when they say yes.
+ *
+ * Activation is never a local flag: it is the drive's mount state via [OptionalDriveActivation],
+ * so it agrees across the user's devices.
+ */
+class EmailViewModel(
+    private val emailPreferences: EmailPreferences,
+    private val emailPermissionViewModel: ExtendPermissionViewModel,
+    private val optionalDriveActivation: OptionalDriveActivation,
+    private val mailProvider: MailProvider,
+) : ViewModel() {
+
+    companion object {
+        private const val TAG = "EmailViewModel"
+    }
+
+    private val _uiState = MutableStateFlow(EmailUiState())
+    val uiState: StateFlow<EmailUiState> = _uiState.asStateFlow()
+
+    private val _events = MutableSharedFlow<EmailUiEvent>(extraBufferCapacity = 4)
+    val events: SharedFlow<EmailUiEvent> = _events.asSharedFlow()
+
+    /** The dialog host; AppNavHost and the screens render this VM's dialog. */
+    val emailExtendPermissionViewModel: ExtendPermissionViewModel
+        get() = emailPermissionViewModel
+
+    init {
+        viewModelScope.launch {
+            optionalDriveActivation.isActivatedFlow(emailLabeledDrive).collect { activated ->
+                _uiState.update { it.copy(driveActivated = activated) }
+            }
+        }
+
+        // The owner approves the drive in a browser, so the grant lands while we are backgrounded.
+        // Mount as soon as the permission check sees it rather than making the user tap again.
+        viewModelScope.launch {
+            emailPermissionViewModel.permissionsGranted.filter { it }.collect {
+                if (_uiState.value.driveActivated != true) {
+                    activateDrive()
+                }
+            }
+        }
+
+        refreshStatus()
+    }
+
+    fun onAction(action: EmailUiAction) {
+        when (action) {
+            EmailUiAction.SetupClicked -> {
+                // Already granted (a second device, or a re-entry) — go straight to mounting.
+                if (emailPermissionViewModel.permissionsGranted.value) {
+                    viewModelScope.launch { activateDrive() }
+                } else {
+                    emailPermissionViewModel.recheckPermissions()
+                }
+            }
+
+            EmailUiAction.DismissOnboardingClicked -> viewModelScope.launch {
+                emailPreferences.setIconVisible(false)
+                _events.tryEmit(EmailUiEvent.CloseOnboarding)
+            }
+
+            EmailUiAction.RefreshStatusClicked -> refreshStatus()
+        }
+    }
+
+    fun refreshStatus() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isCheckingServer = true, statusError = null) }
+            try {
+                val status = mailProvider.getStatus()
+                _uiState.update { it.copy(serverStatus = status, isCheckingServer = false) }
+            } catch (e: Exception) {
+                // A failed call is not the same answer as "this server has no email" — the user
+                // is told to retry rather than told their server does not support it.
+                Logger.w(tag = TAG, throwable = e) { "mail status failed" }
+                _uiState.update {
+                    it.copy(isCheckingServer = false, statusError = EmailError.StatusUnavailable)
+                }
+            }
+        }
+    }
+
+    private suspend fun activateDrive() {
+        optionalDriveActivation.activate(emailLabeledDrive)
+        _events.tryEmit(EmailUiEvent.Activated)
+        // The drive changes what the server reports (driveProvisioned), so re-ask.
+        refreshStatus()
+    }
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/email/components/EmailNoServerContent.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/email/components/EmailNoServerContent.kt
@@ -1,0 +1,119 @@
+package id.homebase.core.ui.screens.email.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Info
+import androidx.compose.material.icons.outlined.MailOutline
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import id.homebase.resources.MR
+import id.homebase.resources.email_no_server_body_1
+import id.homebase.resources.email_no_server_body_2
+import id.homebase.resources.email_no_server_close
+import id.homebase.resources.email_no_server_note
+import id.homebase.resources.email_no_server_retry
+import id.homebase.resources.email_no_server_title
+import org.jetbrains.compose.resources.stringResource
+
+/**
+ * Shown when the server answers that it does not run tenant mail — which is every host today.
+ *
+ * The distinction this screen exists to make: the server was asked and said no. That is not a
+ * network error and not a problem with the identity, so the copy says so plainly instead of
+ * leaving the user to wonder what they broke.
+ */
+@Composable
+fun EmailNoServerContent(
+    onRetry: () -> Unit,
+    onClose: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(horizontal = 24.dp, vertical = 32.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Top,
+    ) {
+        Icon(
+            imageVector = Icons.Outlined.MailOutline,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.size(96.dp),
+        )
+        Spacer(modifier = Modifier.height(24.dp))
+        Text(
+            text = stringResource(MR.string.email_no_server_title),
+            style = MaterialTheme.typography.headlineSmall,
+            textAlign = TextAlign.Center,
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        Text(
+            text = stringResource(MR.string.email_no_server_body_1),
+            style = MaterialTheme.typography.bodyLarge,
+            textAlign = TextAlign.Center,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Spacer(modifier = Modifier.height(12.dp))
+        Text(
+            text = stringResource(MR.string.email_no_server_body_2),
+            style = MaterialTheme.typography.bodyLarge,
+            textAlign = TextAlign.Center,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Spacer(modifier = Modifier.height(28.dp))
+
+        Card(
+            modifier = Modifier.fillMaxWidth(),
+            colors = CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+            ),
+        ) {
+            Row(modifier = Modifier.padding(16.dp)) {
+                Icon(
+                    imageVector = Icons.Outlined.Info,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.size(20.dp),
+                )
+                Spacer(modifier = Modifier.width(12.dp))
+                Text(
+                    text = stringResource(MR.string.email_no_server_note),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.height(28.dp))
+        FilledTonalButton(onClick = onRetry, modifier = Modifier.fillMaxWidth()) {
+            Text(stringResource(MR.string.email_no_server_retry))
+        }
+        Spacer(modifier = Modifier.height(8.dp))
+        TextButton(onClick = onClose, modifier = Modifier.fillMaxWidth()) {
+            Text(stringResource(MR.string.email_no_server_close))
+        }
+    }
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/email/onboarding/EmailOnboardingScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/email/onboarding/EmailOnboardingScreen.kt
@@ -1,0 +1,100 @@
+package id.homebase.core.ui.screens.email.onboarding
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.MailOutline
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import id.homebase.core.ui.screens.email.EmailUiAction
+import id.homebase.resources.MR
+import id.homebase.resources.email_onboarding_body_1
+import id.homebase.resources.email_onboarding_body_2
+import id.homebase.resources.email_onboarding_dismiss
+import id.homebase.resources.email_onboarding_dismiss_hint
+import id.homebase.resources.email_onboarding_setup
+import id.homebase.resources.email_onboarding_title
+import org.jetbrains.compose.resources.stringResource
+
+/**
+ * First run. "Set it up" opens the extend-permissions dialog (the owner approves the email drive
+ * in the owner console); "Dismiss" hides the toolbar icon and leaves the entry under Home.
+ */
+@Composable
+fun EmailOnboardingContent(
+    onAction: (EmailUiAction) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(horizontal = 24.dp, vertical = 32.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Top,
+    ) {
+        Icon(
+            imageVector = Icons.Outlined.MailOutline,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.size(96.dp),
+        )
+        Spacer(modifier = Modifier.height(24.dp))
+        Text(
+            text = stringResource(MR.string.email_onboarding_title),
+            style = MaterialTheme.typography.headlineSmall,
+            textAlign = TextAlign.Center,
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        Text(
+            text = stringResource(MR.string.email_onboarding_body_1),
+            style = MaterialTheme.typography.bodyLarge,
+            textAlign = TextAlign.Center,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Spacer(modifier = Modifier.height(12.dp))
+        Text(
+            text = stringResource(MR.string.email_onboarding_body_2),
+            style = MaterialTheme.typography.bodyLarge,
+            textAlign = TextAlign.Center,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Spacer(modifier = Modifier.height(40.dp))
+        FilledTonalButton(
+            onClick = { onAction(EmailUiAction.SetupClicked) },
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text(stringResource(MR.string.email_onboarding_setup))
+        }
+        Spacer(modifier = Modifier.height(8.dp))
+        TextButton(
+            onClick = { onAction(EmailUiAction.DismissOnboardingClicked) },
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text(stringResource(MR.string.email_onboarding_dismiss))
+        }
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(
+            text = stringResource(MR.string.email_onboarding_dismiss_hint),
+            style = MaterialTheme.typography.bodySmall,
+            textAlign = TextAlign.Center,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/email/settings/EmailSettingsScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/email/settings/EmailSettingsScreen.kt
@@ -1,0 +1,121 @@
+package id.homebase.core.ui.screens.email.settings
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.consumeWindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.outlined.Fingerprint
+import androidx.compose.material.icons.outlined.MailOutline
+import androidx.compose.material.icons.outlined.Visibility
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import id.homebase.core.widget.SettingsRow
+import id.homebase.core.widget.SettingsRowAction
+import id.homebase.resources.MR
+import id.homebase.resources.email_settings_biometrics
+import id.homebase.resources.email_settings_open
+import id.homebase.resources.email_settings_section
+import id.homebase.resources.email_settings_show_icon
+import id.homebase.resources.menu_back
+import org.jetbrains.compose.resources.stringResource
+
+@Composable
+fun EmailSettingsScreen(
+    viewModel: EmailSettingsViewModel,
+    onBackClick: () -> Unit,
+    onOpenEmail: () -> Unit,
+    showOpenEmail: Boolean = true,
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    EmailSettingsUi(
+        uiState = uiState,
+        onAction = { action ->
+            if (action is EmailSettingsUiAction.OpenEmailClicked) onOpenEmail()
+            else viewModel.onAction(action)
+        },
+        onBackClick = onBackClick,
+        showOpenEmail = showOpenEmail,
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun EmailSettingsUi(
+    uiState: EmailSettingsUiState,
+    onAction: (EmailSettingsUiAction) -> Unit,
+    onBackClick: () -> Unit,
+    showOpenEmail: Boolean = true,
+) {
+    val scrollState = rememberScrollState()
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(MR.string.email_settings_section)) },
+                navigationIcon = {
+                    IconButton(onClick = onBackClick) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(MR.string.menu_back),
+                        )
+                    }
+                },
+            )
+        },
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .consumeWindowInsets(innerPadding)
+                .padding(innerPadding)
+                .verticalScroll(scrollState),
+        ) {
+            Spacer(modifier = Modifier.height(8.dp))
+            if (showOpenEmail) {
+                SettingsRow(
+                    icon = Icons.Outlined.MailOutline,
+                    title = stringResource(MR.string.email_settings_open),
+                    action = SettingsRowAction.Navigate {
+                        onAction(EmailSettingsUiAction.OpenEmailClicked)
+                    },
+                )
+            }
+            SettingsRow(
+                icon = Icons.Outlined.Visibility,
+                title = stringResource(MR.string.email_settings_show_icon),
+                action = SettingsRowAction.Toggle(
+                    checked = uiState.iconVisible,
+                    onCheckedChange = { onAction(EmailSettingsUiAction.SetIconVisible(it)) },
+                ),
+            )
+            SettingsRow(
+                icon = Icons.Outlined.Fingerprint,
+                title = stringResource(MR.string.email_settings_biometrics),
+                action = SettingsRowAction.Toggle(
+                    checked = uiState.biometricsEnabled,
+                    onCheckedChange = { onAction(EmailSettingsUiAction.SetBiometricsEnabled(it)) },
+                ),
+            )
+            Spacer(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(24.dp)
+            )
+        }
+    }
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/email/settings/EmailSettingsUiState.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/email/settings/EmailSettingsUiState.kt
@@ -1,0 +1,12 @@
+package id.homebase.core.ui.screens.email.settings
+
+data class EmailSettingsUiState(
+    val iconVisible: Boolean = true,
+    val biometricsEnabled: Boolean = true,
+)
+
+sealed interface EmailSettingsUiAction {
+    data object OpenEmailClicked : EmailSettingsUiAction
+    data class SetIconVisible(val visible: Boolean) : EmailSettingsUiAction
+    data class SetBiometricsEnabled(val enabled: Boolean) : EmailSettingsUiAction
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/email/settings/EmailSettingsViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/email/settings/EmailSettingsViewModel.kt
@@ -1,0 +1,50 @@
+package id.homebase.core.ui.screens.email.settings
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import id.homebase.core.email.EmailPreferences
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+class EmailSettingsViewModel(
+    private val emailPreferences: EmailPreferences,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(
+        EmailSettingsUiState(
+            iconVisible = emailPreferences.iconVisible.value,
+            biometricsEnabled = emailPreferences.biometricsEnabled.value,
+        )
+    )
+    val uiState: StateFlow<EmailSettingsUiState> = _uiState.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            emailPreferences.iconVisible.collect { v ->
+                _uiState.update { it.copy(iconVisible = v) }
+            }
+        }
+        viewModelScope.launch {
+            emailPreferences.biometricsEnabled.collect { v ->
+                _uiState.update { it.copy(biometricsEnabled = v) }
+            }
+        }
+    }
+
+    fun onAction(action: EmailSettingsUiAction) {
+        when (action) {
+            EmailSettingsUiAction.OpenEmailClicked -> {
+                // Handled by the screen — it navigates.
+            }
+            is EmailSettingsUiAction.SetIconVisible -> {
+                viewModelScope.launch { emailPreferences.setIconVisible(action.visible) }
+            }
+            is EmailSettingsUiAction.SetBiometricsEnabled -> {
+                viewModelScope.launch { emailPreferences.setBiometricsEnabled(action.enabled) }
+            }
+        }
+    }
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/settings/SettingsActions.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/settings/SettingsActions.kt
@@ -12,6 +12,7 @@ data class SettingsActions(
     val onHelp: () -> Unit,
     val onMomentsSettings: () -> Unit,
     val onVaultSettings: () -> Unit,
+    val onEmailSettings: () -> Unit,
     val onLocation: () -> Unit,
     val onContactBookSettings: () -> Unit,
     val onProfileEdit: () -> Unit,

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/settings/SettingsScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/settings/SettingsScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.material.icons.outlined.CheckCircle
 import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material.icons.outlined.Error
 import androidx.compose.material.icons.outlined.Lock
+import androidx.compose.material.icons.outlined.MailOutline
 import androidx.compose.material.icons.outlined.LocationOn
 import androidx.compose.material.icons.outlined.Notifications
 import androidx.compose.material.icons.outlined.People
@@ -119,6 +120,8 @@ import id.homebase.resources.settings_storage
 import id.homebase.resources.settings_storage_desc
 import id.homebase.resources.settings_storage_used
 import id.homebase.resources.settings_vault_desc
+import id.homebase.resources.settings_email_desc
+import id.homebase.resources.email_settings_section
 import id.homebase.resources.vault_settings_section
 import org.jetbrains.compose.resources.stringResource
 
@@ -126,6 +129,7 @@ import org.jetbrains.compose.resources.stringResource
 fun SettingsScreen(
     viewModel: SettingsViewModel,
     actions: SettingsActions,
+    showDeveloperMenu: Boolean = false,
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val uriHandler = getUriHandler()
@@ -187,6 +191,7 @@ fun SettingsScreen(
             uiState = uiState,
             onAction = viewModel::onAction,
             actions = actions,
+            showDeveloperMenu = showDeveloperMenu,
         )
 
         if (uiState.isLoggingOut) {
@@ -241,6 +246,8 @@ fun SettingsUi(
     uiState: SettingsUiState,
     onAction: (SettingsUiAction) -> Unit,
     actions: SettingsActions,
+    // Defaults to hidden so previews and tests that do not care stay unchanged.
+    showDeveloperMenu: Boolean = false,
 ) {
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
 
@@ -358,6 +365,19 @@ fun SettingsUi(
                     supportingText = stringResource(MR.string.settings_vault_desc),
                     action = SettingsRowAction.Navigate(actions.onVaultSettings),
                 )
+            }
+            // Email setup is developer-menu gated while the arc is in progress: every host has
+            // Email:TenantMail:Enabled off, so the screen can only say "no email here" today.
+            if (showDeveloperMenu) {
+                item {
+                    SettingsRow(
+                        modifier = Modifier.testTag("emailSettingsButton"),
+                        icon = Icons.Outlined.MailOutline,
+                        title = stringResource(MR.string.email_settings_section),
+                        supportingText = stringResource(MR.string.settings_email_desc),
+                        action = SettingsRowAction.Navigate(actions.onEmailSettings),
+                    )
+                }
             }
             item {
                 SettingsRow(
@@ -575,6 +595,7 @@ fun SettingsUiPreview() {
                 onHelp = {},
                 onMomentsSettings = {},
                 onVaultSettings = {},
+                onEmailSettings = {},
                 onLocation = {},
                 onContactBookSettings = {},
                 onProfileEdit = {},

--- a/homebase-core/src/commonTest/kotlin/id/homebase/core/ui/screens/settings/SettingsUiTest.kt
+++ b/homebase-core/src/commonTest/kotlin/id/homebase/core/ui/screens/settings/SettingsUiTest.kt
@@ -33,6 +33,7 @@ class SettingsUiTest {
             onHelp = { fired += "help" },
             onMomentsSettings = { fired += "moments" },
             onVaultSettings = { fired += "vault" },
+            onEmailSettings = { fired += "email" },
             onLocation = { fired += "location" },
             onContactBookSettings = { fired += "contactBook" },
             onProfileEdit = { fired += "profileEdit" },


### PR DESCRIPTION
First of two stacked PRs adding the **Email setup** mini app. This one is the shell: it renders, it is reachable, and it does nothing irreversible.

Email setup is explicitly **not** a mail reader — reading happens in Thunderbird-class clients over IMAP/JMAP straight to the mail server. This app turns email on for an identity, holds the encryption keypair, and hands the user what their mail app needs.

### What ships here

The add-on wiring per `ADDING_ADDON_APPS.md`: `emailLabeledDrive` (alias and type GUIDs matched exactly to the server's `WellKnownAppDrives.EmailAppDrive` — no placeholder), `MailProvider` in homebase-api with serialization tests, preferences under the `0a07xx` namespace, routes, strings, a dev-menu-gated toolbar entry, onboarding, the "this server has no email" screen, the Settings row, and the DI/nav wiring.

Also corrects `EMAIL_APP.md`, whose step 3 said the keypair is generated on the device. It is generated server-side and written to the drive — see the odin-core side for why.

### Why this is shippable on its own

With `Email:TenantMail:Enabled` off — which is everywhere today — a user who enables the dev menu sees the toolbar icon, taps through onboarding, and lands on "this server has no email yet". That is exactly what production should show, and it is the whole of this PR's behaviour.

**Stack:** this → #TBD setup flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EcPf3xgN4BoFfMkgmqgrxG