### PR TITLE
Play a followed identity's video from the author's drive

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/OdinApiProviderBase.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/OdinApiProviderBase.kt
@@ -66,7 +66,6 @@ abstract class OdinApiProviderBase(
 ) {
 
     private val HOST_URL_REGEX = Regex("""^[a-zA-Z][a-zA-Z0-9+.-]*://[^/]+""")
-    private val CDN_BASE_HEADER = "x-odin-cdn-payload"
 
     protected data class ActiveCredentials(
         val domain: OdinId,
@@ -136,8 +135,6 @@ abstract class OdinApiProviderBase(
                 rawBody
             }
 
-        credentialsManager.observeCdnBase(response.headers[CDN_BASE_HEADER])
-
         return ApiResponse(
             status = response.status.value,
             headers = response.headers,
@@ -196,8 +193,6 @@ abstract class OdinApiProviderBase(
             response.headers["decryptedcontenttype"]
                 ?: response.headers[HttpHeaders.ContentType]
                 ?: "application/octet-stream"
-
-        credentialsManager.observeCdnBase(response.headers[CDN_BASE_HEADER])
 
         return ByteApiResponse(
             status = response.status.value,

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/auth/CredentialsManager.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/auth/CredentialsManager.kt
@@ -1,7 +1,6 @@
 package id.homebase.api.client.auth
 
 import id.homebase.api.common.OdinId
-import kotlin.concurrent.Volatile
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -14,20 +13,6 @@ class CredentialsManager {
     private val storedCredentials = mutableMapOf<String, ApiCredentials>()
 
     private var activeCredentials: ApiCredentials? = null
-
-    /**
-     * The CDN base URL every Odin host stamps on every response. Latched from the first one seen, so any
-     * call at all teaches it — the media reads that need it can be served from cache and never hit the
-     * network themselves. Session-scoped: a different identity may front a different edge.
-     */
-    @Volatile
-    var cdnBaseUrl: String? = null
-        private set
-
-    fun observeCdnBase(advertised: String?) {
-        if (cdnBaseUrl != null) return
-        cdnBaseUrl = advertised?.trim()?.trimEnd('/')?.takeIf { it.isNotBlank() }
-    }
 
     private val _credentialsFlow = MutableStateFlow<ApiCredentials?>(null)
     val credentialsFlow: StateFlow<ApiCredentials?> = _credentialsFlow.asStateFlow()
@@ -52,7 +37,6 @@ class CredentialsManager {
     }
 
     suspend fun removeAllCredentials() = mutex.withLock {
-        cdnBaseUrl = null
         _credentialsFlow.update { null }
         activeCredentials = null
         storedCredentials.clear()

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/cache/DriveFileProviderCached.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/cache/DriveFileProviderCached.kt
@@ -377,6 +377,13 @@ class DriveFileProviderCached(
             fetch: suspend () -> ByteApiResponse
     ): ByteApiResponse = readThrough(thumbDiskCache, cacheKey, thumbnailSemaphore, "ThumbIO", fetch)
 
+    // Peer video ranges land in the same isolated chunk cache as local playback (#845), so a followed
+    // identity's video can't evict images and an image burst can't evict warm segments mid-playback.
+    suspend fun readHlsChunkThrough(
+            cacheKey: String,
+            fetch: suspend () -> ByteApiResponse
+    ): ByteApiResponse = readThrough(hlsChunkDiskCache, cacheKey, payloadSemaphore, "PayloadIO", fetch)
+
     suspend fun getThumbBytesDecrypted(
             driveId: Uuid,
             fileId: Uuid,

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/cache/DriveFileProviderCached.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/cache/DriveFileProviderCached.kt
@@ -377,8 +377,6 @@ class DriveFileProviderCached(
             fetch: suspend () -> ByteApiResponse
     ): ByteApiResponse = readThrough(thumbDiskCache, cacheKey, thumbnailSemaphore, "ThumbIO", fetch)
 
-    // Peer video ranges land in the same isolated chunk cache as local playback (#845), so a followed
-    // identity's video can't evict images and an image burst can't evict warm segments mid-playback.
     suspend fun readHlsChunkThrough(
             cacheKey: String,
             fetch: suspend () -> ByteApiResponse

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/peer/PeerFileByGlobalTransitProvider.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/peer/PeerFileByGlobalTransitProvider.kt
@@ -9,6 +9,7 @@ import id.homebase.api.client.PayloadSizePolicy
 import id.homebase.api.client.auth.CredentialsManager
 import id.homebase.api.client.drives.cache.DriveFileProviderCached
 import id.homebase.api.client.drives.files.BytesResponse
+import id.homebase.api.client.drives.files.DriveFileHelpers
 import id.homebase.api.client.drives.files.DriveFileHttpProvider
 import id.homebase.api.common.OdinId
 import io.ktor.client.HttpClient
@@ -105,6 +106,98 @@ class PeerFileByGlobalTransitProvider(
             return null
         }
         return decrypted(response, keyHeader)
+    }
+
+    /**
+     * Ranged read backing video playback. Null on 404.
+     *
+     * Ranges land in the isolated HLS chunk cache (#845), the same one local playback uses, so a replay
+     * or a scrub back does not re-pull the segment.
+     *
+     * [chunkStart]/[chunkLength] name the range the CALLER wants. An encrypted payload is AES-CBC, so the
+     * request is widened to block boundaries and the surplus trimmed off here.
+     */
+    suspend fun getPayloadChunkOverPeerByGlobalTransitId(
+        peer: OdinId,
+        driveId: Uuid,
+        globalTransitId: Uuid,
+        payloadKey: String,
+        keyHeader: KeyHeader,
+        chunkStart: Long,
+        chunkLength: Long?,
+    ): BytesResponse? {
+        require(payloadKey.isNotBlank()) { "payloadKey must be defined" }
+        require(chunkStart >= 0) { "chunkStart must be >= 0" }
+        val creds = requireCreds()
+
+        val range = DriveFileHelpers.getRangeHeader(chunkStart, chunkLength)
+        val start = range.updatedChunkStart ?: 0L
+        // int.MaxValue is the server's own end-of-file sentinel (OdinControllerBase.GetChunk), which is what
+        // an absent length has to become on a route taking it as a required path segment.
+        val length = range.updatedChunkEnd?.let { it - start + 1 } ?: Int.MAX_VALUE.toLong()
+
+        // Both routes take the range as `/{start}/{length}` path segments rather than a Range header, so each
+        // segment is a distinct URL the edge can cache on its own.
+        val remotePath =
+            "/drives/$driveId/files/by-gtid/$globalTransitId/payload/$payloadKey/$start/$length"
+        val peerUrl = apiUrl(creds.domain, "/peer/$peer$remotePath")
+
+        val cacheKey = peerCacheKey("chunk", peer, driveId, globalTransitId, payloadKey, start, length)
+        val response = try {
+            driveCache.readHlsChunkThrough(cacheKey) {
+                fetchViaCdnOrPeer(peer, remotePath, peerUrl, creds.accessToken, maxBytes = null)
+            }
+        } catch (_: NotFoundException) {
+            Logger.i(tag = TAG) { "404 (not shared / missing) url=$peerUrl" }
+            return null
+        }
+        if (response.status == 404) return null
+
+        val decrypted = driveFileHttpProvider.decryptChunkedBytes(
+            response.headers,
+            response.bytes,
+            keyHeader,
+            startOffset = range.startOffset,
+            chunkStart = chunkStart.toInt(),
+        )
+        val wanted = chunkLength?.toInt() ?: decrypted.size
+        return BytesResponse(
+            bytes = decrypted.sliceArray(0 until minOf(wanted, decrypted.size)),
+            contentType = response.contentType,
+        )
+    }
+
+    /**
+     * Ranged read that returns the bytes exactly as stored, still encrypted. Null on 404.
+     *
+     * iOS hands AVPlayer stock HLS-AES-128 and lets it decrypt, so its local video server must proxy
+     * ciphertext untouched — no block-alignment widening, because the caller wants the literal range.
+     */
+    suspend fun getPayloadChunkEncryptedOverPeerByGlobalTransitId(
+        peer: OdinId,
+        driveId: Uuid,
+        globalTransitId: Uuid,
+        payloadKey: String,
+        chunkStart: Long,
+        chunkLength: Long,
+    ): ByteArray? {
+        require(payloadKey.isNotBlank()) { "payloadKey must be defined" }
+        require(chunkStart >= 0 && chunkLength > 0) { "chunk must be a positive range" }
+        val creds = requireCreds()
+        val remotePath =
+            "/drives/$driveId/files/by-gtid/$globalTransitId/payload/$payloadKey/$chunkStart/$chunkLength"
+        val peerUrl = apiUrl(creds.domain, "/peer/$peer$remotePath")
+        val cacheKey =
+            peerCacheKey("chunk", peer, driveId, globalTransitId, payloadKey, chunkStart, chunkLength)
+        val response = try {
+            driveCache.readHlsChunkThrough(cacheKey) {
+                fetchViaCdnOrPeer(peer, remotePath, peerUrl, creds.accessToken, maxBytes = null)
+            }
+        } catch (_: NotFoundException) {
+            Logger.i(tag = TAG) { "404 (not shared / missing) url=$peerUrl" }
+            return null
+        }
+        return if (response.status == 404) null else response.bytes
     }
 
     // Runs inside the disk cache's fill lambda, so the CDN attempt and the peer fallback share one cache

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/peer/PeerFileByGlobalTransitProvider.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/peer/PeerFileByGlobalTransitProvider.kt
@@ -247,9 +247,8 @@ class PeerFileByGlobalTransitProvider(
 
     private suspend fun cdnUrlFor(peer: OdinId, remotePath: String): String? =
         cdnStateLock.withLock {
-            val base = credentialsManager.cdnBaseUrl ?: return@withLock null
             if (peer.toString() in peerOnlyHosts) return@withLock null
-            "$base/?forward=${"https://$peer/api/v2$remotePath".encodeURLParameter()}"
+            "$CDN_BASE/?forward=${"https://$peer/api/v2$remotePath".encodeURLParameter()}"
         }
 
     private suspend fun markPeerOnly(peer: OdinId) {
@@ -270,5 +269,9 @@ class PeerFileByGlobalTransitProvider(
 
     companion object {
         private const val TAG = "PeerFileByGtid"
+
+        // Pinned, not read from each response's x-odin-cdn-payload: a host fronting a different edge
+        // (or none) 401s here and falls through to peer — same path a missing header took.
+        private const val CDN_BASE = "https://cdn.ravenhosting.cloud"
     }
 }

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/video/PeerVideoDriveAccess.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/video/PeerVideoDriveAccess.kt
@@ -1,0 +1,137 @@
+package id.homebase.api.video
+
+import co.touchlab.kermit.Logger
+import id.homebase.api.client.KeyHeader
+import id.homebase.api.client.drives.files.BytesResponse
+import id.homebase.api.client.peer.PeerFileByGlobalTransitProvider
+import id.homebase.api.common.OdinId
+import id.homebase.api.file.FileOperationsProvider
+import kotlinx.coroutines.flow.flow
+import kotlin.uuid.Uuid
+
+/**
+ * Reads a followed identity's video off the AUTHOR's drive (CDN-first, peer fallback) behind the same
+ * interface the local drive implements, so the three platform player surfaces keep one call shape and
+ * only have to pick which access to hand [resolveVideoContent].
+ *
+ * [fileId] is ignored throughout: a followed post has no local file, and the author's copy is addressed
+ * by globalTransitId instead.
+ */
+class PeerVideoDriveAccess(
+    private val peer: OdinId,
+    private val globalTransitId: Uuid,
+    private val peerProvider: PeerFileByGlobalTransitProvider,
+    private val fileOps: FileOperationsProvider,
+) : VideoPrefetchDriveAccess {
+
+    // The preloader is wired to the local drive provider, so peer prefetch would read the wrong identity.
+    // Playback still warms the shared HLS chunk cache on its own; only the progress bar loses its source.
+    override suspend fun prefetchPayload(
+        driveId: Uuid,
+        fileId: Uuid,
+        key: String,
+        onDownloadProgress: ((Float) -> Unit)?,
+    ) = Unit
+
+    override suspend fun prefetchPayloadChunk(
+        driveId: Uuid,
+        fileId: Uuid,
+        key: String,
+        chunkStart: Long,
+        chunkLength: Long,
+        onDownloadProgress: ((Float) -> Unit)?,
+    ) = Unit
+
+    override suspend fun getPayloadBytesDecrypted(
+        driveId: Uuid,
+        fileId: Uuid,
+        key: String,
+        keyHeader: KeyHeader,
+        chunkStart: Long?,
+        chunkLength: Long?,
+        onDownloadProgress: ((Float) -> Unit)?,
+    ): BytesResponse? = if (chunkStart == null && chunkLength == null) {
+        peerProvider.getPayloadOverPeerByGlobalTransitId(
+            peer = peer,
+            driveId = driveId,
+            globalTransitId = globalTransitId,
+            payloadKey = key,
+            keyHeader = keyHeader,
+        )
+    } else {
+        peerProvider.getPayloadChunkOverPeerByGlobalTransitId(
+            peer = peer,
+            driveId = driveId,
+            globalTransitId = globalTransitId,
+            payloadKey = key,
+            keyHeader = keyHeader,
+            chunkStart = chunkStart ?: 0L,
+            chunkLength = chunkLength,
+        )
+    }
+
+    /**
+     * Non-segmented MP4 path. Pulled in [STREAM_CHUNK_BYTES] slices so RAM stays bounded at any video size
+     * — the whole-payload read is capped at the render limit and would refuse a real video outright.
+     */
+    override suspend fun streamPayloadDecryptedToPath(
+        driveId: Uuid,
+        fileId: Uuid,
+        key: String,
+        keyHeader: KeyHeader,
+        outputPath: String,
+        onProgress: ((Float) -> Unit)?,
+    ): Boolean {
+        var wroteAnything = false
+        fileOps.writeStream(
+            outputPath,
+            flow {
+                var offset = 0L
+                while (true) {
+                    val slice = peerProvider.getPayloadChunkOverPeerByGlobalTransitId(
+                        peer = peer,
+                        driveId = driveId,
+                        globalTransitId = globalTransitId,
+                        payloadKey = key,
+                        keyHeader = keyHeader,
+                        chunkStart = offset,
+                        chunkLength = STREAM_CHUNK_BYTES,
+                    ) ?: break
+                    if (slice.bytes.isEmpty()) break
+                    wroteAnything = true
+                    emit(slice.bytes)
+                    // A short read is the end of the file; the range routes clamp rather than 416.
+                    if (slice.bytes.size < STREAM_CHUNK_BYTES) break
+                    offset += slice.bytes.size
+                }
+            },
+        )
+        if (!wroteAnything) {
+            Logger.w(tag = "VideoIO") { "peer stream produced no bytes for $peer/$globalTransitId/$key" }
+        }
+        return wroteAnything
+    }
+
+    private companion object {
+        const val STREAM_CHUNK_BYTES = 4L * 1024 * 1024
+    }
+}
+
+/**
+ * The drive access this video should be read through: the author's, when the post came from someone we
+ * follow, otherwise our own. Keeps the local-vs-peer branch in one place instead of once per platform
+ * surface.
+ */
+fun VideoPlayerData.driveAccess(
+    local: VideoPrefetchDriveAccess,
+    peerProvider: PeerFileByGlobalTransitProvider,
+    fileOps: FileOperationsProvider,
+): VideoPrefetchDriveAccess {
+    val peer = remoteOdinId
+    val gtid = globalTransitId
+    return if (peer != null && gtid != null) {
+        PeerVideoDriveAccess(peer, gtid, peerProvider, fileOps)
+    } else {
+        local
+    }
+}

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/video/VideoPlayerData.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/video/VideoPlayerData.kt
@@ -1,6 +1,7 @@
 package id.homebase.api.video
 
 import id.homebase.api.client.KeyHeader
+import id.homebase.api.common.OdinId
 import kotlin.uuid.Uuid
 
 data class VideoPlayerData(
@@ -9,4 +10,7 @@ data class VideoPlayerData(
     val payloadKey: String,
     val keyHeader: KeyHeader,
     val descriptorContent: String?,
+    /** Set together for a followed identity's post: the bytes live on their drive, addressed by gtid. */
+    val remoteOdinId: OdinId? = null,
+    val globalTransitId: Uuid? = null,
 )

--- a/homebase-api/src/jvmTest/kotlin/id/homebase/api/client/peer/PeerFileByGlobalTransitProviderTest.kt
+++ b/homebase-api/src/jvmTest/kotlin/id/homebase/api/client/peer/PeerFileByGlobalTransitProviderTest.kt
@@ -35,6 +35,7 @@ class PeerFileByGlobalTransitProviderTest {
     private val peer = OdinId("author.example.com")
     private val driveId = Uuid.parse("11111111-1111-1111-1111-111111111111")
     private val key = "pst0mdi0"
+    private val cdn = "https://cdn.ravenhosting.cloud"
 
     private fun keyHeader() = KeyHeader(
         iv = ByteArray(16) { 3 },
@@ -65,9 +66,14 @@ class PeerFileByGlobalTransitProviderTest {
         var path: String? = null
         val bytes = byteArrayOf(1, 2, 3, 4)
         // payloadencrypted absent → decryptBytes returns the bytes untouched (the public-feed case).
+        // 401 the edge so the read falls through to peer — the route under test here.
         val engine = MockEngine { request ->
-            path = request.url.encodedPath
-            respond(bytes, HttpStatusCode.OK, headersOf(HttpHeaders.ContentType, "image/jpeg"))
+            if (request.url.toString().startsWith("$cdn/")) {
+                respond(ByteArray(0), HttpStatusCode.Unauthorized)
+            } else {
+                path = request.url.encodedPath
+                respond(bytes, HttpStatusCode.OK, headersOf(HttpHeaders.ContentType, "image/jpeg"))
+            }
         }
 
         val result = provider(engine)
@@ -85,8 +91,12 @@ class PeerFileByGlobalTransitProviderTest {
         val gtid = Uuid.random()
         var path: String? = null
         val engine = MockEngine { request ->
-            path = request.url.encodedPath
-            respond(byteArrayOf(9), HttpStatusCode.OK, headersOf(HttpHeaders.ContentType, "image/webp"))
+            if (request.url.toString().startsWith("$cdn/")) {
+                respond(ByteArray(0), HttpStatusCode.Unauthorized)
+            } else {
+                path = request.url.encodedPath
+                respond(byteArrayOf(9), HttpStatusCode.OK, headersOf(HttpHeaders.ContentType, "image/webp"))
+            }
         }
 
         provider(engine).getThumbOverPeerByGlobalTransitId(
@@ -182,34 +192,27 @@ class PeerFileByGlobalTransitProviderTest {
     }
 
     @Test
-    fun cdnIsUsed_onceTheHostHasAdvertisedItsBase() = runTest {
+    fun cdnIsUsedFromTheVeryFirstRead() = runTest {
         val urls = mutableListOf<String>()
         val engine = MockEngine { request ->
             urls += request.url.toString()
             respond(
                 byteArrayOf(9),
                 HttpStatusCode.OK,
-                headersOf(
-                    HttpHeaders.ContentType to listOf("image/jpeg"),
-                    "x-odin-cdn-payload" to listOf("https://cdn.test"),
-                ),
+                headersOf(HttpHeaders.ContentType, "image/jpeg"),
             )
         }
-        val p = provider(engine)
 
-        // First read has no base yet, so it goes over peer — and learns the base from the response.
-        p.getPayloadOverPeerByGlobalTransitId(peer, driveId, Uuid.random(), key, keyHeader())
-        // Second read routes through the edge, forwarding to the AUTHOR's host, not ours.
-        p.getPayloadOverPeerByGlobalTransitId(peer, driveId, Uuid.random(), key, keyHeader())
+        provider(engine)
+            .getPayloadOverPeerByGlobalTransitId(peer, driveId, Uuid.random(), key, keyHeader())
 
-        assertEquals(2, urls.size)
-        assertTrue(urls[0].startsWith("https://me.example.com/"), "first read is peer: ${urls[0]}")
-        assertTrue(urls[1].startsWith("https://cdn.test/?forward="), "second read is CDN: ${urls[1]}")
+        assertEquals(1, urls.size)
+        assertTrue(urls[0].startsWith("$cdn/?forward="), "first read is CDN: ${urls[0]}")
         assertTrue(
-            urls[1].contains("https%3A%2F%2F$peer%2Fapi%2Fv2%2Fdrives"),
-            "CDN forwards to the author's host: ${urls[1]}",
+            urls[0].contains("https%3A%2F%2F$peer%2Fapi%2Fv2%2Fdrives"),
+            "CDN forwards to the author's host: ${urls[0]}",
         )
-        assertTrue(urls[1].contains("by-gtid"), "CDN uses the by-gtid route: ${urls[1]}")
+        assertTrue(urls[0].contains("by-gtid"), "CDN uses the by-gtid route: ${urls[0]}")
     }
 
     @Test
@@ -220,15 +223,12 @@ class PeerFileByGlobalTransitProviderTest {
             urls += url
             when {
                 // A host that does not share the worker's CDN token hard-401s.
-                url.startsWith("https://cdn.test/") ->
+                url.startsWith("$cdn/") ->
                     respond(ByteArray(0), HttpStatusCode.Unauthorized)
                 else -> respond(
                     byteArrayOf(9),
                     HttpStatusCode.OK,
-                    headersOf(
-                        HttpHeaders.ContentType to listOf("image/jpeg"),
-                        "x-odin-cdn-payload" to listOf("https://cdn.test"),
-                    ),
+                    headersOf(HttpHeaders.ContentType, "image/jpeg"),
                 )
             }
         }
@@ -242,7 +242,7 @@ class PeerFileByGlobalTransitProviderTest {
         assertTrue(viaFallback != null, "the peer fallback still returns the bytes")
         assertEquals(
             1,
-            urls.count { it.startsWith("https://cdn.test/") },
+            urls.count { it.startsWith("$cdn/") },
             "the host is probed once, then stays on peer: $urls",
         )
         assertEquals(

--- a/homebase-chat/src/androidMain/kotlin/id/homebase/chat/widget/video/VideoPlayerSurface.android.kt
+++ b/homebase-chat/src/androidMain/kotlin/id/homebase/chat/widget/video/VideoPlayerSurface.android.kt
@@ -43,10 +43,13 @@ import androidx.media3.exoplayer.hls.HlsMediaSource
 import androidx.media3.ui.AspectRatioFrameLayout
 import androidx.media3.ui.PlayerView
 import id.homebase.api.client.KeyHeader
+import id.homebase.api.client.peer.PeerFileByGlobalTransitProvider
 import id.homebase.api.client.drives.files.DriveFileProvider
 import id.homebase.api.file.safeDeleteRecursively
 import id.homebase.api.video.VideoContent
 import id.homebase.api.video.VideoPlayerData
+import id.homebase.api.video.driveAccess
+import id.homebase.api.video.VideoPrefetchDriveAccess
 import id.homebase.api.video.VideoPreloader
 import id.homebase.api.video.resolveVideoContent
 import id.homebase.chat.conversationlist.FullScreenOverlay
@@ -107,6 +110,7 @@ actual fun VideoPlayerSurface(
     val context = LocalContext.current
     val driveFileProvider = koinInject<DriveFileProvider>()
     val fileOperationsProvider = koinInject<id.homebase.api.file.FileOperationsProvider>()
+    val peerFileProvider = koinInject<PeerFileByGlobalTransitProvider>()
     val videoPreloader = koinInject<VideoPreloader>()
     val playerPool = koinInject<ExoPlayerPool>()
     val scope = rememberCoroutineScope()
@@ -296,7 +300,13 @@ actual fun VideoPlayerSurface(
 
         withContext(Dispatchers.IO) {
             try {
-                when (val content = resolveVideoContent(VideoPlayerData(data.fileId, data.driveId, data.payloadKey, data.keyHeader, data.payload.descriptorContent), driveFileProvider, fileOps = fileOperationsProvider, onDownloadProgress = { onProgress(it * 0.5f) })) {
+                val videoData = VideoPlayerData(
+                    data.fileId, data.driveId, data.payloadKey, data.keyHeader,
+                    data.payload.descriptorContent, data.remoteOdinId, data.globalTransitId,
+                )
+                val videoAccess =
+                    videoData.driveAccess(driveFileProvider, peerFileProvider, fileOperationsProvider)
+                when (val content = resolveVideoContent(videoData, videoAccess, fileOps = fileOperationsProvider, onDownloadProgress = { onProgress(it * 0.5f) })) {
                     is VideoContent.Hls -> {
                         // Subscribe to the preloader's live bytes progress BEFORE kicking off the
                         // preload, so StateFlow's initial value and every subsequent emit lands.
@@ -312,15 +322,15 @@ actual fun VideoPlayerSurface(
                         // If MediaItem's preload was cancelled when the chat list left composition,
                         // this is the only path that drives real progress — ExoPlayer's own data-source
                         // fetches bypass onDownloadProgress entirely.
-                        videoPreloader.preload(
-                            VideoPlayerData(data.fileId, data.driveId, data.payloadKey, data.keyHeader, data.payload.descriptorContent)
-                        )
+                        // The preloader reads our own drive, so for a followed identity it would fetch the
+                        // wrong file. Playback warms the chunk cache itself; only progress goes dark.
+                        if (data.remoteOdinId == null) videoPreloader.preload(videoData)
                         val dataSourceFactory = DataSource.Factory {
                             HomebaseVideoDataSource(
                                 strippedPlaylist = content.originalPlaylist.lines()
                                     .filter { !it.startsWith("#EXT-X-KEY") }
                                     .joinToString("\n"),
-                                driveFileProvider = driveFileProvider,
+                                driveFileProvider = videoAccess,
                                 driveId = data.driveId,
                                 fileId = data.fileId,
                                 payloadKey = data.payloadKey,
@@ -561,7 +571,7 @@ private fun isTenBitFormat(format: Format?): Boolean {
 @UnstableApi
 private class HomebaseVideoDataSource(
     private val strippedPlaylist: String,
-    private val driveFileProvider: DriveFileProvider,
+    private val driveFileProvider: VideoPrefetchDriveAccess,
     private val driveId: Uuid,
     private val fileId: Uuid,
     private val payloadKey: String,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiState.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiState.kt
@@ -359,6 +359,9 @@ sealed interface FullScreenOverlay {
         val uploadMessageId: Uuid? = null,
         /** False for a public feed post: plaintext payload, no per-payload IV. */
         val isEncrypted: Boolean = true,
+        /** Set together for a followed identity's post; playback then reads the author's drive by gtid. */
+        val remoteOdinId: OdinId? = null,
+        val globalTransitId: Uuid? = null,
     ) : FullScreenOverlay
 
     @Immutable

--- a/homebase-chat/src/jvmMain/kotlin/id/homebase/chat/widget/video/VideoPlayerSurface.jvm.kt
+++ b/homebase-chat/src/jvmMain/kotlin/id/homebase/chat/widget/video/VideoPlayerSurface.jvm.kt
@@ -46,6 +46,8 @@ import id.homebase.api.client.drives.files.DriveFileProvider
 import id.homebase.api.file.safeDeleteRecursively
 import id.homebase.api.video.VideoContent
 import id.homebase.api.video.VideoPlayerData
+import id.homebase.api.video.driveAccess
+import id.homebase.api.client.peer.PeerFileByGlobalTransitProvider
 import id.homebase.api.video.VideoPreloader
 import id.homebase.api.video.resolveVideoContent
 import id.homebase.chat.conversationlist.FullScreenOverlay
@@ -115,6 +117,7 @@ actual fun VideoPlayerSurface(
     // than leaked; desktop sleep-during-playback is a minor annoyance at worst.
     val driveFileProvider = koinInject<DriveFileProvider>()
     val fileOperationsProvider = koinInject<id.homebase.api.file.FileOperationsProvider>()
+    val peerFileProvider = koinInject<PeerFileByGlobalTransitProvider>()
     val videoPreloader = koinInject<VideoPreloader>()
     val scope = rememberCoroutineScope()
     var state by remember(data) { mutableStateOf<VpsState>(VpsState.Loading) }
@@ -146,7 +149,13 @@ actual fun VideoPlayerSurface(
                     .also { it.mkdirs() }
                 tempDir = dir
 
-                when (val content = resolveVideoContent(VideoPlayerData(data.fileId, data.driveId, data.payloadKey, data.keyHeader, data.payload.descriptorContent), driveFileProvider, fileOps = fileOperationsProvider, onDownloadProgress = { onProgress(it * 0.5f) })) {
+                val videoData = VideoPlayerData(
+                    data.fileId, data.driveId, data.payloadKey, data.keyHeader,
+                    data.payload.descriptorContent, data.remoteOdinId, data.globalTransitId,
+                )
+                val videoAccess =
+                    videoData.driveAccess(driveFileProvider, peerFileProvider, fileOperationsProvider)
+                when (val content = resolveVideoContent(videoData, videoAccess, fileOps = fileOperationsProvider, onDownloadProgress = { onProgress(it * 0.5f) })) {
                     is VideoContent.Hls -> {
                         // Subscribe to the preloader's live bytes progress BEFORE kicking off the
                         // preload, so StateFlow's initial value and every subsequent emit lands.
@@ -162,9 +171,9 @@ actual fun VideoPlayerSurface(
                         // If MediaItem's preload was cancelled when the chat list left composition,
                         // this is the only path that drives real progress — VLC's own data-source
                         // fetches bypass onDownloadProgress entirely.
-                        videoPreloader.preload(
-                            VideoPlayerData(data.fileId, data.driveId, data.payloadKey, data.keyHeader, data.payload.descriptorContent)
-                        )
+                        // The preloader reads our own drive, so for a followed identity it would fetch the
+                        // wrong file. Playback warms the chunk cache itself; only progress goes dark.
+                        if (data.remoteOdinId == null) videoPreloader.preload(videoData)
                         File(dir, "index.m3u8").writeText(
                             content.originalPlaylist.lines()
                                 .filter { !it.startsWith("#EXT-X-KEY") }
@@ -200,7 +209,7 @@ actual fun VideoPlayerSurface(
                             val length = end - start + 1
                             Logger.d(tag = "VideoHLS") { "vlc chunk request: fileId=${data.fileId} key=${data.payloadKey} chunkStart=$start chunkLength=$length name=$name" }
                             val bytes = runBlocking {
-                                driveFileProvider.getPayloadBytesDecrypted(
+                                videoAccess.getPayloadBytesDecrypted(
                                     driveId = data.driveId,
                                     fileId = data.fileId,
                                     key = data.payloadKey,

--- a/homebase-chat/src/nativeMain/kotlin/id/homebase/chat/widget/video/LocalVideoServer.native.kt
+++ b/homebase-chat/src/nativeMain/kotlin/id/homebase/chat/widget/video/LocalVideoServer.native.kt
@@ -48,7 +48,9 @@ import kotlin.uuid.Uuid
 class LocalVideoServer private constructor() {
 
     private data class Session(
-        val driveFileProvider: DriveFileProvider,
+        // Takes (chunkStart, chunkLength) and returns ciphertext. A lambda rather than a provider so a
+        // followed identity's video can be read off the author's drive without this server knowing how.
+        val readEncryptedChunk: suspend (Long, Long) -> ByteArray?,
         val driveId: Uuid,
         val fileId: Uuid,
         val payloadKey: String,
@@ -65,7 +67,7 @@ class LocalVideoServer private constructor() {
     private val sessions = mutableMapOf<String, Session>()
 
     suspend fun register(
-        driveFileProvider: DriveFileProvider,
+        readEncryptedChunk: suspend (Long, Long) -> ByteArray?,
         driveId: Uuid,
         fileId: Uuid,
         payloadKey: String,
@@ -76,7 +78,7 @@ class LocalVideoServer private constructor() {
         val id = Uuid.random().toString()
         sessionsMutex.withLock {
             sessions[id] = Session(
-                driveFileProvider, driveId, fileId, payloadKey,
+                readEncryptedChunk, driveId, fileId, payloadKey,
                 keyHeader, originalPlaylist, totalFileSize,
             )
         }
@@ -138,13 +140,7 @@ class LocalVideoServer private constructor() {
         }
 
         val bytes = try {
-            s.driveFileProvider.getPayloadBytesEncryptedChunk(
-                driveId = s.driveId,
-                fileId = s.fileId,
-                key = s.payloadKey,
-                chunkStart = start,
-                chunkLength = length,
-            )
+            s.readEncryptedChunk(start, length)
         } catch (e: Exception) {
             Logger.e(throwable = e, tag = TAG) { "segment fetch failed: ${e.message}" }
             null

--- a/homebase-chat/src/nativeMain/kotlin/id/homebase/chat/widget/video/VideoPlayerSurface.native.kt
+++ b/homebase-chat/src/nativeMain/kotlin/id/homebase/chat/widget/video/VideoPlayerSurface.native.kt
@@ -21,6 +21,8 @@ import co.touchlab.kermit.Logger
 import id.homebase.api.client.drives.files.DriveFileProvider
 import id.homebase.api.video.VideoContent
 import id.homebase.api.video.VideoPlayerData
+import id.homebase.api.video.driveAccess
+import id.homebase.api.client.peer.PeerFileByGlobalTransitProvider
 import id.homebase.api.video.VideoPreloader
 import id.homebase.api.video.resolveVideoContent
 import id.homebase.chat.conversationlist.FullScreenOverlay
@@ -137,6 +139,7 @@ actual fun VideoPlayerSurface(
 ) {
     val driveFileProvider = koinInject<DriveFileProvider>()
     val fileOperationsProvider = koinInject<id.homebase.api.file.FileOperationsProvider>()
+    val peerFileProvider = koinInject<PeerFileByGlobalTransitProvider>()
     val videoPreloader = koinInject<VideoPreloader>()
     val playerPool = koinInject<AVPlayerPool>()
     val scope = rememberCoroutineScope()
@@ -258,7 +261,13 @@ actual fun VideoPlayerSurface(
         onProgress(0f)
         withContext(Dispatchers.Main) {
             try {
-                when (val content = resolveVideoContent(VideoPlayerData(data.fileId, data.driveId, data.payloadKey, data.keyHeader, data.payload.descriptorContent), driveFileProvider, fileOps = fileOperationsProvider, onDownloadProgress = { onProgress(it * 0.5f) })) {
+                val videoData = VideoPlayerData(
+                    data.fileId, data.driveId, data.payloadKey, data.keyHeader,
+                    data.payload.descriptorContent, data.remoteOdinId, data.globalTransitId,
+                )
+                val videoAccess =
+                    videoData.driveAccess(driveFileProvider, peerFileProvider, fileOperationsProvider)
+                when (val content = resolveVideoContent(videoData, videoAccess, fileOps = fileOperationsProvider, onDownloadProgress = { onProgress(it * 0.5f) })) {
                     is VideoContent.Hls -> {
                         // Subscribe to the preloader's live bytes progress BEFORE kicking off the
                         // preload, so StateFlow's initial value and every subsequent emit lands.
@@ -274,9 +283,9 @@ actual fun VideoPlayerSurface(
                         // If MediaItem's preload was cancelled when the chat list left composition,
                         // this is the only path that drives real progress — AVPlayer's resource loader
                         // delegate bypasses onDownloadProgress entirely.
-                        videoPreloader.preload(
-                            VideoPlayerData(data.fileId, data.driveId, data.payloadKey, data.keyHeader, data.payload.descriptorContent)
-                        )
+                        // The preloader reads our own drive, so for a followed identity it would fetch the
+                        // wrong file. Playback warms the chunk cache itself; only progress goes dark.
+                        if (data.remoteOdinId == null) videoPreloader.preload(videoData)
 
                         // Hand AVPlayer a real `http://127.0.0.1:<port>/...` URL backed by a
                         // tiny CIO server. The server rewrites the playlist so #EXT-X-KEY
@@ -285,8 +294,29 @@ actual fun VideoPlayerSurface(
                         // decrypts via stock HLS-AES-128 — no resource loader, no per-byterange
                         // crypto on our side. See LocalVideoServer.native.kt for the rationale.
                         val server = LocalVideoServer.shared()
+                        val peerOdinId = data.remoteOdinId
+                        val peerGtid = data.globalTransitId
                         val sessionId = server.register(
-                            driveFileProvider = driveFileProvider,
+                            readEncryptedChunk = { start, length ->
+                                if (peerOdinId != null && peerGtid != null) {
+                                    peerFileProvider.getPayloadChunkEncryptedOverPeerByGlobalTransitId(
+                                        peer = peerOdinId,
+                                        driveId = data.driveId,
+                                        globalTransitId = peerGtid,
+                                        payloadKey = data.payloadKey,
+                                        chunkStart = start,
+                                        chunkLength = length,
+                                    )
+                                } else {
+                                    driveFileProvider.getPayloadBytesEncryptedChunk(
+                                        driveId = data.driveId,
+                                        fileId = data.fileId,
+                                        key = data.payloadKey,
+                                        chunkStart = start,
+                                        chunkLength = length,
+                                    )
+                                }
+                            },
                             driveId = data.driveId,
                             fileId = data.fileId,
                             payloadKey = data.payloadKey,

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/feed/widget/FeedMediaFullScreenHost.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/feed/widget/FeedMediaFullScreenHost.kt
@@ -71,8 +71,6 @@ internal fun FeedMediaFullScreenHost(
 
 // Drive resolution mirrors PostMedia: a received post (senderOdinId + globalTransitId + a parseable channel
 // alias) points at the author's channel drive over peer; our own posts stay local on [FeedPostItem.driveId].
-// The image viewer honours those peer fields; the video player does not yet — peer video playback still issues
-// a local read and falls back to its poster frame.
 internal fun feedMediaOverlay(
     post: FeedPostItem,
     index: Int,
@@ -100,6 +98,8 @@ internal fun feedMediaOverlay(
             keyHeader = post.keyHeader,
             payload = payload,
             isEncrypted = post.isEncrypted,
+            remoteOdinId = post.senderOdinId?.takeIf { isPeerMedia },
+            globalTransitId = post.globalTransitId?.takeIf { isPeerMedia },
         )
     } else {
         FullScreenOverlay.ViewMessageData(

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/widget/MomentMediaItem.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/widget/MomentMediaItem.kt
@@ -371,7 +371,9 @@ fun MomentMediaItem(
             }
             var isPreloading by remember(fileId, payload.key) { mutableStateOf(false) }
             var preloadProgress by remember(fileId, payload.key) { mutableFloatStateOf(0f) }
-            if (!isUploading) {
+            // VideoPreloadService only reads the local drive, so a followed author's video would
+            // 404 every tile. The full-screen player fetches it over peer on demand instead.
+            if (!isUploading && remoteOdinId == null) {
                 VideoPreloadEffect(
                     data = videoPlayerData,
                     onPreloading = { isPreloading = it },


### PR DESCRIPTION
Stacked on #1348 — review that one first; this targets its branch.

Feed video from a followed identity never played. `FullScreenOverlay.VideoPlayerData`
carried no peer identity at all, so every platform's data source issued a **local**
read for a file our identity does not host:

```kotlin
driveFileProvider.getPayloadBytesDecrypted(driveId, fileId, ...)   // our drive
    ?.bytes ?: throw IOException("Failed to fetch video chunk at position=$chunkStart")
```

It looked healthy right up to the failure, because the payload *descriptor* rides on
the synced feed row: duration, codec and HLS playlist all resolved, then chunk 0 404'd
and the player fell back to its poster frame. Captured on device before the fix:

```
Warn   preload failed for 92f3b219…/pst_mdi0: Not found
Debug  metadata: mimeType=application/vnd.apple.mpegurl isSegmented=true duration=24946.3
Debug  exo chunk request: chunkStart=0 chunkLength=19452752 path=output.ts
Error  player error: code=ERROR_CODE_IO_UNSPECIFIED message=Source error
```

The repo already knew — `FeedMediaFullScreenHost.kt` carried a comment saying the video
player "does not yet" honour the peer fields.

### What this adds

- **Ranged by-gtid reads**, CDN-first with peer fallback. A decrypting variant for
  Android/desktop, and one returning ciphertext untouched for iOS, which hands AVPlayer
  stock HLS-AES-128 and lets it decrypt. Both routes take the range as
  `/{start}/{length}` path segments rather than a `Range` header, so each segment is a
  distinct URL the edge can cache on its own.
- **AES block alignment.** An encrypted payload is CBC, so the request widens to block
  boundaries and the surplus is trimmed before the caller sees it.
- **`PeerVideoDriveAccess`**, implementing the same `VideoPrefetchDriveAccess` the local
  drive does. The three surfaces keep one call shape and only choose which access to
  hand `resolveVideoContent`, instead of growing a local-vs-peer branch each.
- **`LocalVideoServer` takes a reader lambda** instead of a `DriveFileProvider`, for the
  same reason — it no longer needs to know whose drive the bytes come from.
- **Ranges use the existing isolated HLS chunk cache** (#845), the one local playback
  already uses, so a replay does not re-pull the segment and video still cannot evict
  images.

### Verification

Device-verified on a physical Android device against a followed identity's 24s video:

```
exo chunk request: chunkStart=0 chunkLength=19452752
CDN GET  …/by-gtid/8d15629d…/payload/pst_mdi0/0/19452752
GET      …/peer/frodo.baggins…/payload/pst_mdi0/0/19452752
exo chunk request: chunkStart=19452752  ->  URL /19452736/20364944
player state → READY     player isPlaying=true     1080x1920
```

The second segment is the alignment proof: asked for `19452752`, requested `19452736`,
trimmed on return, playback clean.

`homebase-api:jvmTest` green (1181 tests, 0 failures); api, chat and core compile on JVM
and Android.

### Notes for review

- **iOS and desktop are compile-verified only.** The device on hand is Android. The iOS
  path is the one that differs most — it is the ciphertext variant plus the
  `LocalVideoServer` change — so it deserves a real look.
- **That test video is a restricted post, so it is served over peer, not the CDN.** That
  is correct behaviour here, but it is also the reason video does not yet reach the edge:
  a restricted post is invisible to the CDN caller even though
  `DriveAclAuthorizationService.CallerHasPermission` returns `true` outright for
  `SecurityGroupType.System`. Measured on frodo, same drive — public gtid: cdn 200 /
  anon 200; restricted gtid: **cdn 404 / anon 403**. That is an odin-core gap and a
  separate change; this branch degrades to peer until it lands.
- **The preloader is skipped for peer video.** `VideoPreloadService` resolves the local
  drive from DI, so it cannot reach a followed author's file — it fired a prefetch that
  404'd on every peer tile (`preload failed … Not found`, above). `MomentMediaItem` now
  guards on `remoteOdinId == null`. Playback warms the chunk cache itself; only the
  progress bar loses its source. Threading the peer fields into the preloader instead
  would have been inert — `PeerVideoDriveAccess`'s prefetch methods are no-ops by design.

### The CDN base is now pinned, not learned

Previously the base was read off each response's `x-odin-cdn-payload` header and latched
in `CredentialsManager`. The edge is a fixed deployment (`https://cdn.ravenhosting.cloud`),
so that machinery bought nothing: a host fronting a different edge — or none — 401s and
falls through to peer, which is exactly where a missing header already landed. Removed the
latched field, its observer, the logout reset and both call sites in `OdinApiProviderBase`;
net −24 lines of production code.

One behavioural change: **the first peer media read of a session now goes to the CDN**
rather than peer. Under the old scheme the base could only be learned from a response, so
the first read was always peer. Two route-shape tests (`payload_hitsV2ByGtidRoute`,
`thumb_hitsV2ByGtidThumbRoute`) had quietly depended on that ordering — they read the
first request's path — and now 401 the edge to keep asserting the peer route they exist
to cover.

Verified on desktop before the change that the observation worked as designed: an ordinary
`/api/v2/connections/blocked` call at 10:14:31 taught the base, and the first media read
394 log lines later at 10:20:07 went `CDN GET https://cdn.ravenhosting.cloud/?forward=…`.
Pinning reaches the same place without the round trip.

Trade-off worth knowing: `StartupVerificationBackgroundService` drops the header when the
edge fails its ping, and the client can no longer see that. A CDN outage now costs one
failed request per file before falling back, rather than none. If that bites, treating a
connect failure like a 401 in `markPeerOnly` would bound it to one per host per session.