### PR TITLE
Route the three guarded bottom sheets through AdaptiveSheet

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/event/EventComposerSheet.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/event/EventComposerSheet.kt
@@ -42,7 +42,6 @@ import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.SelectableDates
-import androidx.compose.material3.SheetState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TimePicker
@@ -144,10 +143,9 @@ fun EventComposerSheet(
     onDismiss: () -> Unit,
     onSent: () -> Unit,
 ) {
-    GuardedComposerSheet(onDismiss = onDismiss) { sheetState, requestClose, reportUnsaved ->
+    GuardedComposerSheet(onDismiss = onDismiss) { requestClose, reportUnsaved ->
         EventComposerContent(
             conversationId = conversationId,
-            sheetState = sheetState,
             onDismiss = onDismiss,
             onSent = onSent,
             onRequestClose = requestClose,
@@ -160,7 +158,6 @@ fun EventComposerSheet(
 @Composable
 private fun EventComposerContent(
     conversationId: Uuid,
-    sheetState: SheetState,
     onDismiss: () -> Unit,
     onSent: () -> Unit,
     onRequestClose: () -> Unit = onDismiss,
@@ -311,7 +308,6 @@ private fun EventComposerContent(
                         payloadBundle = bundle,
                     )
                 }
-                sheetState.hide()
                 onSent()
             }
         }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/groodle/GroodleComposerSheet.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/groodle/GroodleComposerSheet.kt
@@ -39,7 +39,6 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.SheetState
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -144,10 +143,9 @@ fun GroodleComposerSheet(
     onDismiss: () -> Unit,
     onSent: () -> Unit,
 ) {
-    GuardedComposerSheet(onDismiss = onDismiss) { sheetState, requestClose, reportUnsaved ->
+    GuardedComposerSheet(onDismiss = onDismiss) { requestClose, reportUnsaved ->
         GroodleComposerContent(
             conversationId = conversationId,
-            sheetState = sheetState,
             onDismiss = onDismiss,
             onSent = onSent,
             onRequestClose = requestClose,
@@ -160,7 +158,6 @@ fun GroodleComposerSheet(
 @Composable
 private fun GroodleComposerContent(
     conversationId: Uuid,
-    sheetState: SheetState,
     onDismiss: () -> Unit,
     onSent: () -> Unit,
     onRequestClose: () -> Unit = onDismiss,
@@ -236,7 +233,6 @@ private fun GroodleComposerContent(
                         previousMessageUniqueId = null,
                     )
                 }
-                sheetState.hide()
                 onSent()
             }
         }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/groupsettings/GroupSettingsScreen.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/groupsettings/GroupSettingsScreen.kt
@@ -96,6 +96,7 @@ import id.homebase.core.avatars.ContactAvatar
 import id.homebase.core.avatars.ConversationAvatarModel
 import id.homebase.core.image.HomebaseImageData
 import id.homebase.core.media.subsample.SubSamplingImageSource
+import id.homebase.core.widget.AdaptiveSheet
 import id.homebase.core.widget.ContactName
 import id.homebase.core.widget.DialogButtons
 import id.homebase.core.widget.DialogCard
@@ -897,13 +898,10 @@ fun GroupSettingsSheets(
         }
 
         is GroupSettingsUiSheet.HealProgress -> {
-            val sheetState = rememberModalBottomSheetState()
-            ModalBottomSheet(
-                // Block dismiss until the heal call returns so the user can see
-                // every line transition. After [finished] flips true, the Close
-                // button (rendered below) is the explicit dismiss path.
-                onDismissRequest = { if (sheet.finished) onSheetClosed() },
-                sheetState = sheetState,
+            // Pinned open until the heal call returns so the user sees every line transition.
+            AdaptiveSheet(
+                onDismiss = onSheetClosed,
+                dismissible = sheet.finished,
             ) {
                 HealProgressSheetContent(
                     items = sheet.items,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/poll/PollComposerSheet.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/poll/PollComposerSheet.kt
@@ -26,7 +26,6 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.SheetState
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -82,10 +81,9 @@ fun PollComposerSheet(
     onDismiss: () -> Unit,
     onSent: () -> Unit,
 ) {
-    GuardedComposerSheet(onDismiss = onDismiss) { sheetState, requestClose, reportUnsaved ->
+    GuardedComposerSheet(onDismiss = onDismiss) { requestClose, reportUnsaved ->
         PollComposerContent(
             conversationId = conversationId,
-            sheetState = sheetState,
             onDismiss = onDismiss,
             onSent = onSent,
             onRequestClose = requestClose,
@@ -101,7 +99,6 @@ private data class OptionDraft(val id: Long, val text: String)
 @Composable
 private fun PollComposerContent(
     conversationId: Uuid,
-    sheetState: SheetState,
     onDismiss: () -> Unit,
     onSent: () -> Unit,
     onRequestClose: () -> Unit = onDismiss,
@@ -157,7 +154,6 @@ private fun PollComposerContent(
                             previousMessageUniqueId = null,
                         )
                     }
-                    sheetState.hide()
                     onSent()
                 } finally {
                     sending = false

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/GuardedComposerSheet.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/GuardedComposerSheet.kt
@@ -2,77 +2,61 @@ package id.homebase.chat.widget
 
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.ModalBottomSheet
-import androidx.compose.material3.SheetState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
-import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import id.homebase.core.widget.AdaptiveSheet
 import id.homebase.resources.MR
 import id.homebase.resources.composer_discard_confirm
 import id.homebase.resources.composer_discard_keep
 import id.homebase.resources.composer_discard_message
 import id.homebase.resources.composer_discard_title
-import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.stringResource
 
 /**
- * A [ModalBottomSheet] for a content composer (Groodle / Event / Poll) that
- * guards against accidental data loss (#891): when the user swipes the sheet
- * down, taps the scrim, presses back, or taps the close button **while there's
- * unsaved content**, it asks "Discard changes?" instead of throwing the draft
- * away — keeping the sheet (and the draft) if the user cancels. An empty
- * composer dismisses immediately, with no prompt.
+ * A sheet for a content composer (Groodle / Event / Poll) that guards against accidental
+ * data loss: while there's unsaved content the sheet is pinned open, so a stray swipe,
+ * scrim tap or back press cannot take the draft with it. The composer's own close button
+ * routes through `requestClose`, which asks "Discard changes?" instead of throwing the
+ * draft away. An empty composer dismisses immediately, with no prompt.
  *
  * [content] reports whether it currently holds unsaved content through the
  * `reportUnsaved` callback, and routes its own close button through
  * `requestClose`.
  */
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun GuardedComposerSheet(
     onDismiss: () -> Unit,
     content: @Composable (
-        sheetState: SheetState,
         requestClose: () -> Unit,
         reportUnsaved: (Boolean) -> Unit,
     ) -> Unit,
 ) {
-    val scope = rememberCoroutineScope()
     var hasUnsaved by remember { mutableStateOf(false) }
     var showDiscardConfirm by remember { mutableStateOf(false) }
 
-    // No confirmValueChange veto — rejecting Hidden mid-fling oscillates the
-    // sheet forever (#997); the unsaved guard lives in onDismissRequest instead.
-    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
-
     val requestClose: () -> Unit = {
-        if (hasUnsaved) showDiscardConfirm = true
-        else scope.launch { sheetState.hide(); onDismiss() }
+        if (hasUnsaved) showDiscardConfirm = true else onDismiss()
     }
 
-    ModalBottomSheet(
-        onDismissRequest = { if (hasUnsaved) showDiscardConfirm = true else onDismiss() },
-        sheetState = sheetState,
-        // Zero insets: the defaults pad inside the draggable surface, so sheet
-        // height tracks sheet position and the anchors oscillate on fling (#997).
+    AdaptiveSheet(
+        onDismiss = requestClose,
+        dismissible = !hasUnsaved,
+        expandFully = true,
+        // The composer sizes itself off the sheet's own height; the default insets pad
+        // inside the draggable surface, so height tracks position and the anchors
+        // oscillate on fling.
         contentWindowInsets = { WindowInsets(0, 0, 0, 0) },
     ) {
-        content(sheetState, requestClose) { hasUnsaved = it }
+        content(requestClose) { hasUnsaved = it }
     }
 
     if (showDiscardConfirm) {
-        // A swipe/scrim/back dismissal already settled Hidden — bring the sheet back.
-        val keepEditing: () -> Unit = {
-            showDiscardConfirm = false
-            scope.launch { sheetState.show() }
-        }
+        val keepEditing: () -> Unit = { showDiscardConfirm = false }
         AlertDialog(
             onDismissRequest = keepEditing,
             title = { Text(stringResource(MR.string.composer_discard_title)) },

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/core/connections/ConnectRequestBottomSheet.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/core/connections/ConnectRequestBottomSheet.kt
@@ -15,9 +15,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.mutableStateOf
@@ -27,7 +25,6 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
-import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
@@ -47,6 +44,7 @@ import id.homebase.api.client.identity.initials
 import id.homebase.core.avatars.AvatarOptions
 import id.homebase.core.avatars.ContactAvatar
 import id.homebase.core.util.getUriHandler
+import id.homebase.core.widget.AdaptiveSheet
 import id.homebase.core.widget.HomebaseIdField
 import id.homebase.resources.MR
 import id.homebase.resources.cancel
@@ -64,7 +62,6 @@ import id.homebase.resources.settings_open_owner_console
 import kotlin.uuid.Uuid
 import org.jetbrains.compose.resources.stringResource
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ConnectRequestBottomSheet(
     viewModel: ConnectRequestViewModel,
@@ -132,29 +129,39 @@ fun ConnectRequestBottomSheet(
     }
 
     if (state.showDialog) {
-        val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+        ConnectRequestSheet(
+            state = state,
+            sheetSnackbarHostState = sheetSnackbarHostState,
+            onAction = viewModel::onAction,
+        )
+    }
+}
 
-        ModalBottomSheet(
-            onDismissRequest = {
-                if (!state.isSending) viewModel.onAction(ConnectRequestAction.CloseDialog)
-            },
-            sheetState = sheetState,
-        ) {
-            Box {
-                ComposeRequestSheetContent(
-                    recipient = state.recipient,
-                    message = state.message,
-                    resolution = state.resolution,
-                    isSending = state.isSending,
-                    onRecipientChange = { viewModel.onAction(ConnectRequestAction.RecipientChanged(it)) },
-                    onMessageChange = { viewModel.onAction(ConnectRequestAction.MessageChanged(it)) },
-                    onSend = { viewModel.onAction(ConnectRequestAction.SendClicked) },
-                )
-                SnackbarHost(
-                    hostState = sheetSnackbarHostState,
-                    modifier = Modifier.align(Alignment.BottomCenter),
-                )
-            }
+@Composable
+internal fun ConnectRequestSheet(
+    state: ConnectRequestState,
+    sheetSnackbarHostState: SnackbarHostState,
+    onAction: (ConnectRequestAction) -> Unit,
+) {
+    AdaptiveSheet(
+        onDismiss = { onAction(ConnectRequestAction.CloseDialog) },
+        dismissible = !state.isSending,
+        expandFully = true,
+    ) {
+        Box {
+            ComposeRequestSheetContent(
+                recipient = state.recipient,
+                message = state.message,
+                resolution = state.resolution,
+                isSending = state.isSending,
+                onRecipientChange = { onAction(ConnectRequestAction.RecipientChanged(it)) },
+                onMessageChange = { onAction(ConnectRequestAction.MessageChanged(it)) },
+                onSend = { onAction(ConnectRequestAction.SendClicked) },
+            )
+            SnackbarHost(
+                hostState = sheetSnackbarHostState,
+                modifier = Modifier.align(Alignment.BottomCenter),
+            )
         }
     }
 }

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/groupsettings/GroupSettingsHealSheetDismissTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/groupsettings/GroupSettingsHealSheetDismissTest.kt
@@ -1,0 +1,76 @@
+package id.homebase.chat.groupsettings
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.SkikoComposeUiTest
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.click
+import androidx.compose.ui.test.isRoot
+import androidx.compose.ui.test.onLast
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.runSkikoComposeUiTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+// Forced compact size: the wide branch is a plain Dialog and cannot reach the bug, so these pass
+// against broken code at the default 1024x768.
+@OptIn(ExperimentalTestApi::class)
+class GroupSettingsHealSheetDismissTest {
+
+    private val compactPhone = Size(400f, 800f)
+
+    private val title = "Healing group"
+
+    private fun SkikoComposeUiTest.showSheet(finished: Boolean, onSheetClosed: () -> Unit) {
+        setContent {
+            MaterialTheme {
+                GroupSettingsSheets(
+                    uiState = GroupSettingsUiState(
+                        isLoading = false,
+                        uiSheet = GroupSettingsUiSheet.HealProgress(
+                            items = emptyList(),
+                            finished = finished,
+                        ),
+                    ),
+                    onUiAction = {},
+                    onSheetClosed = onSheetClosed,
+                )
+            }
+        }
+        waitForIdle()
+    }
+
+    private fun SkikoComposeUiTest.tapAboveTheSheet() {
+        onAllNodes(isRoot()).onLast().performTouchInput {
+            click(Offset(width / 2f, 4f))
+        }
+        waitForIdle()
+    }
+
+    @Test
+    fun `a tap outside mid-heal leaves the sheet on screen`() =
+        runSkikoComposeUiTest(size = compactPhone) {
+            var closes = 0
+            showSheet(finished = false) { closes++ }
+
+            onNodeWithText(title).assertIsDisplayed()
+            tapAboveTheSheet()
+
+            onNodeWithText(title).assertIsDisplayed()
+            assertEquals(0, closes)
+        }
+
+    @Test
+    fun `a tap outside once the heal finished dismisses`() =
+        runSkikoComposeUiTest(size = compactPhone) {
+            var closes = 0
+            showSheet(finished = true) { closes++ }
+
+            tapAboveTheSheet()
+
+            assertEquals(1, closes)
+        }
+}

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/widget/GuardedComposerSheetDismissTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/widget/GuardedComposerSheetDismissTest.kt
@@ -1,0 +1,80 @@
+package id.homebase.chat.widget
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.SkikoComposeUiTest
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.click
+import androidx.compose.ui.test.isRoot
+import androidx.compose.ui.test.onLast
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.runSkikoComposeUiTest
+import androidx.compose.ui.unit.dp
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+// Forced compact size: the wide branch is a plain Dialog and cannot reach the bug, so these pass
+// against broken code at the default 1024x768.
+@OptIn(ExperimentalTestApi::class)
+class GuardedComposerSheetDismissTest {
+
+    private val compactPhone = Size(400f, 800f)
+
+    private val body = "composerBody"
+
+    private val discardTitle = "Discard changes?"
+
+    private fun SkikoComposeUiTest.showSheet(unsaved: Boolean, onDismiss: () -> Unit) {
+        setContent {
+            MaterialTheme {
+                GuardedComposerSheet(onDismiss = onDismiss) { _, reportUnsaved ->
+                    LaunchedEffect(unsaved) { reportUnsaved(unsaved) }
+                    Box(Modifier.testTag(body).fillMaxWidth().height(300.dp))
+                }
+            }
+        }
+        waitForIdle()
+    }
+
+    private fun SkikoComposeUiTest.tapAboveTheSheet() {
+        onAllNodes(isRoot()).onLast().performTouchInput {
+            click(Offset(width / 2f, 4f))
+        }
+        waitForIdle()
+    }
+
+    @Test
+    fun `a tap outside with a draft leaves the sheet on screen`() =
+        runSkikoComposeUiTest(size = compactPhone) {
+            var dismissals = 0
+            showSheet(unsaved = true) { dismissals++ }
+
+            onNodeWithTag(body).assertIsDisplayed()
+            tapAboveTheSheet()
+
+            onNodeWithTag(body).assertIsDisplayed()
+            onNodeWithText(discardTitle).assertDoesNotExist()
+            assertEquals(0, dismissals)
+        }
+
+    @Test
+    fun `a tap outside with an empty composer dismisses`() =
+        runSkikoComposeUiTest(size = compactPhone) {
+            var dismissals = 0
+            showSheet(unsaved = false) { dismissals++ }
+
+            tapAboveTheSheet()
+
+            assertEquals(1, dismissals)
+        }
+}

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/core/connections/ConnectRequestSheetDismissTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/core/connections/ConnectRequestSheetDismissTest.kt
@@ -1,0 +1,78 @@
+package id.homebase.core.connections
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.SkikoComposeUiTest
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.click
+import androidx.compose.ui.test.isRoot
+import androidx.compose.ui.test.onLast
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.runSkikoComposeUiTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+// Forced compact size: the wide branch is a plain Dialog and cannot reach the bug, so these pass
+// against broken code at the default 1024x768.
+@OptIn(ExperimentalTestApi::class)
+class ConnectRequestSheetDismissTest {
+
+    private val compactPhone = Size(400f, 800f)
+
+    private val title = "New connection request"
+
+    private fun SkikoComposeUiTest.showSheet(
+        isSending: Boolean,
+        onAction: (ConnectRequestAction) -> Unit,
+    ) {
+        setContent {
+            MaterialTheme {
+                ConnectRequestSheet(
+                    state = ConnectRequestState(
+                        showDialog = true,
+                        recipient = "ada.example.com",
+                        isSending = isSending,
+                    ),
+                    sheetSnackbarHostState = SnackbarHostState(),
+                    onAction = onAction,
+                )
+            }
+        }
+        waitForIdle()
+    }
+
+    private fun SkikoComposeUiTest.tapAboveTheSheet() {
+        onAllNodes(isRoot()).onLast().performTouchInput {
+            click(Offset(width / 2f, 4f))
+        }
+        waitForIdle()
+    }
+
+    @Test
+    fun `a tap outside mid-send leaves the sheet on screen`() =
+        runSkikoComposeUiTest(size = compactPhone) {
+            var closes = 0
+            showSheet(isSending = true) { if (it is ConnectRequestAction.CloseDialog) closes++ }
+
+            onNodeWithText(title).assertIsDisplayed()
+            tapAboveTheSheet()
+
+            onNodeWithText(title).assertIsDisplayed()
+            assertEquals(0, closes)
+        }
+
+    @Test
+    fun `a tap outside while idle dismisses`() =
+        runSkikoComposeUiTest(size = compactPhone) {
+            var closes = 0
+            showSheet(isSending = false) { if (it is ConnectRequestAction.CloseDialog) closes++ }
+
+            tapAboveTheSheet()
+
+            assertEquals(1, closes)
+        }
+}

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/widget/AdaptiveSheet.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/widget/AdaptiveSheet.kt
@@ -1,8 +1,10 @@
-package id.homebase.core.ui.screens.contactbook.components
+package id.homebase.core.widget
 
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
+import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
@@ -31,6 +33,9 @@ import androidx.window.core.layout.WindowSizeClass
  * @param dismissible false pins the sheet open while the caller has work in flight. Gating
  *   [onDismiss] would not: `ModalBottomSheet` runs `hide()` *before* consulting `onDismissRequest`,
  *   so a refused dismissal leaves an invisible sheet mounted with no way to bring it back.
+ * @param contentWindowInsets compact branch only. Content that sizes itself off the sheet's own
+ *   height (`fillMaxHeight(fraction)`) must pass zero here — the default insets pad inside the
+ *   draggable surface, so height tracks position and the anchors oscillate on fling.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -38,6 +43,7 @@ fun AdaptiveSheet(
     onDismiss: () -> Unit,
     dismissible: Boolean = true,
     expandFully: Boolean = false,
+    contentWindowInsets: @Composable () -> WindowInsets = { BottomSheetDefaults.windowInsets },
     content: @Composable () -> Unit,
 ) {
     val wide = currentWindowAdaptiveInfo().windowSizeClass
@@ -75,6 +81,7 @@ fun AdaptiveSheet(
             onDismissRequest = onDismiss,
             sheetState = sheetState,
             sheetGesturesEnabled = dismissible,
+            contentWindowInsets = contentWindowInsets,
             properties = ModalBottomSheetProperties(
                 shouldDismissOnBackPress = dismissible,
                 shouldDismissOnClickOutside = dismissible,

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/components/CircleMembersSheet.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/components/CircleMembersSheet.kt
@@ -33,6 +33,7 @@ import id.homebase.core.ui.screens.contactbook.CircleMemberStatus
 import id.homebase.core.ui.screens.contactbook.CircleMembersUi
 import id.homebase.core.ui.screens.contactbook.model.ContactBookEntry
 import id.homebase.core.ui.theme.HomebaseTheme
+import id.homebase.core.widget.AdaptiveSheet
 import id.homebase.resources.MR
 import id.homebase.resources.cancel
 import id.homebase.resources.circle_drive_unknown

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/components/ContactEditSheet.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/components/ContactEditSheet.kt
@@ -66,6 +66,7 @@ import id.homebase.core.ui.screens.contactbook.mergeSeed
 import id.homebase.core.ui.screens.contactbook.model.ContactBookEntry
 import id.homebase.core.ui.screens.contactbook.syncedDraft
 import id.homebase.core.ui.screens.contactbook.toDraft
+import id.homebase.core.widget.AdaptiveSheet
 import id.homebase.core.widget.HomebaseIdField
 import id.homebase.resources.MR
 import id.homebase.resources.contactbook_edit_add_email

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/components/PhoneNumberField.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/components/PhoneNumberField.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.intl.Locale
 import androidx.compose.ui.unit.dp
+import id.homebase.core.widget.AdaptiveSheet
 import id.homebase.resources.MR
 import id.homebase.resources.contactbook_country_search
 import org.jetbrains.compose.resources.stringResource

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/EmergencyLocateSheet.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/EmergencyLocateSheet.kt
@@ -31,7 +31,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import id.homebase.chat.data.ContactUiModel
 import id.homebase.core.location.emergency.locateWindowOptionsHours
-import id.homebase.core.ui.screens.contactbook.components.AdaptiveSheet
+import id.homebase.core.widget.AdaptiveSheet
 import id.homebase.resources.MR
 import id.homebase.resources.cancel
 import id.homebase.resources.live_location_age_minutes

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/profile/ProfileEditScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/profile/ProfileEditScreen.kt
@@ -71,7 +71,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import id.homebase.api.client.profile.ProfileAttributeTypes
 import id.homebase.api.client.profile.ProfileVisibility
 import id.homebase.core.ui.screens.contactbook.ContactFieldValidation
-import id.homebase.core.ui.screens.contactbook.components.AdaptiveSheet
+import id.homebase.core.widget.AdaptiveSheet
 import id.homebase.core.ui.screens.contactbook.components.PhoneNumberField
 import id.homebase.core.ui.screens.contactbook.components.formatPhoneForDisplay
 import id.homebase.resources.MR


### PR DESCRIPTION
Fixes #1306.

## The mechanism

`ModalBottomSheet` runs `hide()` **before** it consults `onDismissRequest`, on every dismissal path — `animateToDismiss`, `settleToDismiss`, back press, and the drag handle's **unconditional** `Modifier.clickable`. So the common guard

```kotlin
onDismissRequest = { if (!busy) onDismiss() }
```

refuses nothing. The sheet has already animated away; the guard only declines to tell the caller. The `LaunchedEffect(sheetState) { sheetState.show() }` that opened it never re-runs, so it never comes back.

That is worse than an invisible sheet: `ModalBottomSheet` is a real `MATCH_PARENT` touch-modal `Dialog` window, so the app is **soft-locked** until the in-flight work finishes.

## Scope — this is the complete set

Swept all 14 remaining `ModalBottomSheet` call sites across the UI modules: **zero** others carry a conditional `onDismissRequest`. The three named in the issue were the whole problem.

| Site | Now |
|---|---|
| `ConnectRequestBottomSheet.kt` | `AdaptiveSheet(dismissible = !state.isSending, expandFully = true)` |
| `GroupSettingsScreen.kt` (HealProgress) | `AdaptiveSheet(dismissible = sheet.finished)` |
| `GuardedComposerSheet.kt` | `AdaptiveSheet(dismissible = !hasUnsaved, expandFully = true, contentWindowInsets = zero)` |

`AdaptiveSheet`'s `dismissible` (from #1262) threads to `sheetGesturesEnabled`, both `ModalBottomSheetProperties` flags, and an identity-stable `confirmValueChange` — which is what actually closes the drag-handle hole.

**`AdaptiveSheet` moves `homebase-core` → `homebase-common`** because `homebase-chat` cannot depend on `homebase-core`. Tracked as a rename; 5 existing call sites get import updates.

## Evidence — fails broken, passes fixed

Three new tests, all `runSkikoComposeUiTest(size = Size(400f, 800f))`. The size matters: `runComposeUiTest`'s 1024×768 default lands on the wide `Dialog` branch where the bug cannot occur, so a test written without it passes against broken code.

Against the pre-fix code:

```
GroupSettingsHealSheetDismissTest > a tap outside mid-heal leaves the sheet on screen FAILED
GuardedComposerSheetDismissTest  > a tap outside with a draft leaves the sheet on screen FAILED
ConnectRequestSheetDismissTest   > a tap outside mid-send leaves the sheet on screen FAILED
6 tests completed, 3 failed
```

```
Assert failed: The component with TestTag = 'composerBody' is not displayed!
```

After: 6/6, `failures="0" errors="0"`. Full `:homebase-chat:jvmTest` and `:homebase-core:jvmTest` also green.

*Caveat:* the `GuardedComposerSheet` test's lambda arity changed with the fix (3 params → 2). Its assertions and body are identical across both runs. The other two tests are byte-identical across both runs.

## Device verification — Redmi Note 5 Pro, `id.homebase.feed.debug`

`GuardedComposerSheet` fully verified (Poll composer, Note to Self, with a draft):

- drag-handle tap → sheet stays
- swipe down → sheet does not move
- scrim tap → nothing
- back press → discard prompt shown **with the sheet still rendered behind it** (broken code hid it first)
- sheet still interactive after all four — no soft-lock
- Keep editing → sheet + draft intact, no re-show animation; Discard → closes cleanly
- empty composer → swipe down closes normally

Tree-level corroboration: with a draft, the `View "Close sheet"` scrim node **disappears from the accessibility tree** and returns once the composer is empty — `dismissible` toggling visibly.

## Reviewer attention — three things

**1. A real behaviour change.** `GuardedComposerSheet`'s content lambda loses its `SheetState` param (3 composers touched). Its only use was a cosmetic `sheetState.hide()` before `onSent()`, so **the send path no longer animates the sheet down** — it unmounts. The `keepEditing` → `show()` restore hack also goes, since the sheet never hides. Say if you want the animation kept.

**2. `shouldDismissOnBackPress` is latched at sheet-creation on Android.** `ModalBottomSheet.android.kt:528` registers `PredictiveBackOnBackPressedCallback(isEnabled = properties.shouldDismissOnBackPress)` once at attach and never updates it. All three sites open dismissible and flip later, so back stays enabled throughout. `sheetGesturesEnabled`, the scrim, and `confirmValueChange` all track `dismissible` correctly — back press alone does not.

- Composer: benign, in fact desirable — back reaches `requestClose` → discard prompt, and `confirmValueChange` still refuses Hidden, so #891's contract holds. No `BackHandler(enabled = !dismissible)` was added for exactly this reason; it would swallow back and destroy the verified behaviour.
- ConnectRequest / HealProgress: a back press during the busy state still fires the close. Not the #1306 soft-lock — the sheet unmounts properly, the app stays responsive, and the work continues. A mild residual.

**This is inherited from #1262, not introduced here** — it applies equally to the already-shipped `EmergencyLocateSheet` from #1267. Worth its own issue if back should be fully pinned.

**3. `contentWindowInsets` is a new `AdaptiveSheet` param** (compact branch only, defaults to the material default). `GuardedComposerSheet` carried a zero-insets workaround for #997 — the composers size themselves with `fillMaxHeight(0.92f)`, so default insets make sheet height track sheet position and the fling anchors oscillate. Dropping it silently would have reinstated a known bug.

## Unverified

- **ConnectRequest and HealProgress guarded states, on device.** Both are only reachable by sending a real connection request / pushing group files to live peers from the account on the test device. That is outbound content, so it was not done. Both are covered by the JVM tests.
- **The wide/`Dialog` branch on desktop and tablet.** These three sheets now render as centred 520×680 dialogs at medium+ widths. That is `AdaptiveSheet`'s intent, but it is a visible change to three surfaces that was not checked.

`ConnectRequestBottomSheet` also gained a thin `internal ConnectRequestSheet(state, …)` seam so the sheet is testable without constructing a 5-service ViewModel. Behaviour-preserving.
