### PR TITLE
Keep the scroll-to-bottom FAB aiming at the newest row

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
@@ -221,9 +221,11 @@ import io.github.vinceglb.filekit.dialogs.compose.rememberFilePickerLauncher
 import kotlinx.collections.immutable.persistentMapOf
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.collections.immutable.toPersistentMap
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.datetime.DateTimeUnit
@@ -236,12 +238,15 @@ import kotlinx.datetime.minus
 import kotlinx.datetime.toLocalDateTime
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.koinInject
+import kotlin.coroutines.cancellation.CancellationException
 import kotlin.time.Clock
 import kotlin.uuid.Uuid
 
 /** Upper bound on waiting for an own send to appear in the list before the
  *  follow token is consumed unscrolled (the send failed or was gated out). */
 private const val OWN_SEND_FOLLOW_TIMEOUT_MS = 5_000L
+
+private const val SCROLL_TO_NEWEST_ATTEMPTS = 4
 
 // Mirrors the states in which the composer below is replaced by a banner — keep the two in sync,
 // or a dropped file lands in a conversation with nothing to send it from.
@@ -1404,9 +1409,7 @@ fun ConversationContent(
                                     // history.)
                                     onUiAction(ConversationListUiAction.ScrollToLatest(conversation.conversation.id))
                                 } else {
-                                    coroutineScope.launch {
-                                        listState.animateScrollToItem(listState.layoutInfo.totalItemsCount - 1)
-                                    }
+                                    coroutineScope.launch { listState.animateScrollToNewestItem() }
                                 }
                             },
                         )
@@ -2289,6 +2292,27 @@ private fun getDateSectionLabel(messageDate: LocalDate): String {
             }
             messageDate.format(format)
         }
+    }
+}
+
+/**
+ * A single `animateScrollToItem(totalItemsCount - 1)` goes stale mid-flight: a
+ * `nearTop` prepend lands while it animates, shifting every index by a page, and
+ * its scroll compensation cancels the animation — so it finishes on a mid-history
+ * row. Re-aim until the list really ends in view.
+ */
+private suspend fun LazyListState.animateScrollToNewestItem() {
+    repeat(SCROLL_TO_NEWEST_ATTEMPTS) {
+        val target = layoutInfo.totalItemsCount - 1
+        if (target < 0) return
+        try {
+            animateScrollToItem(target)
+        } catch (e: CancellationException) {
+            // Compose's MutationInterruptedException is internal; a still-active context
+            // means the prepend compensation took the scroll, not the caller going away.
+            if (!currentCoroutineContext().isActive) throw e
+        }
+        if (layoutInfo.visibleItemsInfo.lastOrNull()?.index == layoutInfo.totalItemsCount - 1) return
     }
 }
 


### PR DESCRIPTION
Fixes #1245

## Symptom

A conversation shows the scroll-to-bottom FAB with an unread badge; tapping the down arrow doesn't move the list. Tapping again doesn't help either.

**Not desktop-specific, and not Linux-specific.** The issue was filed against Linux desktop; I reproduced it on **macOS** desktop. The whole path — the FAB, the `nearTop` proximity trigger, and the prepend compensation — lives in `commonMain` with no `expect`/`actual` anywhere in it, and the trigger is a timing relationship between a ~200 ms DB page load and a ~500 ms scroll animation. **Android and iOS are affected too.** I determined that by reading the path and by reproducing on a second platform, not by running on a device.

## Root cause

The FAB's non-`hasNewerMessages` branch evaluated its target **once, at tap time**:

```kotlin
coroutineScope.launch {
    listState.animateScrollToItem(listState.layoutInfo.totalItemsCount - 1)
}
```

then animated for roughly half a second. But the tap only happens while the user is scrolled up in history — which is exactly when the pane's `nearTop` proximity trigger (`ConversationMessagesPane.kt:202-223`) fires `LoadOlderMessages`. That prepend lands **mid-animation** and does two things:

- it shifts every index by a whole page (+74/+75), so the captured target now points about a page short of the real last row;
- its prepend-compensation `SideEffect` (`ConversationContent.kt:1049-1071`) calls `listState.requestScrollToItem(...)`, which can cancel the animation outright.

Either way the scroll finishes on a mid-history row, `lastVisible` stays below `totalItemsCount - 1` so the FAB never hides, and the tap reads as a no-op. It is self-reinforcing: each tap starts from near the top, so each tap triggers another prepend.

### Evidence

Instrumented run on macOS desktop (temporary `FabDbg` logs, not part of this diff).

Stale-target form — target captured as 266, list is 350 rows by the time the animation lands:

```
(FabDbg) onClick hasNewer=false total=267 first=0 lastVisible=10 unread=0 messages=267 merged=267
(FabDbg) animateScrollToItem BEGIN target=266
(ChatPaging) loadOlder(44df02c6-…) +75 hasMore=true windowSize=224→299 hasNewer=false took=349.364625ms
(FabDbg) animateScrollToItem END first=266 lastVisible=276 total=350      <-- 73 rows short of 349
```

Cancellation form — the prepend compensation takes the scroll and the coroutine dies:

```
(FabDbg) onClick hasNewer=false total=351 first=0 lastVisible=10
(FabDbg) animateScrollToItem BEGIN target=350
Error: (FabDbg) animateScrollToItem FAILED target=350
androidx.compose.foundation.MutationInterruptedException: Mutation interrupted
Scroll changed: … (idx=86)                                                <-- stopped at 86 of 356
```

## Candidate 1 from the issue is refuted — please don't re-chase it

The issue's first candidate was that the `hasNewerMessages` → `ScrollToLatest` reload path fails to scroll on desktop. It doesn't. That branch worked **4 out of 4 times** across every state I could construct, including one where the window shrank from 356 rows to 85 underneath it:

```
(FabDbg) onClick hasNewer=true total=362 first=0 lastVisible=10
(FabDbg) dispatch ScrollToLatest
(FabDbg) VM scroll-to-latest resolved=ScrollPosition(firstVisibleItemIndex=84, …, triggerScroll=true) models=85 hasNewer=false
(FabDbg) pane scrollToItem END first=83 lastVisible=84 total=85           <-- landed at the bottom
```

It is robust because it re-resolves the index from the *fresh* model list at emission time and applies it with a plain `scrollToItem`. This PR leaves it untouched.

## The fix

Re-aim at the current last index until the list actually ends in view:

```kotlin
private suspend fun LazyListState.animateScrollToNewestItem() {
    repeat(SCROLL_TO_NEWEST_ATTEMPTS) {
        val target = layoutInfo.totalItemsCount - 1
        if (target < 0) return
        try {
            animateScrollToItem(target)
        } catch (e: CancellationException) {
            // Compose's MutationInterruptedException is internal; a still-active context
            // means the prepend compensation took the scroll, not the caller going away.
            if (!currentCoroutineContext().isActive) throw e
        }
        if (layoutInfo.visibleItemsInfo.lastOrNull()?.index == layoutInfo.totalItemsCount - 1) return
    }
}
```

The terminal condition is deliberately the same predicate as the FAB's own visibility test, so the loop stops exactly when the FAB would hide. `MutationInterruptedException` is `internal` in this Compose version, hence the narrower `CancellationException` catch with an `isActive` guard that rethrows genuine caller cancellation instead of swallowing it.

## Verification

Rebuilt and re-ran the same repro on macOS desktop. Both previously-failing forms now recover:

```
(FabDbg) onClick hasNewer=false total=47 first=0 lastVisible=5
(FabDbg) scrollToNewest attempt=0 target=46
(ChatPaging) loadOlder(…) +74 windowSize=39→113
(FabDbg) scrollToNewest attempt=0 done first=46 lastVisible=56 total=133   <-- old code stopped here
(FabDbg) scrollToNewest attempt=1 target=132
(FabDbg) scrollToNewest attempt=1 done first=131 lastVisible=132 total=133
```

```
(FabDbg) scrollToNewest attempt=0 target=132
(FabDbg) scrollToNewest attempt=0 INTERRUPTED
(FabDbg) scrollToNewest attempt=0 done first=93 lastVisible=103 total=225  <-- old code died here
(FabDbg) scrollToNewest attempt=1 target=224
(FabDbg) scrollToNewest attempt=1 done first=223 lastVisible=224 total=225
```

- **8 of 8 taps** terminated with `lastVisible == totalItemsCount - 1`. Worst case used 2 of the 4 attempts.
- Green: `:homebase-chat:compileKotlinJvm`, `:homebase-chat:compileAndroidMain`, `:homebase-chat:compileKotlinIosSimulatorArm64`, `:homebase-chat:compileKotlinWasmJs`, and `:homebase-chat:jvmTest`.
- All instrumentation was removed before committing; the diff is the fix only.

### How the evidence was captured

The app is a Compose Desktop window, so I drove the real app rather than a harness: Compose Desktop exposes a full macOS accessibility tree, which gives exact on-screen geometry for the FAB and the scrollbar, and input was injected with `java.awt.Robot`. Temporary Kermit logs at the FAB `onClick`, around the scroll, in the pane's `triggerScroll` effect and in the ViewModel's `ScrollToLatest` arm produced the numbers above.

## Reviewer note — alternative approach

This fix **re-aims after the collision** rather than preventing it. The alternative is to **suppress the `nearTop` prepend while an explicit scroll-to-bottom is in flight**: the user is heading away from the top, so that page load is work that is about to be discarded anyway. That approach would need no loop, no `SCROLL_TO_NEWEST_ATTEMPTS` bound and no `CancellationException` catch, and it would also save a pointless DB page per tap. It is a genuinely reasonable option and arguably attacks the cause more directly.

I chose the loop because it does not depend on knowing every source of a mid-flight scroll takeover — it also covers a cancellation arriving from somewhere other than the prepend compensation, and it needs no new cross-component state shared between `ConversationContent` and `ConversationMessagesPane`. But the trade is real, and if you'd rather suppress the prepend I'll rework it.

## Explicitly unverified

- **The `unread > 0` acceptance criterion was never exercised.** Every reproduction ran with `unread=0` — I had no second identity available to send incoming messages from, so nobody watched a badge go 4 → 0. The badge should clear once the list actually lands at the bottom (the pane marks visible messages read there), but that is reasoning, not an observation.
- **Candidate 3 from the issue is neither confirmed nor ruled out.** Every window I inspected contained its newest messages, so I never saw badge-without-messages. If unread messages *can* be missing from the loaded window while `hasNewerMessages` is false, that is a separate defect in the message-arrival path, not in the FAB.
- Not run on a physical Android or iOS device.

## Latent hazard found but deliberately not patched

`pendingScrollToLatest` (`ConversationListViewModel.kt:1407` arms it, `:2039` consumes it) is consumed by whichever `observeMessages` emission arrives first, not specifically by the reload's. `observeMessages` is a `StateFlow` over `paginatedState.windows`, which at least ten methods mutate — so a concurrent `setLoadingOlder`/`setLoadingNewer`/`upsert` landing between arming and the reload would resolve the bottom anchor against the stale history window, and the reload's own emission would then find the flag already consumed.

I never observed it firing, so I left it alone rather than patch on theory. It deserves its own issue.
