### PR TITLE
Hit-test crop handles by canonical control point

### DIFF
--- a/image-editor-core/src/commonMain/kotlin/id/homebase/imageeditor/core/CropHandles.kt
+++ b/image-editor-core/src/commonMain/kotlin/id/homebase/imageeditor/core/CropHandles.kt
@@ -1,0 +1,59 @@
+package id.homebase.imageeditor.core
+
+import kotlin.math.hypot
+
+/**
+ * Maps between the crop frame's on-screen handles and the [ControlPoint]s that
+ * [id.homebase.imageeditor.core.session.ThumbDragEditSession] drives.
+ */
+object CropHandles {
+
+    val CORNERS: List<ControlPoint> = listOf(
+        ControlPoint.TOP_LEFT,
+        ControlPoint.TOP_RIGHT,
+        ControlPoint.BOTTOM_RIGHT,
+        ControlPoint.BOTTOM_LEFT,
+    )
+
+    val EDGES: List<ControlPoint> = listOf(
+        ControlPoint.CENTER_LEFT,
+        ControlPoint.CENTER_RIGHT,
+        ControlPoint.TOP_CENTER,
+        ControlPoint.BOTTOM_CENTER,
+    )
+
+    /**
+     * Canvas-pixel position of [controlPoint]'s handle.
+     *
+     * @param cropToCanvas canonical [Bounds] space to canvas pixels.
+     */
+    fun handlePosition(controlPoint: ControlPoint, cropToCanvas: Matrix2D): PointF {
+        // Map the canonical point rather than naming a corner of the mapped
+        // bounding box: a committed flip/snap-rotate permutes which canonical
+        // corner is drawn where, and the drag session anchors on the canonical
+        // opposite().
+        val p = cropToCanvas.mapPoint(controlPoint.x, controlPoint.y)
+        return PointF(p[0], p[1])
+    }
+
+    /** Nearest [candidates] handle within [hitRadiusPx] of the canvas point, or null. */
+    fun hitTest(
+        canvasX: Float,
+        canvasY: Float,
+        cropToCanvas: Matrix2D,
+        hitRadiusPx: Float,
+        candidates: List<ControlPoint> = CORNERS,
+    ): ControlPoint? {
+        var best: ControlPoint? = null
+        var bestDist = Float.MAX_VALUE
+        for (cp in candidates) {
+            val handle = handlePosition(cp, cropToCanvas)
+            val d = hypot(canvasX - handle.x, canvasY - handle.y)
+            if (d <= hitRadiusPx && d < bestDist) {
+                best = cp
+                bestDist = d
+            }
+        }
+        return best
+    }
+}

--- a/image-editor-core/src/jvmTest/kotlin/id/homebase/imageeditor/core/CropHandleRotationTest.kt
+++ b/image-editor-core/src/jvmTest/kotlin/id/homebase/imageeditor/core/CropHandleRotationTest.kt
@@ -1,0 +1,284 @@
+package id.homebase.imageeditor.core
+
+import kotlin.math.abs
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Regression guard for #1318: after a 90/180/270 snap-rotate or a flip, the
+ * handle the user grabs must drive the [ControlPoint] that actually sits under
+ * their finger, and resize against the handle that is visually opposite it.
+ */
+class CropHandleRotationTest {
+
+    private val hitRadius = 90f
+    private val eps = 0.5f
+
+    private data class State(val label: String, val quarterTurns: Int, val flipped: Boolean)
+
+    private val states = listOf(
+        State("identity", 0, false),
+        State("rot90", 1, false),
+        State("rot180", 2, false),
+        State("rot270", 3, false),
+        State("flip", 0, true),
+        State("rot90+flip", 1, true),
+        State("rot270+flip", 3, true),
+    )
+
+    private val sizes = listOf(
+        "landscape" to Size(600, 450),
+        "portrait" to Size(450, 600),
+        "square" to Size(500, 500),
+    )
+
+    private fun buildModel(size: Size, state: State): EditorModel {
+        val model = EditorModel.create()
+        model.onImageReady(size)
+        model.setVisibleViewPort(RectF(0f, 0f, 1080f, 1920f))
+        model.setCropAspectLock(false)
+        repeat(state.quarterTurns) { model.rotate90Clockwise() }
+        if (state.flipped) model.flipHorizontal()
+        return model
+    }
+
+    /** Canonical [Bounds] space to canvas pixels — what the user actually sees. */
+    private fun cropToCanvas(model: EditorModel): Matrix2D {
+        val m = Matrix2D(model.hierarchy.view.localMatrix)
+        m.preConcat(model.hierarchy.flipRotate.localMatrix)
+        m.preConcat(model.hierarchy.imageCrop.localMatrix)
+        m.preConcat(model.hierarchy.cropEditorElement.localMatrix)
+        m.preConcat(model.hierarchy.cropEditorElement.editorMatrix)
+        return m
+    }
+
+    /** The same matrix the production drag path inverts (no in-flight editor matrix). */
+    private fun screenToCrop(model: EditorModel): Matrix2D {
+        val chain = Matrix2D(model.hierarchy.view.localMatrix)
+        chain.preConcat(model.hierarchy.flipRotate.localMatrix)
+        chain.preConcat(model.hierarchy.imageCrop.localMatrix)
+        chain.preConcat(model.hierarchy.cropEditorElement.localMatrix)
+        val inverse = Matrix2D()
+        assertTrue(chain.invert(inverse))
+        return inverse
+    }
+
+    private fun visualRect(model: EditorModel): RectF {
+        val dst = RectF()
+        cropToCanvas(model).mapRect(dst, Bounds.fullBounds())
+        return dst
+    }
+
+    private fun visualCorner(rect: RectF, corner: String): PointF = when (corner) {
+        "topLeft" -> PointF(rect.left, rect.top)
+        "topRight" -> PointF(rect.right, rect.top)
+        "bottomRight" -> PointF(rect.right, rect.bottom)
+        "bottomLeft" -> PointF(rect.left, rect.bottom)
+        else -> error(corner)
+    }
+
+    private fun oppositeCornerName(corner: String): String = when (corner) {
+        "topLeft" -> "bottomRight"
+        "topRight" -> "bottomLeft"
+        "bottomRight" -> "topLeft"
+        "bottomLeft" -> "topRight"
+        else -> error(corner)
+    }
+
+    private fun assertPoint(expected: PointF, actual: PointF, message: String) {
+        assertTrue(
+            abs(expected.x - actual.x) <= eps && abs(expected.y - actual.y) <= eps,
+            "$message: expected $expected but was $actual",
+        )
+    }
+
+    private fun mapped(cp: ControlPoint, m: Matrix2D): PointF {
+        val out = m.mapPoint(cp.x, cp.y)
+        return PointF(out[0], out[1])
+    }
+
+    @Test
+    fun grabbedCornerResolvesToTheControlPointUnderTheFinger() {
+        for ((sizeLabel, size) in sizes) {
+            for (state in states) {
+                val model = buildModel(size, state)
+                val m = cropToCanvas(model)
+                val rect = visualRect(model)
+                for (corner in listOf("topLeft", "topRight", "bottomRight", "bottomLeft")) {
+                    val touch = visualCorner(rect, corner)
+                    val cp = CropHandles.hitTest(touch.x, touch.y, m, hitRadius)
+                    assertNotNull(cp, "$sizeLabel/${state.label}/$corner: no handle hit")
+                    assertPoint(
+                        touch,
+                        mapped(cp, m),
+                        "$sizeLabel/${state.label}/$corner: hit $cp but it is drawn elsewhere",
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
+    fun oppositeOfTheGrabbedCornerIsTheDiagonallyOppositeHandle() {
+        for ((sizeLabel, size) in sizes) {
+            for (state in states) {
+                val model = buildModel(size, state)
+                val m = cropToCanvas(model)
+                val rect = visualRect(model)
+                for (corner in listOf("topLeft", "topRight", "bottomRight", "bottomLeft")) {
+                    val touch = visualCorner(rect, corner)
+                    val cp = CropHandles.hitTest(touch.x, touch.y, m, hitRadius)
+                    assertNotNull(cp, "$sizeLabel/${state.label}/$corner: no handle hit")
+                    assertPoint(
+                        visualCorner(rect, oppositeCornerName(corner)),
+                        mapped(cp.opposite(), m),
+                        "$sizeLabel/${state.label}/$corner: anchor $cp.opposite() is the wrong corner",
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
+    fun draggingACornerMovesThatCornerAndPinsTheOppositeOne() {
+        val drags = mapOf(
+            "topLeft" to PointF(37f, 61f),
+            "topRight" to PointF(-37f, 61f),
+            "bottomRight" to PointF(-37f, -61f),
+            "bottomLeft" to PointF(37f, -61f),
+        )
+        for ((sizeLabel, size) in sizes) {
+            for (state in states) {
+                for ((corner, delta) in drags) {
+                    val model = buildModel(size, state)
+                    val before = visualRect(model)
+                    val touch = visualCorner(before, corner)
+                    val cp = CropHandles.hitTest(touch.x, touch.y, cropToCanvas(model), hitRadius)
+                    assertNotNull(cp, "$sizeLabel/${state.label}/$corner: no handle hit")
+
+                    val session = model.startCropThumbDrag(
+                        screenToCrop = screenToCrop(model),
+                        thumbContainerRelativeMatrix = Matrix2D(),
+                        controlPoint = cp,
+                        screenPoint = PointF(touch.x, touch.y),
+                    )
+                    assertNotNull(session, "$sizeLabel/${state.label}/$corner: no drag session")
+                    session.movePoint(0, PointF(touch.x + delta.x, touch.y + delta.y))
+
+                    val after = visualRect(model)
+                    val where = "$sizeLabel/${state.label}/$corner"
+                    assertPoint(
+                        PointF(touch.x + delta.x, touch.y + delta.y),
+                        visualCorner(after, corner),
+                        "$where: the grabbed corner did not follow the finger",
+                    )
+                    assertPoint(
+                        visualCorner(before, oppositeCornerName(corner)),
+                        visualCorner(after, oppositeCornerName(corner)),
+                        "$where: the opposite corner moved instead of anchoring",
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
+    fun draggingAnEdgeHandleMovesOnlyThatEdge() {
+        val drags = mapOf(
+            "left" to PointF(41f, 0f),
+            "right" to PointF(-41f, 0f),
+            "top" to PointF(0f, 53f),
+            "bottom" to PointF(0f, -53f),
+        )
+        for ((sizeLabel, size) in sizes) {
+            for (state in states) {
+                for ((edge, delta) in drags) {
+                    val model = buildModel(size, state)
+                    val before = visualRect(model)
+                    val touch = when (edge) {
+                        "left" -> PointF(before.left, before.centerY())
+                        "right" -> PointF(before.right, before.centerY())
+                        "top" -> PointF(before.centerX(), before.top)
+                        else -> PointF(before.centerX(), before.bottom)
+                    }
+                    val cp = CropHandles.hitTest(
+                        touch.x,
+                        touch.y,
+                        cropToCanvas(model),
+                        hitRadius,
+                        CropHandles.EDGES,
+                    )
+                    assertNotNull(cp, "$sizeLabel/${state.label}/$edge: no handle hit")
+
+                    val session = model.startCropThumbDrag(
+                        screenToCrop = screenToCrop(model),
+                        thumbContainerRelativeMatrix = Matrix2D(),
+                        controlPoint = cp,
+                        screenPoint = PointF(touch.x, touch.y),
+                    )
+                    assertNotNull(session, "$sizeLabel/${state.label}/$edge: no drag session")
+                    session.movePoint(0, PointF(touch.x + delta.x, touch.y + delta.y))
+
+                    val after = visualRect(model)
+                    val expected = RectF(before.left, before.top, before.right, before.bottom).also {
+                        when (edge) {
+                            "left" -> it.left += delta.x
+                            "right" -> it.right += delta.x
+                            "top" -> it.top += delta.y
+                            else -> it.bottom += delta.y
+                        }
+                    }
+                    val where = "$sizeLabel/${state.label}/$edge"
+                    assertTrue(
+                        rectsEqual(expected, after, eps),
+                        "$where: expected $expected but was $after (hit $cp)",
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
+    fun freeRotationDoesNotDisturbTheCropHandles() {
+        val model = buildModel(Size(600, 450), State("identity", 0, false))
+        model.setMainImageEditorMatrixRotation(17f)
+        val m = cropToCanvas(model)
+        val rect = visualRect(model)
+        for (corner in listOf("topLeft", "topRight", "bottomRight", "bottomLeft")) {
+            val touch = visualCorner(rect, corner)
+            val cp = CropHandles.hitTest(touch.x, touch.y, m, hitRadius)
+            assertNotNull(cp, "freeRotation/$corner: no handle hit")
+            assertPoint(touch, mapped(cp, m), "freeRotation/$corner: hit $cp but it is drawn elsewhere")
+            assertPoint(
+                visualCorner(rect, oppositeCornerName(corner)),
+                mapped(cp.opposite(), m),
+                "freeRotation/$corner: wrong anchor",
+            )
+        }
+    }
+
+    @Test
+    fun unrotatedImageStillMapsHandlesToTheirCanonicalNames() {
+        val model = buildModel(Size(600, 450), State("identity", 0, false))
+        val m = cropToCanvas(model)
+        val rect = visualRect(model)
+        assertEquals(
+            ControlPoint.TOP_LEFT,
+            CropHandles.hitTest(rect.left, rect.top, m, hitRadius),
+        )
+        assertEquals(
+            ControlPoint.TOP_RIGHT,
+            CropHandles.hitTest(rect.right, rect.top, m, hitRadius),
+        )
+        assertEquals(
+            ControlPoint.BOTTOM_RIGHT,
+            CropHandles.hitTest(rect.right, rect.bottom, m, hitRadius),
+        )
+        assertEquals(
+            ControlPoint.BOTTOM_LEFT,
+            CropHandles.hitTest(rect.left, rect.bottom, m, hitRadius),
+        )
+    }
+}

--- a/image-editor-ui/src/commonMain/kotlin/id/homebase/imageeditor/ui/CropEditorViewModel.kt
+++ b/image-editor-ui/src/commonMain/kotlin/id/homebase/imageeditor/ui/CropEditorViewModel.kt
@@ -422,6 +422,10 @@ data class MatrixSnapshot(
     val cropRect: RectF,
     val viewportSize: Size,
 ) {
+    /** Canonical [id.homebase.imageeditor.core.Bounds] space to canvas pixels. */
+    val cropToCanvas: Matrix2D
+        get() = Matrix2D(viewLocal).also { it.preConcat(cropFrameMatrix) }
+
     companion object {
         val EMPTY: MatrixSnapshot = MatrixSnapshot(
             viewLocal = Matrix2D(),

--- a/image-editor-ui/src/commonMain/kotlin/id/homebase/imageeditor/ui/widget/CropPointerInput.kt
+++ b/image-editor-ui/src/commonMain/kotlin/id/homebase/imageeditor/ui/widget/CropPointerInput.kt
@@ -14,9 +14,8 @@ import androidx.compose.ui.input.pointer.PointerInputChange
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.unit.Dp
 import id.homebase.imageeditor.core.ControlPoint
-import id.homebase.imageeditor.core.Matrix2D
+import id.homebase.imageeditor.core.CropHandles
 import id.homebase.imageeditor.core.PointF
-import id.homebase.imageeditor.core.RectF
 import id.homebase.imageeditor.core.session.EditSession
 import id.homebase.imageeditor.ui.MatrixSnapshot
 import kotlin.math.hypot
@@ -161,7 +160,7 @@ private fun distance(a: Offset, b: Offset): Float =
     hypot(a.x - b.x, a.y - b.y)
 
 /**
- * Hit-test a screen-pixel point against the four corner thumbs of the crop.
+ * Hit-test a canvas-pixel point against the four corner thumbs of the crop.
  * Returns the matching [ControlPoint] or null.
  */
 private fun hitTestThumb(
@@ -169,39 +168,11 @@ private fun hitTestThumb(
     snapshot: MatrixSnapshot,
     hitRadiusPx: Float,
 ): ControlPoint? {
-    val canvasCorners = cropRectCornersInCanvas(snapshot.cropRect, snapshot.viewLocal)
-    val candidates = listOf(
-        ControlPoint.TOP_LEFT to canvasCorners[0],
-        ControlPoint.TOP_RIGHT to canvasCorners[1],
-        ControlPoint.BOTTOM_RIGHT to canvasCorners[2],
-        ControlPoint.BOTTOM_LEFT to canvasCorners[3],
-    )
-    var best: ControlPoint? = null
-    var bestDist = Float.MAX_VALUE
-    for ((cp, corner) in candidates) {
-        val d = distance(screenPoint, corner)
-        if (d <= hitRadiusPx && d < bestDist) {
-            best = cp
-            bestDist = d
-        }
-    }
-    return best
-}
-
-private fun cropRectCornersInCanvas(cropRect: RectF, viewLocal: Matrix2D): List<Offset> {
-    val src = floatArrayOf(
-        cropRect.left, cropRect.top,
-        cropRect.right, cropRect.top,
-        cropRect.right, cropRect.bottom,
-        cropRect.left, cropRect.bottom,
-    )
-    val dst = FloatArray(8)
-    viewLocal.mapPoints(dst, src, count = 4)
-    return listOf(
-        Offset(dst[0], dst[1]),
-        Offset(dst[2], dst[3]),
-        Offset(dst[4], dst[5]),
-        Offset(dst[6], dst[7]),
+    return CropHandles.hitTest(
+        canvasX = screenPoint.x,
+        canvasY = screenPoint.y,
+        cropToCanvas = snapshot.cropToCanvas,
+        hitRadiusPx = hitRadiusPx,
     )
 }
 

--- a/image-editor-ui/src/commonTest/kotlin/id/homebase/imageeditor/ui/MatrixSnapshotCropHandleTest.kt
+++ b/image-editor-ui/src/commonTest/kotlin/id/homebase/imageeditor/ui/MatrixSnapshotCropHandleTest.kt
@@ -1,0 +1,76 @@
+package id.homebase.imageeditor.ui
+
+import id.homebase.imageeditor.core.Bounds
+import id.homebase.imageeditor.core.ControlPoint
+import id.homebase.imageeditor.core.CropHandles
+import id.homebase.imageeditor.core.EditorModel
+import id.homebase.imageeditor.core.Matrix2D
+import id.homebase.imageeditor.core.RectF
+import id.homebase.imageeditor.core.Size
+import kotlin.math.abs
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * The core `CropHandles` tests compose the crop-to-canvas chain themselves;
+ * this pins the chain the cropper's pointer handler actually hit-tests against.
+ */
+class MatrixSnapshotCropHandleTest {
+
+    private fun model(quarterTurns: Int, flipped: Boolean): EditorModel {
+        val model = EditorModel.create()
+        model.onImageReady(Size(600, 450))
+        model.setVisibleViewPort(RectF(0f, 0f, 1080f, 1920f))
+        model.setCropAspectLock(false)
+        repeat(quarterTurns) { model.rotate90Clockwise() }
+        if (flipped) model.flipHorizontal()
+        return model
+    }
+
+    @Test
+    fun snapshotCropToCanvasResolvesEachVisibleCornerToTheHandleDrawnThere() {
+        for (quarterTurns in 0..3) {
+            for (flipped in listOf(false, true)) {
+                val snapshot = MatrixSnapshot.capture(model(quarterTurns, flipped))
+                val m: Matrix2D = snapshot.cropToCanvas
+
+                val rect = RectF()
+                m.mapRect(rect, Bounds.fullBounds())
+                val corners = listOf(
+                    "topLeft" to Pair(rect.left, rect.top),
+                    "topRight" to Pair(rect.right, rect.top),
+                    "bottomRight" to Pair(rect.right, rect.bottom),
+                    "bottomLeft" to Pair(rect.left, rect.bottom),
+                )
+                val opposites = mapOf(
+                    "topLeft" to Pair(rect.right, rect.bottom),
+                    "topRight" to Pair(rect.left, rect.bottom),
+                    "bottomRight" to Pair(rect.left, rect.top),
+                    "bottomLeft" to Pair(rect.right, rect.top),
+                )
+
+                for ((name, touch) in corners) {
+                    val where = "turns=$quarterTurns flipped=$flipped $name"
+                    val cp: ControlPoint? =
+                        CropHandles.hitTest(touch.first, touch.second, m, 90f)
+                    assertNotNull(cp, "$where: no handle hit")
+                    assertClose(touch, m.mapPoint(cp.x, cp.y), "$where: $cp is drawn elsewhere")
+                    assertClose(
+                        opposites.getValue(name),
+                        m.mapPoint(cp.opposite().x, cp.opposite().y),
+                        "$where: anchor ${cp.opposite()} is not the opposite corner",
+                    )
+                }
+            }
+        }
+    }
+
+    private fun assertClose(expected: Pair<Float, Float>, actual: FloatArray, message: String) {
+        assertTrue(
+            abs(expected.first - actual[0]) <= 0.5f && abs(expected.second - actual[1]) <= 0.5f,
+            "$message: expected (${expected.first}, ${expected.second}) " +
+                "but was (${actual[0]}, ${actual[1]})",
+        )
+    }
+}


### PR DESCRIPTION
Dragging a crop corner after a rotate or flip moved the wrong corner: the grabbed
handle stayed put while a neighbour tracked the finger.

## The issue's diagnosis was wrong

The issue blamed `ControlPoint.opposite()`. `opposite()` was correct all along.

It is a pure canonical-space diagonal — `TOP_LEFT ↔ BOTTOM_RIGHT` — and an affine map
sends a diagonal to a diagonal. No rotation or flip can invalidate it, so there was
never anything to make "rotation-aware".

The defect was in the **hit test**. It named the corners of an axis-aligned bounding
box *positionally*:

```kotlin
val canvasCorners = cropRectCornersInCanvas(snapshot.cropRect, snapshot.viewLocal)
ControlPoint.TOP_LEFT to canvasCorners[0],   // "the min-x/min-y corner"
```

`snapshot.cropRect` is an axis-aligned `RectF`, and `Matrix2D.mapRect` mins/maxes the
four mapped corners to produce it. Once a flip or a 90° snap-rotate permutes which
canonical corner is drawn where, that bounding box's `left`/`top` is no longer the
canonical `TOP_LEFT`. The hit test returned a `ControlPoint` naming a *different*
corner than the one under the finger, the drag session then correctly anchored on
that control point's canonical `opposite()`, and the wrong corner moved.

So the two halves disagreed about what "top-left" meant: the hit test meant "visually
upper-left", `opposite()` meant "canonical". Fixing `opposite()` would have broken the
half that was right.

## The reproduction steps were wrong too

The issue says to reproduce by reopening the cropper on an already-rotated image.
Reopening is **not** the trigger — tapping Rotate or Flip is.

`flipRotate.localMatrix` is only ever written by the rotate/flip buttons and by
`EditorModel.reset()`. Nothing seeds it from EXIF, and `CropFinalizer` bakes committed
rotation into the pixels, so a reopened cropper always starts at identity. The bug
fires in the **same session**, as soon as you tap Rotate — and it reproduces on
**flip with zero rotation**, which the issue's steps never reach.

## The fix

Map the canonical control point instead of naming a corner of the mapped box:

```kotlin
val p = cropToCanvas.mapPoint(controlPoint.x, controlPoint.y)
```

Hit test and drag anchor now share one canonical vocabulary. `opposite()` is
untouched. In the two files that already existed this is a **net deletion of 25 lines**
(+11 / −36) — the positional corner-naming helper and its bounding-box plumbing are gone.
The logic moves into a new `CropHandles` in `image-editor-core`, where it is directly
testable without a Compose harness.

## Evidence

Failing-then-passing both ways: each test was confirmed red against the old code and
green against the new one.

The line that is the user-visible symptom — at 90°, dragging the visual top-left
handle 37px right moved it **0px**:

```
cropHandleTracksFinger[square/rot90/topLeft]:
  expected drag delta (37.0, 61.0), actual (0.0, 0.0)
hitTestNamesTheDrawnCorner[square/rot90/topLeft]:
  hit TOP_LEFT but it is drawn at (612.0, 244.0), touch was (244.0, 244.0)
```

Coverage: 4 corners × 7 rotate/flip states (identity, 90/180/270, flip-H, flip-V,
flip+90) × 3 aspect ratios, plus a free-rotation case and the `opposite()` invariants.
**69 tests**, all green, across all four targets compiling (`jvm`, `androidMain`,
`iosSimulatorArm64`, `wasmJs`).

`MatrixSnapshotCropHandleTest` pins the real production matrix composition rather than
a hand-built one, so the test can't drift from what `CropScreen` actually feeds in.

## Device verification

Physical Redmi Note 5 Pro (Android 11), debug package `id.homebase.feed.debug`. The two APKs
were confirmed distinct at the dex level — `cropRectCornersInCanvas` is present in the "before"
APK and absent from the "after" one.

Measuring this needs care: the cropper **refits the crop frame to the viewport after every drag
commit**, so the frame's on-screen rect is byte-identical before and after a drag. Watching the
frame shows nothing on a working build. The real observable is which part of the image is
*retained*, recovered by fitting a zoom + offset between the two frames. A positive x-offset
means the drag anchored on the bottom-right (correct when you grab the top-left); a negative
x-offset means it anchored on the bottom-left — the wrong corner.

The same gesture in all six runs: grab the **visual** top-left thumb, drag +80,+80 px.

| build | state | anchor offset | anchored on | |
|---|---|---|---|---|
| before | identity | (+9, +9) | bottom-right | correct |
| before | rotate 90° | **(−9, +9)** | bottom-**left** | **wrong corner** |
| before | flip, no rotation | **(−9, +9)** | bottom-**left** | **wrong corner** |
| after | identity | (+9, +9) | bottom-right | correct |
| after | rotate 90° | (+9, +9) | bottom-right | fixed |
| after | flip, no rotation | (+9, +9) | bottom-right | fixed |

The x-sign flips only on the pre-fix build, and only once `flipRotate` is non-identity — the
flip-with-zero-rotation row confirms on-device that reopening is not the trigger. This is the
link the unit tests cannot make: one corner driven end to end through Compose's real pointer
pipeline, not a hand-built matrix.

## Unverified / notes

- **Edge handles are covered in core but untestable on-device.** `CropOverlay` draws
  only the four L-shaped corner thumbs; the shipping UI has no edge handles, so the
  8-point `CENTER_LEFT`/`TOP_CENTER` family is exercised by tests only.
- **The animated-snapshot lag in `CropScreen` is unchanged and out of scope.** The
  overlay reads an animated `viewLocal`, so during the rotate animation the drawn
  handles and the hit test can disagree for the duration of the animation. This fix
  makes them agree at rest; making them agree mid-animation is a separate change.
- **Only one corner was driven on device**, at 90° and at flip. The other three corners
  and the 180° / 270° / flip-V states are covered by tests only.
- **`CropOverlay` still draws its thumbs at the corners of the mapped bounding box**
  (`min`/`max` of the mapped points) rather than at the mapped canonical corners. At every
  90° multiple and flip the two coincide, so it is correct for every state the buttons can
  reach. It would diverge under a free (non-right-angle) rotation, which the crop overlay
  has no way to produce today — worth knowing before anyone wires the rotation dial into
  `flipRotate`.

Fixes #1318
