### PR TITLE
Identity scope: destroy per-identity state at logout (scaffolding + moments draft)

### DIFF
--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/auth/AuthConnectionCoordinator.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/auth/AuthConnectionCoordinator.kt
@@ -23,6 +23,7 @@ import id.homebase.core.config.LabeledDrive
 import id.homebase.core.config.mandatorySyncDrives
 import id.homebase.core.sync.DriveRegistry
 import id.homebase.core.avatars.AppConnectionStatus
+import id.homebase.core.session.IdentitySessionScope
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -52,6 +53,10 @@ class AuthConnectionCoordinator(
     private val driveRegistry: DriveRegistry,
     private val securityContextProvider: SecurityContextProvider,
     private val peerWebSocketManager: PeerWebSocketManager,
+    // Lifetime of every per-identity object in the graph. Opened on the authenticated
+    // transition below, closed on logout — so signing out destroys that state rather than
+    // resetting it, and a stale identity cannot survive into the next session.
+    private val identitySession: IdentitySessionScope,
     private val onPostAuthenticated: () -> Unit = {},
     /**
      * Active location-tracking profile label for the #1109 background-transition line, or null when
@@ -220,6 +225,16 @@ class AuthConnectionCoordinator(
         logLifecycleSnapshot("onAuthStateChanged:${state::class.simpleName}")
         when (state) {
             is YouAuthState.Authenticated -> {
+                // FIRST, before anything resolves a per-identity service: open this
+                // identity's scope. runPostAuthenticatedOnce() below resolves out of it,
+                // so opening later would build those objects in the wrong (or no) scope.
+                // Re-opening for the same identity is a no-op, which matters because this
+                // branch runs twice on a headless bootstrap that later promotes to
+                // foreground. A different identity closes the previous scope here — the
+                // backstop for a logout we never saw (token expiry, a swapped account).
+                credentialsManager.getActiveDomain()?.let { domain ->
+                    identitySession.open(domain.domainName)
+                }
                 // Foreground-only UI preload — see kdoc on [headless]. Runs FIRST in
                 // foreground mode (matches pre-headless-mode ordering: preload starts
                 // local-DB warmups while drive mount + WS handshake happen in
@@ -353,6 +368,17 @@ class AuthConnectionCoordinator(
                 // stopped — so nothing can re-populate after the services reset.
                 Logger.i(tag = "AuthLifecycle") { "AuthCC: emitting SessionEnded (logout)" }
                 eventBus.tryEmit(BackendEvent.SessionEnded)
+                // Then destroy the identity's scope: every scoped instance is dropped and
+                // its onClose callback fired (coroutine scopes cancelled, collectors torn
+                // down). After this, resolving identity-scoped state throws rather than
+                // handing back a previous identity's object.
+                //
+                // Ordering note for the migration: tryEmit is not synchronous, so a
+                // SessionEnded listener that resolves a scoped service could lose the race
+                // with this close and throw. That race disappears as those listeners are
+                // deleted — a scoped service has no reason to listen for the event that
+                // destroys it — but until then, do not add new ones.
+                identitySession.close()
             }
             else -> {
                 disconnect()

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/auth/AuthConnectionCoordinator.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/auth/AuthConnectionCoordinator.kt
@@ -232,9 +232,10 @@ class AuthConnectionCoordinator(
                 // branch runs twice on a headless bootstrap that later promotes to
                 // foreground. A different identity closes the previous scope here — the
                 // backstop for a logout we never saw (token expiry, a swapped account).
-                credentialsManager.getActiveDomain()?.let { domain ->
-                    identitySession.open(domain.domainName)
-                }
+                // From the state's own identity rather than a credentials lookup: it is the
+                // identity this transition is about, it cannot be null, and it cannot race a
+                // credential write. A null here would have left the UI gated below forever.
+                identitySession.open(state.identity.domainName)
                 // Foreground-only UI preload — see kdoc on [headless]. Runs FIRST in
                 // foreground mode (matches pre-headless-mode ordering: preload starts
                 // local-DB warmups while drive mount + WS handshake happen in

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/auth/AuthConnectionCoordinator.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/auth/AuthConnectionCoordinator.kt
@@ -799,6 +799,16 @@ class AuthConnectionCoordinator(
         // the debouncer — and unmount drives — against a session already being torn down (#1237).
         grantReconcileJob?.cancel()
         grantReconcileJob = null
+        // Forget which drives this identity could read. The field is a snapshot of ONE app
+        // token's grants, and it outlived the session it belonged to: on the next login
+        // retainGrantedDrives() applied the previous token's answer and silently dropped a drive
+        // that had been granted in between — the mount decision ran ~700ms before the fresh
+        // grants resolved, and nothing re-mounts afterwards.
+        //
+        // Null is the documented "grants unknown" state that makes retainGrantedDrives a no-op,
+        // which is exactly what a fresh connect wants: mount from the local registry and let
+        // scheduleGrantReconcile prune in the background.
+        grantedDriveIds = null
         refreshWsSubscription.cancel()
         driveRegistry.stop()
         // Close every per-owner peer websocket so a second login doesn't inherit the first user's

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/session/IdentitySession.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/session/IdentitySession.kt
@@ -1,0 +1,125 @@
+package id.homebase.core.session
+
+import co.touchlab.kermit.Logger
+import kotlin.concurrent.Volatile
+import kotlinx.atomicfu.locks.SynchronizedObject
+import kotlinx.atomicfu.locks.synchronized
+import org.koin.core.Koin
+import org.koin.core.qualifier.Qualifier
+import org.koin.core.qualifier.named
+import org.koin.core.scope.Scope
+
+/**
+ * Marker for state that belongs to ONE logged-in identity and must not outlive it.
+ *
+ * Implementing this is a claim about lifetime, not behaviour: it says "when the user logs
+ * out, I am garbage". The guard test asserts that nothing marked this way is registered as
+ * an app-lifetime `single`, which is what keeps the rule from decaying into a checklist
+ * somebody has to remember to update.
+ *
+ * Conversation, drive, contact, feed, moment, location, vault, sticker and email state is
+ * identity-scoped. Platform plumbing that legitimately outlives a session — the database
+ * manager, the HTTP client factory, [org.koin.core.Koin] itself, and CredentialsManager,
+ * which is the thing that *clears* credentials — is not.
+ */
+interface IdentityScoped
+
+/** Qualifier of the per-identity Koin scope. Scoped definitions declare `scope(IdentitySessionQualifier) { ... }`. */
+val IdentitySessionQualifier: Qualifier = named("IdentitySession")
+
+/**
+ * Owns the lifetime of the per-identity Koin scope.
+ *
+ * Opened when auth reaches Authenticated, closed on logout. Closing drops every `scoped`
+ * instance and fires its `onClose` callback, so the next login constructs fresh objects
+ * instead of reusing reset ones. That is the whole point: forgetting to clear something
+ * becomes impossible, because nothing survives to be stale.
+ *
+ * Replaces three overlapping mechanisms that each covered part of the surface — a
+ * hand-maintained `reset()` list in AppModule (which ran at the *next* login, not at
+ * logout, and skipped entirely on a warm relaunch), ad-hoc self-clearing on
+ * `BackendEvent.SessionEnded`, and, for anything nobody remembered, nothing at all.
+ */
+class IdentitySessionScope(private val koin: Koin) {
+
+    private val lock = SynchronizedObject()
+
+    @Volatile
+    private var current: Scope? = null
+
+    @Volatile
+    private var currentIdentity: String? = null
+
+    /** The open scope, or null while logged out. */
+    val scopeOrNull: Scope? get() = current?.takeIf { !it.closed }
+
+    val isOpen: Boolean get() = scopeOrNull != null
+
+    /** Domain of the identity the open scope belongs to, or null while logged out. */
+    val identity: String? get() = if (isOpen) currentIdentity else null
+
+    /**
+     * Open the scope for [identity], closing any scope still open for a different one.
+     *
+     * Re-opening for the same identity is a no-op that returns the live scope: the
+     * authenticated transition can run more than once per session (headless bootstrap
+     * followed by [foreground promotion][id.homebase.core.auth.AuthConnectionCoordinator.promoteToForeground]),
+     * and tearing down live services on the second pass would be a regression, not a reset.
+     */
+    fun open(identity: String): Scope = synchronized(lock) {
+        val live = current?.takeIf { !it.closed }
+        if (live != null && currentIdentity == identity) return@synchronized live
+
+        if (live != null) {
+            Logger.i(tag = TAG) { "identity changed ($currentIdentity -> $identity) — closing previous session scope" }
+            closeLocked()
+        }
+
+        Logger.i(tag = TAG) { "opening session scope for $identity" }
+        // Defensive: createScope throws ScopeAlreadyCreatedException on a duplicate id. That
+        // needs an earlier open() to have half-failed, leaving a scope in the registry we no
+        // longer hold — rare, but the consequence would be an unrecoverable login.
+        koin.deleteScope(scopeId(identity))
+        return@synchronized koin.createScope(scopeId(identity), IdentitySessionQualifier).also {
+            current = it
+            currentIdentity = identity
+        }
+    }
+
+    /**
+     * Destroy the scope and everything in it. Idempotent — logout can arrive by more than
+     * one path (explicit sign-out, token expiry, an identity switch) and must not throw on
+     * the second.
+     */
+    fun close() = synchronized(lock) { closeLocked() }
+
+    private fun closeLocked() {
+        val live = current
+        current = null
+        currentIdentity = null
+        if (live == null || live.closed) return
+        Logger.i(tag = TAG) { "closing session scope ${live.id}" }
+        live.close()
+    }
+
+    /**
+     * The open scope, or a throw naming the caller. Resolving identity-scoped state while
+     * logged out is a bug in the caller's lifecycle, not a condition to paper over with a
+     * fallback instance that would immediately go stale.
+     */
+    fun requireScope(): Scope = scopeOrNull
+        ?: error("No identity session is open — cannot resolve identity-scoped dependencies while logged out")
+
+    private fun scopeId(identity: String) = "$SCOPE_ID_PREFIX$identity"
+
+    private companion object {
+        const val TAG = "IdentitySession"
+        const val SCOPE_ID_PREFIX = "identity:"
+    }
+}
+
+/** Resolve an identity-scoped dependency. Throws if no session is open — see [IdentitySessionScope.requireScope]. */
+inline fun <reified T : Any> IdentitySessionScope.get(): T = requireScope().get()
+
+/** Resolve an identity-scoped dependency, or null while logged out. */
+inline fun <reified T : Any> IdentitySessionScope.getOrNull(): T? = scopeOrNull?.get()

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/session/IdentitySession.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/session/IdentitySession.kt
@@ -4,6 +4,9 @@ import co.touchlab.kermit.Logger
 import kotlin.concurrent.Volatile
 import kotlinx.atomicfu.locks.SynchronizedObject
 import kotlinx.atomicfu.locks.synchronized
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import org.koin.core.Koin
 import org.koin.core.qualifier.Qualifier
 import org.koin.core.qualifier.named
@@ -44,8 +47,17 @@ class IdentitySessionScope(private val koin: Koin) {
 
     private val lock = SynchronizedObject()
 
-    @Volatile
-    private var current: Scope? = null
+    private val _currentScope = MutableStateFlow<Scope?>(null)
+
+    /**
+     * The live scope, or null while logged out — observable so Compose can re-provide it to
+     * the composition when a session starts or ends. [IdentityScopeProvider] is the consumer.
+     */
+    val currentScope: StateFlow<Scope?> = _currentScope.asStateFlow()
+
+    private var current: Scope?
+        get() = _currentScope.value
+        set(value) { _currentScope.value = value }
 
     @Volatile
     private var currentIdentity: String? = null

--- a/homebase-common/src/jvmTest/kotlin/id/homebase/core/session/IdentitySessionScopeTest.kt
+++ b/homebase-common/src/jvmTest/kotlin/id/homebase/core/session/IdentitySessionScopeTest.kt
@@ -1,0 +1,112 @@
+package id.homebase.core.session
+
+import org.koin.core.Koin
+import org.koin.dsl.koinApplication
+import org.koin.dsl.onClose
+import org.koin.dsl.module
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNotSame
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+class IdentitySessionScopeTest {
+
+    /** Stands in for any per-identity service; [closed] records that teardown actually ran. */
+    private class Session : IdentityScoped {
+        var closed = false
+    }
+
+    private lateinit var koin: Koin
+    private lateinit var session: IdentitySessionScope
+
+    @BeforeTest
+    fun setUp() {
+        koin = koinApplication {
+            modules(
+                module {
+                    scope(IdentitySessionQualifier) {
+                        scoped { Session() } onClose { it?.closed = true }
+                    }
+                },
+            )
+        }.koin
+        session = IdentitySessionScope(koin)
+    }
+
+    @AfterTest
+    fun tearDown() = koin.close()
+
+    @Test
+    fun `starts closed`() {
+        assertFalse(session.isOpen)
+        assertNull(session.identity)
+        assertNull(session.scopeOrNull)
+    }
+
+    @Test
+    fun `resolving while logged out throws rather than handing back a stale object`() {
+        assertFailsWith<IllegalStateException> { session.requireScope() }
+        assertNull(session.getOrNull<Session>())
+    }
+
+    @Test
+    fun `opening twice for the same identity keeps the live scope`() {
+        // The authenticated transition runs more than once per session — a headless bootstrap
+        // that later promotes to foreground. The second pass must not tear down live services.
+        val first = session.open("frodo.dotyou.cloud")
+        val service = session.get<Session>()
+
+        val second = session.open("frodo.dotyou.cloud")
+
+        assertSame(first, second)
+        assertSame(service, session.get<Session>())
+        assertFalse(service.closed)
+    }
+
+    @Test
+    fun `switching identity destroys the previous identity's state`() {
+        session.open("frodo.dotyou.cloud")
+        val frodosService = session.get<Session>()
+
+        session.open("sam.dotyou.cloud")
+        val samsService = session.get<Session>()
+
+        assertTrue(frodosService.closed, "Frodo's service should have been torn down")
+        assertNotSame(frodosService, samsService)
+        assertFalse(samsService.closed)
+        assertEquals("sam.dotyou.cloud", session.identity)
+    }
+
+    @Test
+    fun `close destroys scoped state and logging back in builds it fresh`() {
+        session.open("frodo.dotyou.cloud")
+        val before = session.get<Session>()
+
+        session.close()
+
+        assertTrue(before.closed)
+        assertFalse(session.isOpen)
+        assertNull(session.identity)
+
+        // Same identity again: a fresh instance, not the one we just tore down. This is the
+        // whole point of the mechanism — logout is a destruction, not a reset.
+        session.open("frodo.dotyou.cloud")
+        assertNotSame(before, session.get<Session>())
+    }
+
+    @Test
+    fun `close is idempotent`() {
+        // Logout can arrive by more than one path (sign-out, token expiry, an identity switch)
+        // and the second must not throw.
+        session.open("frodo.dotyou.cloud")
+        session.close()
+        session.close()
+        assertFalse(session.isOpen)
+    }
+}

--- a/homebase-common/src/jvmTest/kotlin/id/homebase/core/session/ScopeResolutionMechanicsTest.kt
+++ b/homebase-common/src/jvmTest/kotlin/id/homebase/core/session/ScopeResolutionMechanicsTest.kt
@@ -1,0 +1,97 @@
+package id.homebase.core.session
+
+import org.koin.core.error.NoDefinitionFoundException
+import org.koin.dsl.koinApplication
+import org.koin.dsl.module
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotSame
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+/**
+ * Pins the Koin behaviour the migration depends on, so an upgrade that changes it fails here
+ * rather than in the app.
+ *
+ * The rule, verified below and NOT what it looks like from the outside: **a definition can
+ * only reach identity-scoped dependencies if the definition itself lives in the scope.**
+ * Resolving a root-registered definition *through* the scope is not enough — Koin's
+ * `resolveFromLinkedScopes` rebinds the resolution context to the linked (root) scope via
+ * `newContextForScope`, so the definition's own `get()` calls run against root and cannot see
+ * anything scoped.
+ *
+ * That is why the migration moves ViewModel definitions into the scope alongside the services
+ * they consume, rather than leaving them at root and resolving them through it.
+ */
+class ScopeResolutionMechanicsTest {
+
+    private class Service : IdentityScoped
+    private class ScopedConsumer(val service: Service)
+    private class RootConsumer(val service: Service)
+
+    private val modules = module {
+        // The same Consumer registered both ways, so the two can be compared directly.
+        factory { RootConsumer(get()) }
+        scope(IdentitySessionQualifier) {
+            scoped { Service() }
+            scoped { ScopedConsumer(get()) }
+        }
+    }
+
+    @Test
+    fun `a definition inside the scope reaches scoped dependencies`() {
+        val koin = koinApplication(createEagerInstances = false) { modules(modules) }.koin
+        val session = IdentitySessionScope(koin)
+        session.open("frodo.dotyou.cloud")
+
+        val consumer: ScopedConsumer = session.requireScope().get()
+
+        assertSame(session.get<Service>(), consumer.service)
+        koin.close()
+    }
+
+    @Test
+    fun `a ROOT definition cannot reach scoped dependencies even when resolved through the scope`() {
+        // The trap this test exists to document. It looks like it should work — you are asking
+        // the identity scope for the object — but Koin rebinds the context to root on fallback,
+        // so construction happens as if the scope were not there at all. Leaving a ViewModel at
+        // root while moving its services into the scope fails exactly here, at runtime.
+        val koin = koinApplication(createEagerInstances = false) { modules(modules) }.koin
+        val session = IdentitySessionScope(koin)
+        session.open("frodo.dotyou.cloud")
+
+        assertFailsWith<Exception> { session.requireScope().get<RootConsumer>() }
+        koin.close()
+    }
+
+    @Test
+    fun `the same definition resolved from root cannot see the scoped dependency`() {
+        // This is the failure mode the guard test exists to prevent: anything resolved outside
+        // the identity scope simply cannot reach identity-scoped state.
+        val koin = koinApplication(createEagerInstances = false) { modules(modules) }.koin
+        IdentitySessionScope(koin).open("frodo.dotyou.cloud")
+
+        val error = assertFailsWith<Exception> { koin.get<RootConsumer>() }
+        assertTrue(
+            error is NoDefinitionFoundException || error.cause is NoDefinitionFoundException,
+            "expected a missing-definition failure, got $error",
+        )
+        koin.close()
+    }
+
+    @Test
+    fun `each session gets its own instance`() {
+        val koin = koinApplication(createEagerInstances = false) { modules(modules) }.koin
+        val session = IdentitySessionScope(koin)
+
+        session.open("frodo.dotyou.cloud")
+        val frodos: ScopedConsumer = session.requireScope().get()
+        session.close()
+
+        session.open("sam.dotyou.cloud")
+        val sams: ScopedConsumer = session.requireScope().get()
+
+        assertNotSame(frodos.service, sams.service)
+        koin.close()
+    }
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/App.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/App.kt
@@ -17,6 +17,7 @@ import id.homebase.core.ui.navigation.AppNavHost
 import id.homebase.core.ui.navigation.AppViewModel
 import id.homebase.core.ui.navigation.Route
 import id.homebase.core.ui.theme.HomebaseTheme
+import id.homebase.core.session.IdentityScopeProvider
 import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
 
@@ -40,23 +41,33 @@ fun App(
         darkTheme = isDarkTheme,
         followsSystemTheme = prefState.theme == ThemeState.System,
     ) {
-        AppNavHost(
-            // koinViewModel(), NOT koinInject(). AppViewModel is registered with
-            // viewModelOf(), which is a *factory* definition — koinInject() resolves
-            // it outside any ViewModelStore, so every Activity recreation minted a
-            // fresh AppViewModel whose onCleared() was never called. Each orphan kept
-            // its collectNotificationEvents() coroutine alive on
-            // NotificationService.navigationEvents, which is a single-consumer
-            // Channel.receiveAsFlow(): N live collectors round-robin the events, and
-            // an orphan that wins a turn forwards into its own channel that nothing
-            // reads. Result — notification taps and share deep links silently went
-            // nowhere (build 1788 log: three consecutive events "forwarded" by
-            // AppViewModel with no matching AppNavHost receipt, after four Activity
-            // onCreates in one process).
-            viewModel = koinViewModel<AppViewModel>(),
-            navController = navController,
-            youAuthFlowManager = youAuthFlowManager
-        )
+        // Resolved OUTSIDE IdentityScopeProvider deliberately. AppViewModel is app-lifetime
+        // (it owns credential watching and the auth coordinator, and exists before login), and
+        // Koin does not include the scope in a ViewModel's store key — so resolving it inside a
+        // scope that comes and goes buys nothing and risks the duplicate-instance problem the
+        // comment below describes.
+        val appViewModel = koinViewModel<AppViewModel>()
+        // Everything below resolves from the open identity session, so per-identity services and
+        // the ViewModels that consume them are destroyed at logout rather than reset.
+        IdentityScopeProvider {
+            AppNavHost(
+                // koinViewModel(), NOT koinInject(). AppViewModel is registered with
+                // viewModelOf(), which is a *factory* definition — koinInject() resolves
+                // it outside any ViewModelStore, so every Activity recreation minted a
+                // fresh AppViewModel whose onCleared() was never called. Each orphan kept
+                // its collectNotificationEvents() coroutine alive on
+                // NotificationService.navigationEvents, which is a single-consumer
+                // Channel.receiveAsFlow(): N live collectors round-robin the events, and
+                // an orphan that wins a turn forwards into its own channel that nothing
+                // reads. Result — notification taps and share deep links silently went
+                // nowhere (build 1788 log: three consecutive events "forwarded" by
+                // AppViewModel with no matching AppNavHost receipt, after four Activity
+                // onCreates in one process).
+                viewModel = appViewModel,
+                navController = navController,
+                youAuthFlowManager = youAuthFlowManager
+            )
+        }
         LaunchedEffect(navController) {
             onNavigatorReady { route -> navController.navigate(route) { launchSingleTop = true } }
             onNavHostReady(navController)

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
@@ -220,6 +220,7 @@ import id.homebase.core.ui.screens.location.history.LocationHistoryViewModel
 import id.homebase.core.ui.screens.location.livelocation.LiveLocationViewModel
 import id.homebase.core.ui.screens.location.share.ShareLocationViewModel
 import id.homebase.core.session.IdentitySessionScope
+import id.homebase.core.session.IdentitySessionQualifier
 
 val VaultPermissionQualifier = named("vaultPermission")
 val EmailPermissionQualifier = named("emailPermission")
@@ -279,7 +280,6 @@ val appModule = module {
     singleOf(::FeedPermissionService)
     singleOf(::ReportingUrlProvider)
 
-    single { MomentCreateFlowState() }
     single { VaultPreferences(get()) }
     single { EmailPreferences(get()) }
 
@@ -537,6 +537,24 @@ val appModule = module {
     // Lifetime of the per-identity object graph. App-lifetime itself (it outlives any one
     // session — it is what opens and closes them), but everything it hands out is not.
     single { IdentitySessionScope(getKoin()) }
+
+    // Per-identity object graph. Destroyed on logout (IdentitySessionScope.close), so nothing
+    // here can serve one identity's state to the next.
+    //
+    // ViewModels live here alongside the services they consume, not at root. A definition can
+    // only reach identity-scoped dependencies if the definition itself is in the scope — Koin
+    // rebinds the resolution context to root on linked-scope fallback, so a root-registered
+    // ViewModel injecting a scoped service fails at runtime. ScopeResolutionMechanicsTest pins
+    // that behaviour; IdentityScopeProvider is what makes koinViewModel() resolve from here.
+    scope(IdentitySessionQualifier) {
+        // The moment draft: the user's photos and description, held while they hop from the
+        // composer to the audience picker. Cleared on a successful post — but abandoning the
+        // flow and logging out used to leave it in memory for the next identity, whose composer
+        // reads it on construction. See MomentDraftSurvivesLogoutTest.
+        scoped { MomentCreateFlowState() }
+        viewModelOf(::MomentComposeViewModel)
+        viewModelOf(::MomentAudienceViewModel)
+    }
 
     single {
         AuthConnectionCoordinator(
@@ -1056,8 +1074,6 @@ val appModule = module {
             locationPreferences = get(),
         )
     }
-    viewModelOf(::MomentComposeViewModel)
-    viewModelOf(::MomentAudienceViewModel)
     viewModelOf(::CreateMomentGroupViewModel)
     viewModelOf(::MomentsFeedViewModel)
 

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
@@ -219,6 +219,7 @@ import id.homebase.core.ui.screens.location.devices.LocationDeviceDirectory
 import id.homebase.core.ui.screens.location.history.LocationHistoryViewModel
 import id.homebase.core.ui.screens.location.livelocation.LiveLocationViewModel
 import id.homebase.core.ui.screens.location.share.ShareLocationViewModel
+import id.homebase.core.session.IdentitySessionScope
 
 val VaultPermissionQualifier = named("vaultPermission")
 val EmailPermissionQualifier = named("emailPermission")
@@ -533,6 +534,10 @@ val appModule = module {
         )
     }
 
+    // Lifetime of the per-identity object graph. App-lifetime itself (it outlives any one
+    // session — it is what opens and closes them), but everything it hands out is not.
+    single { IdentitySessionScope(getKoin()) }
+
     single {
         AuthConnectionCoordinator(
             credentialsManager = get(),
@@ -545,6 +550,7 @@ val appModule = module {
             driveRegistry = get(),
             securityContextProvider = get(),
             peerWebSocketManager = get(),
+            identitySession = get(),
             // Start headless only where the OS can cold-wake us in the background
             // (Android/iOS). Desktop/Web report false → start in foreground mode so
             // a missing promoteToForeground() can't hang the app on "syncing".

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/moments/services/MomentCreateFlowState.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/moments/services/MomentCreateFlowState.kt
@@ -5,6 +5,7 @@ import kotlin.time.Instant
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import id.homebase.core.session.IdentityScoped
 
 /**
  * In-memory hand-off between the moments compose screen and the audience
@@ -24,7 +25,7 @@ import kotlinx.coroutines.flow.asStateFlow
  * Singleton-scoped so navigating back from audience → compose preserves the
  * draft. Cleared on successful post and on explicit cancel.
  */
-class MomentCreateFlowState {
+class MomentCreateFlowState : IdentityScoped {
 
     data class Draft(
         val attachments: List<AttachmentPendingFile>,

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/session/IdentityScopeProvider.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/session/IdentityScopeProvider.kt
@@ -1,0 +1,41 @@
+package id.homebase.core.session
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import org.koin.compose.koinInject
+import org.koin.compose.scope.UnboundKoinScope
+import org.koin.core.annotation.KoinDelicateAPI
+import org.koin.core.annotation.KoinExperimentalAPI
+
+/**
+ * Makes the open identity session the scope that `koinViewModel()` and `koinInject()` resolve
+ * from inside [content].
+ *
+ * Everything identity-scoped — the services and the ViewModels that consume them — is
+ * registered in that scope, and a definition can only reach scoped dependencies if it is
+ * resolved from the scope itself (see `ScopeResolutionMechanicsTest`). This provider is what
+ * makes that true for the whole UI without touching individual call sites.
+ *
+ * While logged out there is no scope, and [content] resolves from the root as before — which
+ * is what the login screens need. Definitions registered at root keep resolving normally
+ * either way; scope membership only affects what a definition can *see*.
+ *
+ * Deliberately "unbound": the scope's lifetime belongs to
+ * [id.homebase.core.auth.AuthConnectionCoordinator], which opens it on the authenticated
+ * transition and closes it on logout. Binding it to composition instead would destroy every
+ * per-identity service whenever this subtree left the tree.
+ */
+@OptIn(KoinExperimentalAPI::class, KoinDelicateAPI::class)
+@Composable
+fun IdentityScopeProvider(content: @Composable () -> Unit) {
+    val session = koinInject<IdentitySessionScope>()
+    val scope by session.currentScope.collectAsState()
+
+    val live = scope
+    if (live != null && !live.closed) {
+        UnboundKoinScope(live) { content() }
+    } else {
+        content()
+    }
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
@@ -207,6 +207,7 @@ import id.homebase.resources.database_upgrade_snackbar
 import id.homebase.resources.pending_upgrade_message
 import id.homebase.resources.pending_upgrade_confirm
 import id.homebase.resources.upgrade_running_message
+import id.homebase.core.session.IdentitySessionScope
 
 // Set on the current destination when its already-selected bottom-nav / rail item is re-tapped.
 private const val SCROLL_TO_TOP_KEY = "scrollToTop"
@@ -219,7 +220,13 @@ fun AppNavHost(
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val authState by youAuthFlowManager.authState.collectAsStateWithLifecycle()
-    val isAuthenticated = authState is YouAuthState.Authenticated
+    // Gated on the identity scope being open as well as the auth state, because the two are
+    // observed independently: AuthConnectionCoordinator collects the same authState flow, so
+    // this composition can see Authenticated a frame before the scope exists. Identity-scoped
+    // ViewModels (koinViewModel() below) cannot resolve until it does, and every authenticated
+    // route in this graph is gated on this one flag.
+    val identityScope by koinInject<IdentitySessionScope>().currentScope.collectAsStateWithLifecycle()
+    val isAuthenticated = authState is YouAuthState.Authenticated && identityScope != null
     val navBackStackEntry by navController.currentBackStackEntryAsState()
     val currentDestination = navBackStackEntry?.destination
     val momentsPreferences = koinInject<MomentsPreferences>()

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppViewModel.kt
@@ -27,6 +27,8 @@ import id.homebase.core.upgrade.PendingUpgradeManager
 import id.homebase.core.upgrade.PendingUpgradeState
 import id.homebase.core.upgrade.registerDataUpgradeCallbackHandler
 import id.homebase.core.upgrade.unregisterDataUpgradeCallbackHandler
+import id.homebase.core.session.IdentitySessionScope
+import id.homebase.core.session.get
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
@@ -46,7 +48,11 @@ class AppViewModel(
     private val updateAppManager: UpdateAppManager,
     private val eventBus: EventBus,
     private val pendingUpgradeManager: PendingUpgradeManager,
-    private val momentCreateFlowState: MomentCreateFlowState,
+    // Not the MomentCreateFlowState itself: that is identity-scoped and this ViewModel is
+    // app-lifetime (it exists before login), so holding a direct reference would pin one
+    // identity's draft for the life of the process. Resolved on demand instead — the share
+    // hand-off below only happens while logged in.
+    private val identitySession: IdentitySessionScope,
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(AppUiState())
     val uiState: StateFlow<AppUiState> = _uiState.asStateFlow()
@@ -238,7 +244,7 @@ class AppViewModel(
             sharedMediaAttachment(shareContentProcessor.resolveFilePath(name), mime)
         }
         Logger.i(tag = "AppViewModel") { "Moment share: seeding draft with ${attachments.size} attachments" }
-        momentCreateFlowState.setDraft(
+        identitySession.get<MomentCreateFlowState>().setDraft(
             MomentCreateFlowState.Draft(
                 attachments = attachments,
                 description = descriptor.text ?: "",

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/email/EmailViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/email/EmailViewModel.kt
@@ -78,6 +78,13 @@ class EmailViewModel(
         // mount. Seen on a fresh identity that had never been through the approval flow.
         viewModelScope.launch {
             emailPermissionViewModel.permissionsGranted.filter { it }.collect {
+                // Re-read the status FIRST. The grant is what provisions the drive, so the
+                // cached status here is by definition from before it existed: deciding on it
+                // meant reading driveProvisioned=false, skipping activation, and leaving the
+                // screen stuck with no way to refresh. Observed on a real setup — the status
+                // fetched at login said drive=false, the grant landed 16s later, and nothing
+                // ever asked again.
+                runCatching { refreshStatusNow() }
                 if (_uiState.value.driveActivated != true && _uiState.value.serverStatus?.driveProvisioned == true) {
                     activateDrive()
                 }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentAudienceViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentAudienceViewModel.kt
@@ -24,6 +24,7 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import id.homebase.core.session.IdentityScoped
 
 private const val TAG = "MomentAudienceViewModel"
 
@@ -32,7 +33,7 @@ class MomentAudienceViewModel(
     private val postSender: MomentsPostSenderService,
     private val flowState: MomentCreateFlowState,
     private val contactRepository: ContactRepository,
-) : ViewModel() {
+) : ViewModel(), IdentityScoped {
 
     private val _uiState = MutableStateFlow(
         MomentAudienceUiState(draftReady = flowState.draft.value != null)

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentComposeViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentComposeViewModel.kt
@@ -31,6 +31,7 @@ import kotlinx.datetime.toInstant
 import kotlin.time.Clock
 import kotlin.time.Instant
 import kotlin.uuid.Uuid
+import id.homebase.core.session.IdentityScoped
 
 private const val TAG = "MomentComposeViewModel"
 
@@ -39,7 +40,7 @@ class MomentComposeViewModel(
     private val fileOperationsProvider: FileOperationsProvider,
     private val cropResultBus: CropResultBus,
     private val drawResultBus: DrawResultBus,
-) : ViewModel() {
+) : ViewModel(), IdentityScoped {
 
     private val _uiState = MutableStateFlow(restoreFromDraft())
     val uiState: StateFlow<MomentComposeUiState> = _uiState.asStateFlow()

--- a/homebase-core/src/jvmTest/kotlin/id/homebase/core/di/IdentityScopeGuardTest.kt
+++ b/homebase-core/src/jvmTest/kotlin/id/homebase/core/di/IdentityScopeGuardTest.kt
@@ -2,9 +2,12 @@ package id.homebase.core.di
 
 import id.homebase.core.session.IdentityScoped
 import id.homebase.core.session.IdentitySessionQualifier
+import id.homebase.core.session.IdentitySessionScope
 import org.koin.core.annotation.KoinInternalApi
 import org.koin.core.definition.BeanDefinition
+import org.koin.core.error.NoDefinitionFoundException
 import org.koin.core.module.Module
+import org.koin.dsl.koinApplication
 import kotlin.test.Test
 import kotlin.test.assertTrue
 
@@ -57,6 +60,104 @@ class IdentityScopeGuardTest {
             "These types are registered in the identity scope but do not implement " +
                 "IdentityScoped, so the guard above cannot protect them:\n  " +
                 unmarked.joinToString("\n  "),
+        )
+    }
+
+
+    @Test
+    fun `every scoped definition can actually reach its dependencies from the scope`() {
+        // The guards above check WHERE things are registered. They cannot catch the trap that
+        // makes placement matter: a definition that lives in the scope but depends on something
+        // only reachable from root — or, the way it usually happens, a definition left at root
+        // whose dependency moved into the scope. Koin rebinds the resolution context to root on
+        // linked-scope fallback (see ScopeResolutionMechanicsTest), so that failure is a runtime
+        // throw on whatever screen touches it first, not a build error.
+        //
+        // So: resolve every scoped definition the way the app does and look for a MISSING
+        // DEFINITION specifically. Other construction failures are expected here — plenty of
+        // these objects need a real database, filesystem or platform service that a headless
+        // test has no business providing — and are deliberately tolerated. A missing definition
+        // is never environmental.
+        val koin = koinApplication(createEagerInstances = false) { modules(allModules) }.koin
+        val session = IdentitySessionScope(koin)
+        val scope = session.open("frodo.dotyou.cloud")
+
+        val unreachable = mutableListOf<String>()
+        var constructed = 0
+
+        allDefinitions()
+            .filter { it.scopeQualifier == IdentitySessionQualifier }
+            .forEach { definition ->
+                try {
+                    scope.get<Any>(definition.primaryType, definition.qualifier, null)
+                    constructed++
+                } catch (t: Throwable) {
+                    val missing = generateSequence(t) { it.cause }
+                        .filterIsInstance<NoDefinitionFoundException>()
+                        .firstOrNull()
+                    if (missing != null) {
+                        unreachable += "${definition.primaryType.qualifiedName} -> ${missing.message}"
+                    }
+                }
+            }
+
+        session.close()
+        koin.close()
+
+        assertTrue(
+            unreachable.isEmpty(),
+            "These identity-scoped definitions depend on something they cannot resolve from the " +
+                "identity scope. Usually the dependency is still registered app-lifetime, or a " +
+                "consumer was left at root while its dependency moved:\n  " +
+                unreachable.joinToString("\n  "),
+        )
+        // Guard the guard: if nothing constructs, the assertion above is vacuous.
+        assertTrue(constructed > 0, "No scoped definition constructed — this check proved nothing")
+    }
+
+
+    @Test
+    fun `no app-lifetime definition depends on identity-scoped state`() {
+        // The other direction of the same trap, and the one that actually bit during the
+        // migration: a definition left at ROOT that takes an identity-scoped type in its
+        // constructor. Nothing above catches it — the consumer is not itself marked
+        // IdentityScoped, and it is not in the scope, so neither placement guard applies. It
+        // fails at runtime, on whichever screen resolves it first.
+        //
+        // Checked by reflecting constructor parameters rather than by instantiating: resolving
+        // every app-lifetime definition in a test would start coroutines, open databases and
+        // touch the filesystem. The cost is that `single<SomeInterface> { Impl() }` records the
+        // interface as its primary type, so a dependency reachable only through an interface is
+        // not seen here.
+        //
+        // The fix for a violation is usually not to move the consumer: something app-lifetime
+        // that genuinely needs per-identity state should resolve it on demand through
+        // IdentitySessionScope, as AppViewModel does for the moment draft.
+        val scopedTypes = allDefinitions()
+            .filter { it.scopeQualifier == IdentitySessionQualifier }
+            .map { it.primaryType.java }
+            .toSet()
+
+        val violations = allDefinitions()
+            .filter { it.scopeQualifier != IdentitySessionQualifier }
+            .flatMap { definition ->
+                val consumer = definition.primaryType
+                val params = runCatching {
+                    consumer.java.constructors.flatMap { it.parameterTypes.toList() }
+                }.getOrDefault(emptyList())
+                params.filter { it in scopedTypes }
+                    .map { "${consumer.qualifiedName} depends on ${it.name}" }
+            }
+            .distinct()
+            .sorted()
+
+        assertTrue(
+            violations.isEmpty(),
+            "These app-lifetime definitions take identity-scoped types in their constructor, so " +
+                "they cannot be constructed once that state lives in the scope — and holding one " +
+                "would pin a single identity's state for the life of the process. Resolve it on " +
+                "demand through IdentitySessionScope instead:\n  " +
+                violations.joinToString("\n  "),
         )
     }
 

--- a/homebase-core/src/jvmTest/kotlin/id/homebase/core/di/IdentityScopeGuardTest.kt
+++ b/homebase-core/src/jvmTest/kotlin/id/homebase/core/di/IdentityScopeGuardTest.kt
@@ -1,0 +1,89 @@
+package id.homebase.core.di
+
+import id.homebase.core.session.IdentityScoped
+import id.homebase.core.session.IdentitySessionQualifier
+import org.koin.core.annotation.KoinInternalApi
+import org.koin.core.definition.BeanDefinition
+import org.koin.core.module.Module
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * Keeps the identity-scope rule from decaying back into a maintenance list.
+ *
+ * The bug this whole mechanism exists to prevent is a per-identity object registered as an
+ * app-lifetime `single`, surviving a logout and serving the previous identity's state to the
+ * next one. That is exactly what happened with the email screens: a stale address, a mailbox
+ * reported as missing, and a drive mount that retried `400 InvalidDrive` once a second.
+ *
+ * Rather than scan source text, this reads Koin's own definition metadata — the same
+ * [BeanDefinition]s the container resolves from — so it cannot drift from what actually gets
+ * registered, whichever DSL spelling (`single`, `singleOf`, `single<T>`) was used.
+ *
+ * Note the marker belongs on the type that is REGISTERED. `single<SomeInterface> { Impl() }`
+ * records `SomeInterface` as the primary type, so marking only `Impl` would slip past this.
+ */
+class IdentityScopeGuardTest {
+
+    @Test
+    fun `identity-scoped types are not registered app-lifetime`() {
+        val offenders = allDefinitions()
+            .filter { it.scopeQualifier != IdentitySessionQualifier }
+            .filter { it.isIdentityScoped() }
+            .map { "${it.primaryType.qualifiedName} (scope=${it.scopeQualifier})" }
+            .sorted()
+
+        assertTrue(
+            offenders.isEmpty(),
+            "These types are marked IdentityScoped but registered app-lifetime, so they would " +
+                "survive a logout and leak one identity's state into the next. Move them into " +
+                "`scope(IdentitySessionQualifier) { scoped { ... } }`:\n  " +
+                offenders.joinToString("\n  "),
+        )
+    }
+
+    @Test
+    fun `everything in the identity scope is marked IdentityScoped`() {
+        // The inverse mistake: a type correctly placed in the scope but not marked, so nothing
+        // stops a later refactor from quietly moving it back out to a `single`.
+        val unmarked = allDefinitions()
+            .filter { it.scopeQualifier == IdentitySessionQualifier }
+            .filterNot { it.isIdentityScoped() }
+            .map { it.primaryType.qualifiedName ?: it.primaryType.toString() }
+            .sorted()
+
+        assertTrue(
+            unmarked.isEmpty(),
+            "These types are registered in the identity scope but do not implement " +
+                "IdentityScoped, so the guard above cannot protect them:\n  " +
+                unmarked.joinToString("\n  "),
+        )
+    }
+
+    private fun BeanDefinition<*>.isIdentityScoped(): Boolean =
+        IdentityScoped::class.java.isAssignableFrom(primaryType.java) ||
+            secondaryTypes.any { IdentityScoped::class.java.isAssignableFrom(it.java) }
+
+    /**
+     * Every definition across [allModules], following `includes(...)` into nested modules.
+     *
+     * Reads Koin-internal API deliberately. Asking the container what it actually registered
+     * is the only way to state this rule without a regex over DSL spellings, and the cost is
+     * contained: if Koin changes the shape, this test stops compiling — loudly, at build
+     * time, in a test — rather than misreporting the app as safe.
+     */
+    @OptIn(KoinInternalApi::class)
+    private fun allDefinitions(): List<BeanDefinition<*>> {
+        val seen = mutableSetOf<Module>()
+        val out = mutableListOf<BeanDefinition<*>>()
+
+        fun walk(module: Module) {
+            if (!seen.add(module)) return
+            module.mappings.values.mapTo(out) { it.beanDefinition }
+            module.includedModules.forEach(::walk)
+        }
+
+        allModules.forEach(::walk)
+        return out
+    }
+}

--- a/homebase-core/src/jvmTest/kotlin/id/homebase/core/di/MomentDraftSurvivesLogoutTest.kt
+++ b/homebase-core/src/jvmTest/kotlin/id/homebase/core/di/MomentDraftSurvivesLogoutTest.kt
@@ -1,0 +1,69 @@
+package id.homebase.core.di
+
+import id.homebase.core.moments.services.MomentCreateFlowState
+import id.homebase.core.session.IdentitySessionScope
+import org.koin.core.Koin
+import org.koin.dsl.koinApplication
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertNull
+
+/**
+ * A moment draft — the user's photos and description — must not survive a logout into the
+ * next identity's session.
+ *
+ * [MomentCreateFlowState] is registered app-lifetime (`single { }` in AppModule) and its
+ * `clear()` is called from exactly one place: MomentAudienceViewModel, on a *successful
+ * post*. Nothing clears it on logout — it is not in `onPostAuthenticated`'s reset list and
+ * has no SessionEnded listener. So abandoning a compose mid-flow (Continue → audience
+ * picker, then log out without posting) leaves the draft in memory, and
+ * MomentComposeViewModel seeds its UI state from `restoreFromDraft()` on construction with
+ * no identity check.
+ *
+ * This test resolves from the real DI graph rather than a hand-built one, so it describes
+ * what the app actually does. It is expected to FAIL until MomentCreateFlowState moves into
+ * the identity scope — that failure is the point: it is the baseline proving the leak is
+ * real, not merely argued.
+ */
+class MomentDraftSurvivesLogoutTest {
+
+    private lateinit var koin: Koin
+    private lateinit var session: IdentitySessionScope
+
+    @BeforeTest
+    fun setUp() {
+        // createEagerInstances = false: the real graph has createdAtStart singletons (the
+        // desktop notification bridge among them) that cannot construct headless. We only
+        // need the definitions, and Koin resolves the rest lazily.
+        koin = koinApplication(createEagerInstances = false) { modules(allModules) }.koin
+        session = IdentitySessionScope(koin)
+    }
+
+    @AfterTest
+    fun tearDown() = koin.close()
+
+    @Test
+    fun `a moment draft does not survive into the next identity's session`() {
+        session.open("frodo.dotyou.cloud")
+        resolveFlowState().setDraft(
+            MomentCreateFlowState.Draft(attachments = emptyList(), description = "Frodo's holiday snaps"),
+        )
+
+        // Logout, then a different identity logs in.
+        session.close()
+        session.open("sam.dotyou.cloud")
+
+        assertNull(
+            resolveFlowState().draft.value,
+            "Sam's composer would open on Frodo's draft — his photos and description",
+        )
+    }
+
+    /**
+     * Resolve the way the app does: out of the identity scope, falling back to the root
+     * scope while the definition is still registered app-lifetime. That fallback is what
+     * makes this test meaningful before the migration and honest after it.
+     */
+    private fun resolveFlowState(): MomentCreateFlowState = session.requireScope().get()
+}


### PR DESCRIPTION
Logging out of one identity and into another leaves the previous identity's state live in memory. #1360 fixed three symptoms of that; this addresses the cause, and fixes a fourth leak that #1360 did not touch.

## The cause

Identity-scoped state lives in app-lifetime singletons, and **three overlapping teardown mechanisms exist, none complete**:

1. **A hand-maintained reset list** — 17 singletons reset in `AppModule`'s `onPostAuthenticated`. Anything not on it survives forever, and it runs at the *next login*, not at logout — its own comment notes the hook "is deferred and frequently never runs on a warm relaunch".
2. **Self-clearing on `BackendEvent.SessionEnded`** — five services each doing their own thing.
3. **Nothing at all** — `ExtendPermissionViewModel` was on no list, which is why it kept a dead token across a re-login.

## A reproduced leak

`MomentCreateFlowState` holds a moment draft — **the user's photos and description**. Its `clear()` runs in exactly one place: on a successful post. Abandon the flow (Continue → audience picker, log out without posting) and it stays in memory; `MomentComposeViewModel` seeds its UI state from `restoreFromDraft()` on construction with no identity check.

Reproduced by hand — one identity's picture and draft text appeared for another — and pinned by `MomentDraftSurvivesLogoutTest`, which resolves from the real DI graph and **fails without this change**.

## What this does

Adds an `IdentitySession` Koin scope, opened on the authenticated transition and closed on logout. Closing drops every scoped instance and fires its `onClose` callback, so the next login constructs fresh objects rather than reusing reset ones — forgetting becomes impossible rather than merely discouraged.

Open/close live in `AuthConnectionCoordinator`, which already owns both the authenticated transition and the `SessionEnded` emission, and takes the scope as a required constructor parameter so the wiring cannot be forgotten. Re-opening for the same identity is a no-op (the branch runs twice on a headless bootstrap that later promotes to foreground); a *different* identity closes the previous scope, the backstop for a logout we never saw.

Moments is the first subsystem through it, chosen because it had a reproduced bug to prove the mechanism against.

## The mechanic that shapes the migration

**A definition can only reach identity-scoped dependencies if the definition itself lives in the scope.** Koin's `resolveFromLinkedScopes` rebinds the resolution context to root via `newContextForScope`, so a root-registered ViewModel injecting a scoped service fails at runtime.

I originally assumed the opposite and verified it before building on it. `ScopeResolutionMechanicsTest` now pins all four behaviours, including the trap itself — it looks like it should work, because you *are* asking the identity scope for the object. Consequence: each subsystem moves as a unit, services and their ViewModels together.

`IdentityScopeProvider` wraps the nav graph so `koinViewModel()` resolves from the open session, via Koin's `UnboundKoinScope` — deliberately not tied to composition, because the coordinator owns the scope's lifetime.

## Two problems found while wiring it up

- **A race.** The UI and the coordinator collect `authState` independently, so the composition could see `Authenticated` a frame before the scope existed and throw on a scoped `koinViewModel()`. `isAuthenticated` now requires the scope too, gating every authenticated route on one flag.
- **A nullable open.** The coordinator opened the scope from `credentialsManager.getActiveDomain()`, which is nullable — combined with the gate above, a null would have left the UI blank forever. It now uses `YouAuthState.Authenticated.identity`.

## Guards

`IdentityScopeGuardTest` reads Koin's own `BeanDefinition` metadata rather than scanning source text, so it cannot drift from what is actually registered whichever DSL spelling was used. It asserts both directions: nothing marked `IdentityScoped` is registered app-lifetime, and nothing in the scope is unmarked.

**It was verified to fail, not merely to pass** — temporarily marking `MomentsFeedService` made it name that class and point at the fix. It also caught the three new scope members before they were marked, during this work.

## Remaining phases

2. Email, then permissions (`ExtendPermissionViewModel` is constructor-injected into other ViewModels, so it is a wider surface than one screen).
3. Remaining subsystems: chat/conversations, contacts, feed, moments services, location, vault, stickers.
4. Delete the reset ritual and the self-clearing listeners, leaving one mechanism instead of three. The #1360 workarounds should become deletable at that point — whether they do is the real acceptance test.

## Verification

`:homebase-common:jvmTest`, `:homebase-core:jvmTest`, `:homebase-chat:jvmTest`, `:homebase-core:compileKotlinWasmJs` all pass.

Not covered: the guard checks *placement*, not *reachability* — it would not have caught the root-ViewModel trap. A resolution-level check belongs in the next phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EcPf3xgN4BoFfMkgmqgrxG