### PR TITLE
Email screen: say whether email actually works

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/mail/MailModels.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/mail/MailModels.kt
@@ -41,6 +41,36 @@ data class MailDnsRecord(
     val domain: String = "",
     val value: String = "",
     val description: String = "",
+    /**
+     * The server's lookup verdict: "success" when the record is published correctly, otherwise
+     * "unknown" / "domainOrRecordNotFound" / "incorrectValue" / ... Only meaningful on records
+     * that came from a health check; the DKIM set returned by activation leaves it empty.
+     */
+    val status: String = "",
+)
+
+/**
+ * Whether the identity's email actually WORKS, as opposed to how far setup got —
+ * `GET /api/v2/mail/health`, mirroring odin-core `MailAppHealthResult`.
+ *
+ * [MailAppStatus] answers only the second question, so an identity whose domain has no MX
+ * reports as fully configured while nothing can deliver mail to it.
+ *
+ * The server decides: [brokenRecords] is already filtered and [needsAttention] is already
+ * computed, so this app renders the verdict rather than re-deriving it. Re-deriving it here
+ * would let the app and the owner console disagree about the same identity.
+ */
+@Serializable
+data class MailAppHealth(
+    val tenantMailEnabled: Boolean = false,
+    /** False when email was never activated: nothing to report, rather than everything broken. */
+    val activated: Boolean = false,
+    val records: List<MailDnsRecord> = emptyList(),
+    val brokenRecords: List<MailDnsRecord> = emptyList(),
+    /** Checks a record comparison cannot make: DKIM pair proof, public-key drift. */
+    val errors: List<String> = emptyList(),
+    val warnings: List<String> = emptyList(),
+    val needsAttention: Boolean = false,
 )
 
 /**

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/mail/MailProvider.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/mail/MailProvider.kt
@@ -122,6 +122,31 @@ class MailProvider(
     }
 
     /** Mailbox state, or available = false when the mail server does not report it. */
+    /**
+     * Whether email actually works for this identity, as opposed to how far setup got.
+     *
+     * Runs the same DNS-record and key checks the owner console's Email tab runs — server-side,
+     * from the same services — so the two surfaces cannot disagree and nothing is duplicated
+     * here. On demand only: it does DNS lookups plus outbound HTTPS, which is why it is not part
+     * of [getStatus], which runs on every login and identity switch.
+     */
+    suspend fun getHealth(): MailAppHealth {
+        val creds = requireCreds()
+        val response = encryptedGet(
+            url = apiUrl(creds.domain, "$BASE/health"),
+            token = creds.accessToken,
+            secret = creds.secret,
+        )
+        throwForFailure(response)
+        val health = deserialize<MailAppHealth>(response.body)
+        Logger.d(tag = TAG) {
+            "health: enabled=${health.tenantMailEnabled} activated=${health.activated} " +
+                "broken=${health.brokenRecords.size}/${health.records.size} " +
+                "errors=${health.errors.size} needsAttention=${health.needsAttention}"
+        }
+        return health
+    }
+
     suspend fun getMailboxStatus(): MailboxStatusResult {
         val creds = requireCreds()
         val response = encryptedGet(

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/client/mail/MailModelsSerializationTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/client/mail/MailModelsSerializationTest.kt
@@ -112,4 +112,53 @@ class MailModelsSerializationTest {
         assertEquals("wcDMA0hp0m8AAAAB", challenge.encryptedNonceBase64)
         assertEquals("n4bQgYhMfWWaL+qgxVrQFaO/TxsrC4Is0V1sFbDwCgg=", challenge.nonceSha256Base64)
     }
+
+    /**
+     * The health shape. The dangerous default here is `needsAttention` silently reading false:
+     * the screen would then report healthy email for an identity whose domain has no MX, which
+     * is the exact failure this endpoint exists to surface.
+     */
+    @Test
+    fun healthParsesTheServerShape() {
+        val json = """
+            {
+              "tenantMailEnabled": true,
+              "activated": true,
+              "records": [
+                { "type": "MX", "name": "", "domain": "frodo.dotyou.cloud", "value": "10 mx1.dotyou.cloud", "description": "MX Record (inbound mail)", "status": "domainOrRecordNotFound" },
+                { "type": "TXT", "name": "s1._domainkey", "domain": "s1._domainkey.frodo.dotyou.cloud", "value": "v=DKIM1; k=ed25519; p=abc", "description": "DKIM", "status": "success" }
+              ],
+              "brokenRecords": [
+                { "type": "MX", "name": "", "domain": "frodo.dotyou.cloud", "value": "10 mx1.dotyou.cloud", "description": "MX Record (inbound mail)", "status": "domainOrRecordNotFound" }
+              ],
+              "errors": ["DKIM pair proof failed"],
+              "warnings": ["Could not reach the WKD endpoint"],
+              "needsAttention": true
+            }
+        """.trimIndent()
+
+        val health = OdinSystemSerializer.deserialize<MailAppHealth>(json)
+
+        assertTrue(health.tenantMailEnabled)
+        assertTrue(health.activated)
+        assertEquals(2, health.records.size)
+        assertEquals("domainOrRecordNotFound", health.records.first().status)
+        assertEquals(1, health.brokenRecords.size)
+        assertEquals("MX", health.brokenRecords.first().type)
+        assertEquals(listOf("DKIM pair proof failed"), health.errors)
+        assertEquals(listOf("Could not reach the WKD endpoint"), health.warnings)
+        assertTrue(health.needsAttention, "the server's verdict must survive the wire")
+    }
+
+    /** A host with no email must parse as "nothing to see", not as a warning. */
+    @Test
+    fun healthParsesTheEmailIsOffShape() {
+        val health = OdinSystemSerializer.deserialize<MailAppHealth>(
+            """{ "tenantMailEnabled": false, "activated": false }"""
+        )
+
+        assertTrue(!health.tenantMailEnabled)
+        assertTrue(!health.needsAttention)
+        assertTrue(health.records.isEmpty())
+    }
 }

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -1176,6 +1176,14 @@
     <string name="email_mailbox_junk">%1$d in junk</string>
     <string name="email_mailbox_queued">%1$d message(s) still trying to send</string>
     <string name="email_mailbox_open_client">Open %1$s</string>
+    <!-- Email health: whether mail actually works, as opposed to whether setup finished. -->
+    <string name="email_health_check">Check my email</string>
+    <string name="email_health_checking">Checking…</string>
+    <string name="email_health_ok">Your email is working.</string>
+    <string name="email_health_attention">Your email needs attention. Mail may not reach you, or may be treated as spam.</string>
+    <string name="email_health_missing_record">%1$s record missing or incorrect</string>
+    <string name="email_health_fix_hint">Open the owner console to fix this: Security → Email.</string>
+    <string name="email_health_unavailable">Could not check your email right now.</string>
     <string name="email_mailbox_open_failed">%1$s does not seem to be installed</string>
 
     <!-- Vault -->

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/email/EmailScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/email/EmailScreen.kt
@@ -103,6 +103,10 @@ fun EmailScreen(
                     onRefresh = { viewModel.onAction(EmailUiAction.RefreshStatusClicked) },
                     onOpenMailClient = { viewModel.onAction(EmailUiAction.OpenMailClientClicked) },
                     isRefreshing = uiState.isCheckingServer,
+                    health = uiState.health,
+                    isCheckingHealth = uiState.isCheckingHealth,
+                    healthUnavailable = uiState.healthError != null,
+                    onCheckHealth = { viewModel.onAction(EmailUiAction.CheckHealthClicked) },
                 )
 
                 else -> EmailSetupContent(

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/email/EmailUiState.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/email/EmailUiState.kt
@@ -1,5 +1,6 @@
 package id.homebase.core.ui.screens.email
 
+import id.homebase.api.client.mail.MailAppHealth
 import id.homebase.api.client.mail.MailAppStatus
 import id.homebase.api.client.mail.MailboxStatusResult
 import id.homebase.core.email.MailClientDescriptor
@@ -28,6 +29,16 @@ data class EmailUiState(
     val mailboxStatus: MailboxStatusResult? = null,
     /** The mail app the user picked, if any — decides whether we can offer to open it. */
     val selectedMailClient: MailClientDescriptor? = null,
+    /**
+     * Whether email actually WORKS, as opposed to how far setup got. Null until the user asks:
+     * the check costs DNS lookups plus outbound HTTPS server-side, so it is not run on entry.
+     *
+     * [serverStatus] cannot answer this — an identity whose domain has no MX reports as fully
+     * configured there while nothing can deliver mail to it.
+     */
+    val health: MailAppHealth? = null,
+    val isCheckingHealth: Boolean = false,
+    val healthError: EmailError? = null,
 ) {
     /** The server answered, and answered no. Nothing to set up here. */
     val serverHasNoEmail: Boolean
@@ -50,6 +61,9 @@ sealed interface EmailUiAction {
 
     /** Opens the chosen mail app, if this platform knows how. */
     data object OpenMailClientClicked : EmailUiAction
+
+    /** "Check my email" — asks the server whether email actually works. */
+    data object CheckHealthClicked : EmailUiAction
 }
 
 sealed interface EmailUiEvent {
@@ -65,4 +79,10 @@ sealed interface EmailUiEvent {
 sealed interface EmailError {
     /** The status call failed. Distinct from "the server says it has no email". */
     data object StatusUnavailable : EmailError
+
+    /**
+     * The health check failed. Deliberately its own case: "we could not check" must never
+     * render as "your email is fine", which is what reusing a null health would do.
+     */
+    data object HealthUnavailable : EmailError
 }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/email/EmailViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/email/EmailViewModel.kt
@@ -160,12 +160,38 @@ class EmailViewModel(
 
             EmailUiAction.RefreshStatusClicked -> refreshStatus()
 
+            EmailUiAction.CheckHealthClicked -> checkHealth()
+
             EmailUiAction.OpenMailClientClicked -> viewModelScope.launch {
                 val client = MailClientCatalog.byId(emailPreferences.selectedMailClientId.value)
                     ?: return@launch
                 // False means not installed — say so rather than appearing to do nothing.
                 if (!launchMailClient(client)) {
                     _events.tryEmit(EmailUiEvent.MailClientUnavailable(client.displayName))
+                }
+            }
+        }
+    }
+
+    /**
+     * Ask the server whether email actually works.
+     *
+     * Every check runs server-side, from the same services the owner console's Email tab uses,
+     * and the verdict (`needsAttention`, `brokenRecords`) arrives already decided. Nothing is
+     * recomputed here on purpose: two clients deriving "healthy" from raw records would
+     * eventually disagree about the same identity, and the one that disagreed quietly would be
+     * the one people trusted.
+     */
+    fun checkHealth() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isCheckingHealth = true, healthError = null) }
+            try {
+                val health = mailProvider.getHealth()
+                _uiState.update { it.copy(health = health, isCheckingHealth = false) }
+            } catch (e: Exception) {
+                Logger.e(throwable = e, tag = TAG) { "email health check failed: ${e.message}" }
+                _uiState.update {
+                    it.copy(isCheckingHealth = false, healthError = EmailError.HealthUnavailable)
                 }
             }
         }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/email/components/EmailHomeContent.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/email/components/EmailHomeContent.kt
@@ -34,6 +34,13 @@ import id.homebase.api.client.mail.MailboxStatusResult
 import id.homebase.core.email.MailClientDescriptor
 import id.homebase.core.email.canLaunchMailClient
 import id.homebase.resources.MR
+import id.homebase.resources.email_health_attention
+import id.homebase.resources.email_health_check
+import id.homebase.resources.email_health_checking
+import id.homebase.resources.email_health_fix_hint
+import id.homebase.resources.email_health_missing_record
+import id.homebase.resources.email_health_ok
+import id.homebase.resources.email_health_unavailable
 import id.homebase.resources.email_home_address_label
 import id.homebase.resources.email_home_secrets
 import id.homebase.resources.email_client_none
@@ -46,6 +53,7 @@ import id.homebase.resources.email_mailbox_open_client
 import id.homebase.resources.email_mailbox_queued
 import id.homebase.resources.email_mailbox_unread
 import id.homebase.resources.email_no_server_retry
+import id.homebase.api.client.mail.MailAppHealth
 import org.jetbrains.compose.resources.stringResource
 
 /**
@@ -64,6 +72,10 @@ fun EmailHomeContent(
     onRefresh: () -> Unit,
     onOpenMailClient: () -> Unit,
     isRefreshing: Boolean,
+    health: MailAppHealth?,
+    isCheckingHealth: Boolean,
+    healthUnavailable: Boolean,
+    onCheckHealth: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -182,6 +194,69 @@ fun EmailHomeContent(
                 Spacer(modifier = Modifier.height(8.dp))
                 TextButton(onClick = onRefresh, enabled = !isRefreshing) {
                     Text(stringResource(MR.string.email_no_server_retry))
+                }
+
+                // "Set up" and "works" are different questions. Everything above answers the
+                // first; an identity whose domain has no MX looks fully configured there while
+                // nothing can deliver mail to it. The verdict below is the server's — the same
+                // checks the owner console runs, decided there and rendered here.
+                Spacer(modifier = Modifier.height(8.dp))
+                TextButton(onClick = onCheckHealth, enabled = !isCheckingHealth) {
+                    Text(
+                        stringResource(
+                            if (isCheckingHealth) MR.string.email_health_checking
+                            else MR.string.email_health_check
+                        )
+                    )
+                }
+
+                when {
+                    // A failed check must never read as a clean bill of health.
+                    healthUnavailable -> Text(
+                        text = stringResource(MR.string.email_health_unavailable),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+
+                    health == null -> Unit
+
+                    health.needsAttention -> {
+                        Text(
+                            text = stringResource(MR.string.email_health_attention),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.error,
+                        )
+                        health.brokenRecords.forEach { record ->
+                            Text(
+                                text = stringResource(
+                                    MR.string.email_health_missing_record,
+                                    record.description.ifBlank { record.type },
+                                ),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                        health.errors.forEach { message ->
+                            Text(
+                                text = message,
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                        // Publishing DNS is an owner action, so point there rather than
+                        // duplicating a write button in the app.
+                        Text(
+                            text = stringResource(MR.string.email_health_fix_hint),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+
+                    else -> Text(
+                        text = stringResource(MR.string.email_health_ok),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
                 }
             }
         }


### PR DESCRIPTION
The app knew how far setup got and nothing more, so an identity whose domain has **no MX** reported as fully set up while nothing could deliver mail to it. That is the state `biggus.dickus.demo.rocks` is in right now: mailbox live, key published, DKIM valid — and no MX, SPF, DMARC, MTA-STS, TLS-RPT or `mta-sts` CNAME.

Adds a **"Check my email"** button calling `GET /api/v2/mail/health` (odin-core #1683).

## One source of truth

Every check runs **server-side**, from the same services the owner console's Email tab uses — `DnsHealthService` for the record rows, `EmailHealthVerifier` for the DKIM pair proof and public-key drift. The verdict arrives already decided: `brokenRecords` is pre-filtered and `needsAttention` is pre-computed.

Nothing is recomputed here on purpose. Two clients deriving "healthy" from raw records would eventually disagree about the same identity, and the one that disagreed quietly would be the one people trusted.

On demand rather than folded into the status call: the server does DNS lookups plus outbound HTTPS, and `status` runs on every login and identity switch.

## Scoped deliberately

The screen **points at the owner console** to fix things rather than offering a publish button of its own. Publishing DNS is a rare owner-scoped action, and duplicating the write here would be a second place to keep correct.

Three states, kept distinct because collapsing them is how this goes wrong:

- healthy
- needs attention — lists the broken records and any key errors
- **could not check** — its own `EmailError` case, never a null health. A failed check must never render as a clean bill of health.

## The test, and the failure it guards

`MailModelsSerializationTest` covers the new shape. `ignoreUnknownKeys` is on for every wire model here, so a field misspelled against the server silently reads as its default — and the dangerous default is `needsAttention` reading **false**, which would report healthy email for a domain that cannot receive any. Both the populated and the email-is-off shapes are pinned.

The email-is-off case matters as much as the broken one: it is what the majority of hosts return, and a warning on all of them is the fastest way to teach people to ignore the warning that matters.

## Verification

`homebase-api`, `homebase-common`, `homebase-core` and `homebase-chat` `jvmTest` all pass, plus the `wasmJs` compile — re-run on top of the merged main.

Not yet exercised against a live server: that needs #1683 deployed. `biggus.dickus.demo.rocks` is the natural first check, since it should report six missing records today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EcPf3xgN4BoFfMkgmqgrxG