### PR TITLE
Tighten the desktop conversation row to pointer metrics

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationItem.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationItem.kt
@@ -50,6 +50,7 @@ import id.homebase.core.ui.theme.emojiFontFamily
 import id.homebase.core.ui.theme.withEmojiFont
 import id.homebase.core.util.formatTimestamp
 import id.homebase.core.util.ifTrue
+import id.homebase.core.util.isDesktopOrWeb
 import id.homebase.core.util.stripComposerLineBreakArtifacts
 import id.homebase.resources.MR
 import id.homebase.resources.chat_archived
@@ -80,10 +81,13 @@ fun ConversationItem(
 ) {
     var showMenu by rememberSaveable { mutableStateOf(false) }
 
+    // Pointer rows tighten the inset and pair title+preview as one block; touch keeps 88dp targets.
+    val compact = isDesktopOrWeb()
+
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 16.dp)
+            .padding(horizontal = if (compact) 8.dp else 16.dp)
             .clip(RoundedCornerShape(8.dp))
             .ifTrue(isSelected) {
                 Modifier.background(MaterialTheme.colorScheme.secondaryContainer)
@@ -93,12 +97,12 @@ fun ConversationItem(
                 onLongClick = { showMenu = true }
             )
             .semantics { selected = isSelected }
-            .padding(horizontal = 12.dp, vertical = 12.dp),
+            .padding(horizontal = if (compact) 10.dp else 12.dp, vertical = 12.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
         ConversationAvatar(
             avatarModel = enrichedData.conversation.avatarModel,
-            modifier = Modifier.padding(8.dp),
+            modifier = Modifier.padding(if (compact) 0.dp else 8.dp),
             options = AvatarOptions(onClick = { enrichedData.participants.firstOrNull()?.odinId?.let { onContactClick(it) } })
         )
 
@@ -144,7 +148,7 @@ fun ConversationItem(
                 )
             }
 
-            Spacer(modifier = Modifier.height(4.dp))
+            Spacer(modifier = Modifier.height(if (compact) 2.dp else 4.dp))
 
             Row(
                 modifier = Modifier.fillMaxWidth(),

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationItem.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationItem.kt
@@ -81,7 +81,7 @@ fun ConversationItem(
 ) {
     var showMenu by rememberSaveable { mutableStateOf(false) }
 
-    // Pointer rows tighten the inset and pair title+preview as one block; touch keeps 88dp targets.
+    // Pointer rows follow Signal Desktop: one step down the type scale, title+preview as one block.
     val compact = isDesktopOrWeb()
 
     Row(
@@ -120,7 +120,8 @@ fun ConversationItem(
                 else enrichedData.getDisplayName(youLabel = stringResource(MR.string.you))
                 Text(
                     text = title.withEmojiFont(),
-                    style = MaterialTheme.typography.bodyLarge,
+                    style = if (compact) MaterialTheme.typography.bodyMedium
+                    else MaterialTheme.typography.bodyLarge,
                     fontWeight = if (enrichedData.conversation.unreadCount > 0) FontWeight.Bold else FontWeight.Normal,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
@@ -148,7 +149,7 @@ fun ConversationItem(
                 )
             }
 
-            Spacer(modifier = Modifier.height(if (compact) 2.dp else 4.dp))
+            Spacer(modifier = Modifier.height(if (compact) 0.dp else 4.dp))
 
             Row(
                 modifier = Modifier.fillMaxWidth(),
@@ -378,6 +379,9 @@ fun ConversationMessagePreview(
     prefix: String? = null,
     prefixColor: Color = MaterialTheme.colorScheme.onSurfaceVariant,
 ) {
+    val compact = isDesktopOrWeb()
+    val previewStyle = if (compact) MaterialTheme.typography.bodySmall
+    else MaterialTheme.typography.bodyMedium
     val emojiFamily = emojiFontFamily()
     Row(
         verticalAlignment = Alignment.CenterVertically,
@@ -387,7 +391,7 @@ fun ConversationMessagePreview(
         if (prefix != null) {
             Text(
                 text = prefix.withEmojiFont(emojiFamily),
-                style = MaterialTheme.typography.bodyMedium,
+                style = previewStyle,
                 color = prefixColor.copy(
                     alpha = if (isDeleted) 0.5f else 1f
                 ),
@@ -399,7 +403,8 @@ fun ConversationMessagePreview(
             Icon(
                 imageVector = iconRes,
                 contentDescription = null,
-                modifier = Modifier.size(16.dp).alpha(if (isDeleted) 0.5f else 1f),
+                modifier = Modifier.size(if (compact) 14.dp else 16.dp)
+                    .alpha(if (isDeleted) 0.5f else 1f),
                 tint = MaterialTheme.colorScheme.onSurfaceVariant
             )
         }
@@ -417,7 +422,7 @@ fun ConversationMessagePreview(
 
             Text(
                 text = previewText,
-                style = MaterialTheme.typography.bodyMedium,
+                style = previewStyle,
                 color = MaterialTheme.colorScheme.onSurfaceVariant.copy(
                     alpha = if (isDeleted) 0.5f else 1f
                 ),
@@ -429,7 +434,7 @@ fun ConversationMessagePreview(
             // Fallback for empty message with no icon
             Text(
                 text = stringResource(MR.string.chat_no_messages),
-                style = MaterialTheme.typography.bodyMedium,
+                style = previewStyle,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,


### PR DESCRIPTION
The conversation row was designed for touch and shipped unchanged to desktop and web. Next to WhatsApp and Signal Desktop the difference reads as "too much air" — but the row *height* was never the problem. Measured at 1x, ours is 72px around a 48px avatar; Signal's `$normal-row-height` is **72px** around a 48px avatar, and WhatsApp's is 69px. The height already matched.

What differs is the horizontal inset, how the space is distributed inside the row, and the type scale.

## Metrics

| | WhatsApp | Signal | before | after |
|---|---|---|---|---|
| avatar | 48px | 48px | 48px | 48px |
| row height | 69px | 72px | 72px | 72px |
| pane edge -> avatar | 18px | 14-24px | 28px | 18px |
| avatar -> text | 12px | 12px | 18px | 12px |
| title | — | 14px / 20px | 16sp / 24sp | 14sp / 20sp |
| preview | — | 12px / 17px | 14sp / 20sp | 12sp / 16sp |
| title -> preview gap | ~1px | 0 | 9px | 0 |

Both references pack the two text lines into one tight block and spend the whitespace *around* it, letting line-height leading do the separating. Ours spread the space evenly between and around the lines, so the pair stopped reading as a single item.

M3 maps onto Signal almost exactly: `bodyMedium` is 14sp/20sp (an exact match for their title) and `bodySmall` is 12sp/16sp (a pixel off their preview leading — not worth a custom TextStyle).

## Change

Seven values gated on `isDesktopOrWeb()`:

| | touch | desktop/web |
|---|---|---|
| outer gutter | 16dp | 8dp |
| inner horizontal padding | 12dp | 10dp |
| avatar padding | 8dp | 0dp |
| title style | bodyLarge | bodyMedium |
| preview style | bodyMedium | bodySmall |
| preview content icon | 16dp | 14dp |
| title/preview gap | 4dp | 0dp |
| row vertical padding | 12dp | 12dp |
| avatar | 48dp | 48dp |

`isDesktopOrWeb()` is an `expect`/`actual` returning a compile-time constant, so on Android and iOS every branch above resolves to the left-hand column and the row renders byte-identically to `main`.

## Why not `isExpandedLayout()`

This is a pointer-vs-touch call, not a screen-width one. A tablet in a wide two-pane layout is still finger-driven and needs the 48dp target, so a width gate would have shrunk it wrongly. It also means resizing the desktop window does not disturb the row: below 840dp the shell collapses to a single pane and the FAB returns, but the row metrics have no width input at all — and so cannot be hit by the known stale-size-class bug in `isExpandedLayout()`.

**Known limitation:** a touchscreen Windows laptop or a touch Chromebook on the web build reports `isDesktopOrWeb() == true` and would get the compact target under a finger. Covering that needs a runtime coarse-vs-fine pointer check rather than a platform constant; left for its own change.

## Rejected

An earlier pass took the row to 64dp by shrinking the avatar to 40dp. It read as starved and was reverted — Signal reaches its density by keeping the 48px avatar and squeezing the padding, not by shrinking the avatar.

## Notes

- Neither WhatsApp nor Signal draws row separators here. Verified by sampling the pixel columns between rows in a WhatsApp screenshot; they are pure background.
- The `Pinned` / `Conversations` section headers cost ~90px before the first row, which neither reference spends. That accounts for most of the remaining "they fit more rows" impression and is left for a separate change.

## Verification

- `:homebase-chat:compileKotlinJvm` green.
- `:homebase-common:jvmTest --tests '*ArchitectureTest*'` and `:homebase-chat:jvmTest --tests '*ConversationMessagePreview*'` green.
- Ran on the desktop app and compared against side-by-side WhatsApp and Signal references.
- Resized the window to its 480px minimum and back; row metrics unaffected, no relayout fault.
