### PR TITLE
Email Secrets: mail app settings, and save the private key to a file

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/mail/MailModels.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/mail/MailModels.kt
@@ -20,12 +20,37 @@ data class MailAppStatus(
     val primaryEmailAddress: String? = null,
     /** A public certificate is published — the server-side "email is on" signal. */
     val activated: Boolean = false,
+    /**
+     * What to type into a mail app. Null when the host publishes no mail hosts, so the screen
+     * shows nothing rather than a form pointing at an empty server name.
+     */
+    val clientSettings: MailClientSettings? = null,
     val publicKeyFingerprint: String? = null,
     val publishedAt: Long? = null,
     val dkimRecords: List<MailDnsRecord> = emptyList(),
     /** The drive file holding the current secret keyring, once one exists. */
     @Serializable(with = UuidSerializer::class)
     val currentKeyFileUniqueId: Uuid? = null,
+)
+
+/**
+ * Hostnames, ports and username for setting up a mail app by hand — the same values the
+ * server publishes as autoconfig XML, mirroring odin-core `MailClientSettings`.
+ *
+ * Ports are implicit TLS (993 / 465), NOT STARTTLS on 587: a client given the wrong pairing
+ * does not error, it hangs. The username is the FULL address, not the local part, and the
+ * outgoing password is the same app password as incoming.
+ */
+@Serializable
+data class MailClientSettings(
+    val incomingHost: String = "",
+    val incomingPort: Int = 0,
+    /** "SSL" — implicit TLS. */
+    val incomingSocketType: String = "",
+    val outgoingHost: String = "",
+    val outgoingPort: Int = 0,
+    val outgoingSocketType: String = "",
+    val username: String = "",
 )
 
 /**

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/client/mail/MailModelsSerializationTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/client/mail/MailModelsSerializationTest.kt
@@ -161,4 +161,50 @@ class MailModelsSerializationTest {
         assertTrue(!health.needsAttention)
         assertTrue(health.records.isEmpty())
     }
+
+    /**
+     * Mail-app settings. The dangerous default is a field name that does not match the
+     * server's: it reads as "" or 0, and the screen then tells someone to connect to an empty
+     * hostname on port zero. Nothing errors — they simply cannot set up mail and have no idea
+     * why.
+     */
+    @Test
+    fun clientSettingsParseTheServerShape() {
+        val json = """
+            {
+              "tenantMailEnabled": true,
+              "activated": true,
+              "clientSettings": {
+                "incomingHost": "mx1.bleeding.ravenhosting.cloud",
+                "incomingPort": 993,
+                "incomingSocketType": "SSL",
+                "outgoingHost": "mx1.bleeding.ravenhosting.cloud",
+                "outgoingPort": 465,
+                "outgoingSocketType": "SSL",
+                "username": "mail@biggus.dickus.demo.rocks"
+              }
+            }
+        """.trimIndent()
+
+        val settings = OdinSystemSerializer.deserialize<MailAppStatus>(json).clientSettings
+        assertTrue(settings != null)
+
+        assertEquals("mx1.bleeding.ravenhosting.cloud", settings!!.incomingHost)
+        assertEquals(993, settings.incomingPort)
+        assertEquals(465, settings.outgoingPort)
+        // Implicit TLS, not STARTTLS — the wrong pairing hangs rather than erroring.
+        assertEquals("SSL", settings.incomingSocketType)
+        assertEquals("SSL", settings.outgoingSocketType)
+        // The FULL address, not the local part.
+        assertEquals("mail@biggus.dickus.demo.rocks", settings.username)
+    }
+
+    /** A host with no mail hosts sends no settings; the screen must render nothing. */
+    @Test
+    fun clientSettingsAreNullWhenTheServerSendsNone() {
+        val status = OdinSystemSerializer.deserialize<MailAppStatus>(
+            """{ "tenantMailEnabled": false }"""
+        )
+        assertNull(status.clientSettings)
+    }
 }

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -1178,6 +1178,13 @@
     <string name="email_mailbox_open_client">Open %1$s</string>
     <!-- Email health: whether mail actually works, as opposed to whether setup finished. -->
     <!-- Mail app setup: what to type into a client that has no autoconfig. -->
+    <!-- Private key export: mail apps import a file, not clipboard text. -->
+    <string name="email_secrets_save_private_key">Save key file</string>
+    <string name="email_secrets_save_private_key_title">Save your private key to a file?</string>
+    <string name="email_secrets_save_private_key_body">Mail apps import your key from a file. Anyone who gets this file can read your encrypted email and sign messages as you. Save it somewhere only you can reach, and delete it once your mail app has imported it.</string>
+    <string name="email_secrets_save_private_key_confirm">Save file</string>
+    <string name="email_secrets_key_saved">Private key saved to %1$s. Delete it once your mail app has imported it.</string>
+    <string name="email_secrets_key_save_failed">Could not save the key file.</string>
     <string name="email_settings_title">Mail app settings</string>
     <string name="email_settings_intro">Most mail apps find these automatically. Enter them by hand if yours does not.</string>
     <string name="email_settings_incoming">Incoming (IMAP)</string>

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -1177,6 +1177,17 @@
     <string name="email_mailbox_queued">%1$d message(s) still trying to send</string>
     <string name="email_mailbox_open_client">Open %1$s</string>
     <!-- Email health: whether mail actually works, as opposed to whether setup finished. -->
+    <!-- Mail app setup: what to type into a client that has no autoconfig. -->
+    <string name="email_settings_title">Mail app settings</string>
+    <string name="email_settings_intro">Most mail apps find these automatically. Enter them by hand if yours does not.</string>
+    <string name="email_settings_incoming">Incoming (IMAP)</string>
+    <string name="email_settings_outgoing">Outgoing (SMTP)</string>
+    <string name="email_settings_server">Server</string>
+    <string name="email_settings_port">Port</string>
+    <string name="email_settings_security">Security</string>
+    <string name="email_settings_username">Username</string>
+    <string name="email_settings_password_hint">Password: use one of the app passwords below. The same one works for both.</string>
+    <string name="email_settings_cert_warning">Your server may ask you to accept a security exception the first time you connect.</string>
     <string name="email_health_check">Check my email</string>
     <string name="email_health_checking">Checking…</string>
     <string name="email_health_ok">Your email is working.</string>

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/email/secrets/EmailSecretsScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/email/secrets/EmailSecretsScreen.kt
@@ -48,6 +48,16 @@ import id.homebase.core.clipboard.clipEntryOf
 import id.homebase.core.ui.screens.email.model.EmailCredential
 import id.homebase.core.ui.screens.email.model.EmailKeyRef
 import id.homebase.resources.MR
+import id.homebase.resources.email_settings_cert_warning
+import id.homebase.resources.email_settings_incoming
+import id.homebase.resources.email_settings_intro
+import id.homebase.resources.email_settings_outgoing
+import id.homebase.resources.email_settings_password_hint
+import id.homebase.resources.email_settings_port
+import id.homebase.resources.email_settings_security
+import id.homebase.resources.email_settings_server
+import id.homebase.resources.email_settings_title
+import id.homebase.resources.email_settings_username
 import id.homebase.resources.email_secrets_cancel
 import id.homebase.resources.email_secrets_copy_fingerprint
 import id.homebase.resources.email_secrets_copy_label
@@ -133,6 +143,52 @@ fun EmailSecretsUi(
                 .verticalScroll(rememberScrollState())
                 .padding(horizontal = 16.dp),
         ) {
+            // Mail-app settings first: this is what someone opening this screen while staring
+            // at a half-configured mail client is actually looking for. The credentials below
+            // are only useful once the server details are right.
+            uiState.clientSettings?.let { settings ->
+                SectionHeader(stringResource(MR.string.email_settings_title))
+                Text(
+                    text = stringResource(MR.string.email_settings_intro),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+
+                MailSettingsCard(
+                    title = stringResource(MR.string.email_settings_incoming),
+                    host = settings.incomingHost,
+                    port = settings.incomingPort,
+                    security = settings.incomingSocketType,
+                    username = settings.username,
+                    onCopy = copy,
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                MailSettingsCard(
+                    title = stringResource(MR.string.email_settings_outgoing),
+                    host = settings.outgoingHost,
+                    port = settings.outgoingPort,
+                    security = settings.outgoingSocketType,
+                    username = settings.username,
+                    onCopy = copy,
+                )
+
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = stringResource(MR.string.email_settings_password_hint),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                // Until the server has a trusted certificate, clients refuse to connect - and
+                // Thunderbird fails SILENTLY on the outgoing side, losing Sent copies. Saying
+                // so here costs a line and saves someone an evening.
+                Text(
+                    text = stringResource(MR.string.email_settings_cert_warning),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+
             SectionHeader(stringResource(MR.string.email_secrets_passwords))
 
             Text(
@@ -446,6 +502,65 @@ private fun KeyCard(
                 ) {
                     Text(stringResource(MR.string.email_secrets_copy_private_key))
                 }
+            }
+        }
+    }
+}
+
+
+/**
+ * One server's settings, each value copyable. Copy matters more than it looks: these are typed
+ * into a different application, often on a different device, and a mistyped hostname or the
+ * wrong port produces a hang rather than an error message.
+ */
+@Composable
+private fun MailSettingsCard(
+    title: String,
+    host: String,
+    port: Int,
+    security: String,
+    username: String,
+    onCopy: (String) -> Unit,
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
+    ) {
+        Column(modifier = Modifier.padding(12.dp)) {
+            Text(text = title, style = MaterialTheme.typography.titleSmall)
+            Spacer(modifier = Modifier.height(6.dp))
+            SettingRow(stringResource(MR.string.email_settings_server), host, onCopy)
+            SettingRow(stringResource(MR.string.email_settings_port), port.toString(), onCopy)
+            SettingRow(stringResource(MR.string.email_settings_security), security, null)
+            SettingRow(stringResource(MR.string.email_settings_username), username, onCopy)
+        }
+    }
+}
+
+/** A label/value pair. [onCopy] null for values nobody types, like "SSL". */
+@Composable
+private fun SettingRow(label: String, value: String, onCopy: ((String) -> Unit)?) {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(vertical = 2.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.width(84.dp),
+        )
+        Text(
+            text = value,
+            style = MaterialTheme.typography.bodyMedium,
+            modifier = Modifier.weight(1f),
+        )
+        if (onCopy != null) {
+            IconButton(onClick = { onCopy(value) }) {
+                Icon(
+                    imageVector = Icons.Outlined.ContentCopy,
+                    contentDescription = stringResource(MR.string.email_settings_server),
+                )
             }
         }
     }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/email/secrets/EmailSecretsScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/email/secrets/EmailSecretsScreen.kt
@@ -47,7 +47,19 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import id.homebase.core.clipboard.clipEntryOf
 import id.homebase.core.ui.screens.email.model.EmailCredential
 import id.homebase.core.ui.screens.email.model.EmailKeyRef
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.runtime.LaunchedEffect
+import id.homebase.core.util.getUriHandler
+import id.homebase.core.localization.TranslationUtil
+import kotlinx.io.files.Path
 import id.homebase.resources.MR
+import id.homebase.resources.email_secrets_key_save_failed
+import id.homebase.resources.email_secrets_key_saved
+import id.homebase.resources.email_secrets_save_private_key
+import id.homebase.resources.email_secrets_save_private_key_body
+import id.homebase.resources.email_secrets_save_private_key_confirm
+import id.homebase.resources.email_secrets_save_private_key_title
 import id.homebase.resources.email_settings_cert_warning
 import id.homebase.resources.email_settings_incoming
 import id.homebase.resources.email_settings_intro
@@ -94,7 +106,51 @@ fun EmailSecretsScreen(
     onBackClick: () -> Unit,
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
-    EmailSecretsUi(uiState = uiState, onAction = viewModel::onAction, onBackClick = onBackClick)
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    // The platform save lives here, not in the ViewModel: FileSystemHandler comes from
+    // getUriHandler(), a Composable accessor that is not in DI. The ViewModel writes the file
+    // and hands us the path; we give it to the OS and tell the ViewModel to drop the temp.
+    val fileSystemHandler = getUriHandler()
+    val scope = rememberCoroutineScope()
+
+    LaunchedEffect(viewModel) {
+        viewModel.events.collect { event ->
+            when (event) {
+                is EmailSecretsUiEvent.SaveKeyFile -> fileSystemHandler.saveFile(
+                    file = Path(event.path),
+                    suggestedName = event.suggestedName,
+                    onSuccess = { location ->
+                        viewModel.discardKeyFile(event.path)
+                        scope.launch {
+                            snackbarHostState.showSnackbar(
+                                TranslationUtil.getString(MR.string.email_secrets_key_saved, location)
+                            )
+                        }
+                    },
+                    onError = {
+                        viewModel.discardKeyFile(event.path)
+                        scope.launch {
+                            snackbarHostState.showSnackbar(
+                                TranslationUtil.getString(MR.string.email_secrets_key_save_failed)
+                            )
+                        }
+                    },
+                )
+
+                EmailSecretsUiEvent.KeySaveFailed -> snackbarHostState.showSnackbar(
+                    TranslationUtil.getString(MR.string.email_secrets_key_save_failed)
+                )
+            }
+        }
+    }
+
+    EmailSecretsUi(
+        uiState = uiState,
+        onAction = viewModel::onAction,
+        onBackClick = onBackClick,
+        snackbarHostState = snackbarHostState,
+    )
 }
 
 /**
@@ -111,9 +167,11 @@ fun EmailSecretsUi(
     uiState: EmailSecretsUiState,
     onAction: (EmailSecretsUiAction) -> Unit,
     onBackClick: () -> Unit,
+    snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
 ) {
     var confirmRevoke by remember { mutableStateOf<EmailCredential?>(null) }
     var confirmPrivateKey by remember { mutableStateOf<EmailKeyRef?>(null) }
+    var confirmSaveKey by remember { mutableStateOf<EmailKeyRef?>(null) }
     var confirmNewKey by remember { mutableStateOf(false) }
 
     val clipboard = LocalClipboard.current
@@ -121,6 +179,7 @@ fun EmailSecretsUi(
     val copy: (String) -> Unit = { text -> scope.launch { clipboard.setClipEntry(clipEntryOf(text)) } }
 
     Scaffold(
+        snackbarHost = { SnackbarHost(snackbarHostState) },
         topBar = {
             TopAppBar(
                 title = { Text(stringResource(MR.string.email_secrets_title)) },
@@ -220,6 +279,7 @@ fun EmailSecretsUi(
                     onCopyFingerprint = { copy(key.fingerprintHex) },
                     onCopyPublicKey = { copy(key.publicCertificateArmored) },
                     onCopyPrivateKey = { confirmPrivateKey = key },
+                    onSavePrivateKey = { confirmSaveKey = key },
                 )
                 Spacer(modifier = Modifier.height(8.dp))
             }
@@ -316,6 +376,30 @@ fun EmailSecretsUi(
     }
 
     // Not destructive, but it puts the key that opens all your mail on the clipboard.
+    // Saving asks separately from copying. Both hand over the private key, but a FILE persists
+    // on the device until someone deletes it, so the warning names that rather than reusing the
+    // clipboard wording.
+    confirmSaveKey?.let { key ->
+        AlertDialog(
+            onDismissRequest = { confirmSaveKey = null },
+            title = { Text(stringResource(MR.string.email_secrets_save_private_key_title)) },
+            text = { Text(stringResource(MR.string.email_secrets_save_private_key_body)) },
+            confirmButton = {
+                TextButton(onClick = {
+                    onAction(EmailSecretsUiAction.SavePrivateKey(key))
+                    confirmSaveKey = null
+                }) {
+                    Text(stringResource(MR.string.email_secrets_save_private_key_confirm))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { confirmSaveKey = null }) {
+                    Text(stringResource(MR.string.email_secrets_cancel))
+                }
+            },
+        )
+    }
+
     confirmPrivateKey?.let { key ->
         AlertDialog(
             onDismissRequest = { confirmPrivateKey = null },
@@ -449,6 +533,7 @@ private fun KeyCard(
     onCopyFingerprint: () -> Unit,
     onCopyPublicKey: () -> Unit,
     onCopyPrivateKey: () -> Unit,
+    onSavePrivateKey: () -> Unit,
 ) {
     Card(
         modifier = Modifier.fillMaxWidth(),
@@ -501,6 +586,14 @@ private fun KeyCard(
                     contentPadding = PaddingValues(horizontal = 8.dp, vertical = 4.dp),
                 ) {
                     Text(stringResource(MR.string.email_secrets_copy_private_key))
+                }
+                // Mail apps import a key from a FILE - clipboard is not an option in most of
+                // them, and on phones it is not an option at all.
+                TextButton(
+                    onClick = onSavePrivateKey,
+                    contentPadding = PaddingValues(horizontal = 8.dp, vertical = 4.dp),
+                ) {
+                    Text(stringResource(MR.string.email_secrets_save_private_key))
                 }
             }
         }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/email/secrets/EmailSecretsViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/email/secrets/EmailSecretsViewModel.kt
@@ -9,6 +9,11 @@ import id.homebase.core.ui.screens.email.EmailStream
 import id.homebase.core.ui.screens.email.model.EmailCredential
 import id.homebase.core.ui.screens.email.model.EmailKeyRef
 import id.homebase.api.client.mail.MailClientSettings
+import id.homebase.api.file.FileOperationsProvider
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.io.files.Path
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -29,6 +34,7 @@ class EmailSecretsViewModel(
     private val mailProvider: MailProvider,
     private val emailService: EmailService,
     private val emailStream: EmailStream,
+    private val fileOps: FileOperationsProvider,
 ) : ViewModel() {
 
     companion object {
@@ -41,6 +47,9 @@ class EmailSecretsViewModel(
     private val _revealed = MutableStateFlow<Set<String>>(emptySet())
     private val _busy = MutableStateFlow<Set<String>>(emptySet())
     private val _error = MutableStateFlow<String?>(null)
+
+    private val _events = MutableSharedFlow<EmailSecretsUiEvent>(extraBufferCapacity = 4)
+    val events: SharedFlow<EmailSecretsUiEvent> = _events.asSharedFlow()
 
     /**
      * Mail-app settings, from the server. Config-derived and free, so fetched once on entry
@@ -86,7 +95,50 @@ class EmailSecretsViewModel(
             is EmailSecretsUiAction.Revoke -> revoke(action.credential)
 
             EmailSecretsUiAction.ErrorDismissed -> _error.value = null
+
+            is EmailSecretsUiAction.SavePrivateKey -> savePrivateKey(action.key)
         }
+    }
+
+    /**
+     * Write the armored private key to a file and hand it to the platform's save flow.
+     *
+     * A file rather than the clipboard because that is what mail apps import - and on phones
+     * the clipboard is not an option at all.
+     *
+     * The temp is deleted as soon as the platform has taken it. It lives in the cache dir,
+     * which the CacheSweeper reaps anyway, but a private key sitting around waiting for a
+     * sweep is not a risk worth accepting for the sake of two lines.
+     */
+    private fun savePrivateKey(key: EmailKeyRef) {
+        viewModelScope.launch {
+            try {
+                val path = fileOps.writeBytesToTempFile(
+                    bytes = key.secretKeyArmored.encodeToByteArray(),
+                    prefix = "email-key",
+                    suffix = ".asc",
+                )
+                _events.tryEmit(
+                    EmailSecretsUiEvent.SaveKeyFile(
+                        path = path,
+                        suggestedName = "homebase-${key.userId ?: "key"}-private.asc",
+                    )
+                )
+            } catch (e: Exception) {
+                Logger.e(throwable = e, tag = TAG) { "writing private key file failed: ${e.message}" }
+                _events.tryEmit(EmailSecretsUiEvent.KeySaveFailed)
+            }
+        }
+    }
+
+    /**
+     * Drop the temp once the platform has taken it - or failed to.
+     *
+     * It lives in the cache dir, which the CacheSweeper reaps anyway, but a private key sitting
+     * on disk waiting for a sweep is not a risk worth accepting to save two lines.
+     */
+    fun discardKeyFile(path: String) {
+        fileOps.deleteTempFile(path)
     }
 
     /**
@@ -160,4 +212,21 @@ sealed interface EmailSecretsUiAction {
     data class ToggleReveal(val id: String) : EmailSecretsUiAction
     data class Revoke(val credential: EmailCredential) : EmailSecretsUiAction
     data object ErrorDismissed : EmailSecretsUiAction
+
+    /** Write the private key to a file the user can import into a mail app. */
+    data class SavePrivateKey(val key: EmailKeyRef) : EmailSecretsUiAction
+}
+
+sealed interface EmailSecretsUiEvent {
+    /**
+     * The key is written and ready to hand to the platform's save flow.
+     *
+     * The ViewModel writes the file but does NOT save it: saving needs a FileSystemHandler,
+     * which is a Composable accessor (getUriHandler()) and not in DI - injecting it here
+     * compiles and then fails at runtime. So the file lifecycle stays here and the platform
+     * interaction stays in the UI, which is the right split regardless.
+     */
+    data class SaveKeyFile(val path: String, val suggestedName: String) : EmailSecretsUiEvent
+
+    data object KeySaveFailed : EmailSecretsUiEvent
 }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/email/secrets/EmailSecretsViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/email/secrets/EmailSecretsViewModel.kt
@@ -8,6 +8,7 @@ import id.homebase.core.ui.screens.email.EmailService
 import id.homebase.core.ui.screens.email.EmailStream
 import id.homebase.core.ui.screens.email.model.EmailCredential
 import id.homebase.core.ui.screens.email.model.EmailKeyRef
+import id.homebase.api.client.mail.MailClientSettings
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -41,13 +42,28 @@ class EmailSecretsViewModel(
     private val _busy = MutableStateFlow<Set<String>>(emptySet())
     private val _error = MutableStateFlow<String?>(null)
 
+    /**
+     * Mail-app settings, from the server. Config-derived and free, so fetched once on entry
+     * rather than watched - unlike the credentials and keys above, nothing here changes while
+     * the screen is open.
+     */
+    private val _clientSettings = MutableStateFlow<MailClientSettings?>(null)
+
+    init {
+        viewModelScope.launch {
+            runCatching { mailProvider.getStatus().clientSettings }
+                .onSuccess { _clientSettings.value = it }
+                .onFailure { Logger.d(tag = TAG) { "mail client settings unavailable: ${it.message}" } }
+        }
+    }
+
     val uiState: StateFlow<EmailSecretsUiState> = combine(
         emailStream.credentials,
         emailStream.keys,
         emailStream.currentKeyFileId,
         _revealed,
-        combine(_busy, _error) { busy, error -> busy to error },
-    ) { credentials, keys, currentKey, revealed, (busy, error) ->
+        combine(_busy, _error, _clientSettings) { busy, error, settings -> Triple(busy, error, settings) },
+    ) { credentials, keys, currentKey, revealed, (busy, error, settings) ->
         EmailSecretsUiState(
             credentials = credentials,
             keys = keys,
@@ -55,6 +71,7 @@ class EmailSecretsViewModel(
             revealedIds = revealed,
             busyIds = busy,
             error = error,
+            clientSettings = settings,
         )
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), EmailSecretsUiState())
 
@@ -131,6 +148,8 @@ data class EmailSecretsUiState(
     /** Which secrets the user has asked to see right now. */
     val revealedIds: Set<String> = emptySet(),
     val busyIds: Set<String> = emptySet(),
+    /** Null while loading, or when this host publishes no mail hosts. */
+    val clientSettings: MailClientSettings? = null,
     val error: String? = null,
 )
 


### PR DESCRIPTION
Two things the Email Secrets screen was missing for anyone setting up a real mail client.

Pairs with **odin-core #1689** for the first half.

## 1. Mail app settings

Setting up a client that has no autoconfig support means knowing hostnames, ports, encryption and username. The server has always published them as autoconfig XML — the app had no way to show them.

They come from the **same definition that produces the autoconfig XML**, so the screen and a self-configuring client cannot end up describing different servers.

Two cards — Incoming (IMAP) and Outgoing (SMTP) — placed **above** the app passwords, because someone opening this screen while staring at a half-configured mail client wants the server details first. Every value that gets typed elsewhere is copyable; `SSL` isn't, since nobody types it.

Two notes rendered on screen rather than left to be rediscovered:

- **The same app password works for both directions.** People assume outgoing needs its own.
- **A certificate exception may be needed on first connect.** Until the server has a trusted certificate, clients refuse it — and Thunderbird fails *silently* on the outgoing side, sending mail successfully while quietly never saving a Sent copy. That cost an evening; one line prevents the next one.

## 2. Save the private key to a file

Mail apps import an OpenPGP key from a **file**. Copy-to-clipboard was the only way to get the private key out, and most mail clients can't accept a key that way — on phones, none can.

Asks separately from copying. Both hand over the private key, but a file **persists on the device** until someone deletes it, so the warning says that rather than reusing the clipboard wording.

Saved as `homebase-<address>-private.asc` — `.asc` is what clients expect for an armored key, and the address makes it obvious which identity it belongs to. The snackbar reports **where** it landed ("Downloads", "Files", …) and reminds the user to delete it once imported: a key whose location they can't find is a key they can't delete.

### One thing worth reviewing

The ViewModel writes the file; the **screen** performs the platform save. That isn't stylistic — `FileSystemHandler` comes from `getUriHandler()`, a Composable accessor that is **not registered in DI**. Injecting it into the ViewModel compiled cleanly and would have failed at runtime the moment the screen opened. Caught by checking the Koin modules, not by the compiler.

The temp is deleted as soon as the platform takes it, on success *and* failure.

## Verification

`homebase-api`, `homebase-common`, `homebase-core` and `homebase-chat` `jvmTest` all pass, plus the `wasmJs` compile.

The serialization guard is the test worth reading: `ignoreUnknownKeys` is on, so a field named differently from the server's reads as `""` or `0` — and the screen would then tell someone to connect to an empty hostname on port zero, with nothing erroring anywhere.

**Not yet seen on a device.** The settings only render once #1689 is deployed (the field is absent until then, which correctly renders nothing), and the save flow differs per platform — worth exercising on Android and desktop before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EcPf3xgN4BoFfMkgmqgrxG