### PR TITLE
Log out when the server has invalidated this device's client token

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/websockets/WebSocketUpgradeAuth.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/websockets/WebSocketUpgradeAuth.kt
@@ -1,0 +1,18 @@
+package id.homebase.api.client.websockets
+
+// Ktor's WebSocketException carries no status code — a rejected upgrade survives only as the
+// message "Handshake exception, expected status code 101 but was 401" (WebSockets.kt:233).
+// OkHttp and Darwin both special-case 401 so it reaches us as that exception rather than a raw
+// engine error; CIO produces it for any non-101. WebSocketUpgradeAuthTest pins the wording, so a
+// Ktor upgrade that reworded it fails the build instead of silently disabling the logout.
+private const val UPGRADE_401_MARKER = "but was 401"
+
+fun Throwable.isWebSocketUpgradeUnauthorized(): Boolean {
+    val seen = HashSet<Throwable>()
+    var cur: Throwable? = this
+    while (cur != null && seen.add(cur)) {
+        if (cur.message?.contains(UPGRADE_401_MARKER) == true) return true
+        cur = cur.cause
+    }
+    return false
+}

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/auth/AuthConnectionCoordinator.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/auth/AuthConnectionCoordinator.kt
@@ -9,6 +9,7 @@ import id.homebase.api.client.eventbus.BackendEvent
 import id.homebase.api.client.eventbus.EventBus
 import id.homebase.api.client.peer.PeerWebSocketManager
 import id.homebase.api.client.websockets.OdinWebSocketClient
+import id.homebase.api.client.websockets.isWebSocketUpgradeUnauthorized
 import id.homebase.api.common.OdinId
 import id.homebase.api.common.time.UnixTimeUtc
 import id.homebase.api.diagnostics.BgTrace
@@ -96,6 +97,21 @@ class AuthConnectionCoordinator(
         }
     )
     private var wsClient: OdinWebSocketClient? = null
+
+    // #1349 dead-token detection. The server rejects the notify-WS upgrade with 401 once this
+    // device's app registration is revoked, but the reconnect loop treats that like any other
+    // drop and retries every 5s forever, leaving authState == Authenticated with no way out.
+    // Count only CONSECUTIVE upgrade-401s: a successful connect or any other failure resets, so
+    // a one-off 401 (server hiccup, clock skew, token-refresh race) can never reach the
+    // threshold. Corroboration is DEAD_TOKEN_THRESHOLD separate server responses that each
+    // specifically said 401 to this token.
+    @Volatile
+    private var consecutiveUpgradeAuthFailures = 0
+
+    // logout() has no internal in-flight guard and wipes the DB, so two concurrent callers would
+    // each run a full wipe. 401s keep arriving during the ~seconds logout takes; this latches.
+    @Volatile
+    private var deadTokenLogoutStarted = false
 
     // #1109 background-transition tracking: the last foreground/background state we logged and when,
     // so setForeground() can emit the duration of the window that just ended. Seeded foreground=true
@@ -356,6 +372,11 @@ class AuthConnectionCoordinator(
             }
             is YouAuthState.Unauthenticated -> {
                 disconnect()
+                // Clear the drive snapshot that gates applyWsHold's authResolved check. Without
+                // this a foreground transition after logout rebuilds a WS with no credentials,
+                // whose connectOnce() returns false rather than throwing — so the reconnect loop
+                // backs off and retries "No active credentials" forever (#1349).
+                lastAuthenticatedDrives = null
                 // Reset the post-auth gate so the next login re-runs onPostAuthenticated().
                 postAuthGate.withLock { postAuthenticatedRan = false }
                 // The profile is loaded here on auth (loadProfile); clear it on the
@@ -548,6 +569,10 @@ class AuthConnectionCoordinator(
                         "AuthCC: onConnected fired for ${wsClient?.let { "WS[${it.instanceId}]" } ?: "null-wsClient"}"
                     }
                     _connectionState.update { it.copy(isConnected = true) }
+                    // Also clears the latch: a later session on this same process whose token
+                    // dies must be able to trigger the logout again.
+                    consecutiveUpgradeAuthFailures = 0
+                    deadTokenLogoutStarted = false
                     logLifecycleSnapshot("onConnected")
                     scope.launch {
                         try {
@@ -601,6 +626,11 @@ class AuthConnectionCoordinator(
                     outboxSync.setOnline(false)
                     _connectionState.update { it.copy(isConnected = false, isConnecting = false) }
                     logLifecycleSnapshot("onConnectError")
+                    consecutiveUpgradeAuthFailures =
+                        nextUpgradeAuthFailureCount(consecutiveUpgradeAuthFailures, e)
+                    if (consecutiveUpgradeAuthFailures >= DEAD_TOKEN_THRESHOLD) {
+                        startDeadTokenLogout()
+                    }
                 }
             ).also {
                 Logger.i(tag = "AuthLifecycle") { "AuthCC: WS[${it.instanceId}] created, start() invoked" }
@@ -932,10 +962,54 @@ class AuthConnectionCoordinator(
     }
 
 
+    /**
+     * #1349: the client token is dead — the registration was revoked server-side. Tear the session
+     * down through the normal logout path, so `authState` flips to Unauthenticated and AppNavHost
+     * routes to Login. `force = true` skips the server-side logout notify, which would only 401 too.
+     *
+     * Deliberately NOT a 403 path: a 403 means one drive's ACL was revoked and is already handled
+     * per-drive by DriveSync (unmount for the session). Only a 401 means the whole token is void.
+     */
+    private fun startDeadTokenLogout() {
+        if (deadTokenLogoutStarted) return
+        deadTokenLogoutStarted = true
+        Logger.w(tag = "AuthLifecycle") { "AuthCC: client token is dead — logging out" }
+        // Main, not this scope's default dispatcher. logout() flips authState, and
+        // AuthConnectionCoordinator then closes the Koin identity scope; AppNavHost's body
+        // resolves identity-scoped ViewModels unconditionally (outside its isAuthenticated
+        // gate), so a recomposition landing between the flip and the close resolves from a
+        // closed scope and dies on main. Every existing caller (SettingsViewModel, the dev
+        // menu) already logs out from viewModelScope — Main.immediate — which orders the flip
+        // and the teardown against composition. Match that or reproduce the crash (#1349).
+        scope.launch(Dispatchers.Main.immediate) {
+            try {
+                youAuthFlowManager.logout(force = true)
+            } catch (e: Exception) {
+                deadTokenLogoutStarted = false
+                Logger.e(throwable = e, tag = "AuthLifecycle") { "AuthCC: dead-token logout failed" }
+            }
+        }
+    }
+
     companion object {
         private const val REFRESH_DEBOUNCE_MS = 500L
     }
 }
+
+/**
+ * #1349: how many consecutive WS-upgrade 401s mean the client token is dead rather than a one-off
+ * server hiccup. Each one is a separate server response that specifically rejected this token.
+ */
+internal const val DEAD_TOKEN_THRESHOLD = 3
+
+/**
+ * The consecutive WS-upgrade-401 count after a connect attempt failed with [error]. Only an upgrade
+ * 401 advances the count; every other failure resets it, and a successful connect resets it at the
+ * call site — so a single transient 401 can never reach [DEAD_TOKEN_THRESHOLD]. Pure so the
+ * spurious-logout guard is unit-tested directly.
+ */
+internal fun nextUpgradeAuthFailureCount(previous: Int, error: Throwable): Int =
+    if (error.isWebSocketUpgradeUnauthorized()) previous + 1 else 0
 
 // Match compareStringUuId's normalization so drive ids compare regardless of hyphen/case format.
 internal fun normalizeDriveId(driveId: String): String = driveId.lowercase().replace("-", "")

--- a/homebase-common/src/jvmTest/kotlin/id/homebase/core/auth/DeadTokenLogoutTest.kt
+++ b/homebase-common/src/jvmTest/kotlin/id/homebase/core/auth/DeadTokenLogoutTest.kt
@@ -1,0 +1,84 @@
+package id.homebase.core.auth
+
+import id.homebase.api.client.websockets.isWebSocketUpgradeUnauthorized
+import io.ktor.client.plugins.websocket.WebSocketException
+import java.io.IOException
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+// The exact message Ktor 3.4.3 builds at WebSockets.kt:233, captured from a real revoked
+// registration on a physical Android device (#1349). If a Ktor upgrade rewords this, these tests
+// fail — which is the point: the dead-token logout is driven entirely off this string.
+private const val REAL_UPGRADE_401 =
+    "Handshake exception, expected status code 101 but was 401"
+
+class DeadTokenLogoutTest {
+
+    @Test
+    fun `detects the real Ktor upgrade 401`() {
+        assertTrue(WebSocketException(REAL_UPGRADE_401).isWebSocketUpgradeUnauthorized())
+    }
+
+    @Test
+    fun `does not match the 101 in the same message`() {
+        assertFalse(
+            WebSocketException("Handshake exception, expected status code 101 but was 403")
+                .isWebSocketUpgradeUnauthorized()
+        )
+    }
+
+    @Test
+    fun `does not match transient transport failures`() {
+        assertFalse(IOException("Connection reset").isWebSocketUpgradeUnauthorized())
+        assertFalse(IOException("Software caused connection abort").isWebSocketUpgradeUnauthorized())
+        assertFalse(WebSocketException("Handshake exception, expected status code 101 but was 502")
+            .isWebSocketUpgradeUnauthorized())
+    }
+
+    @Test
+    fun `unwraps a wrapped cause`() {
+        val wrapped = IllegalStateException("connect failed", WebSocketException(REAL_UPGRADE_401))
+        assertTrue(wrapped.isWebSocketUpgradeUnauthorized())
+    }
+
+    // The cause walk mirrors isTransientNetworkFailure's guarded shape. Without the visited set
+    // this test hangs rather than fails.
+    @Test
+    fun `survives a cyclic cause chain`() {
+        assertFalse(CyclicThrowable().isWebSocketUpgradeUnauthorized())
+    }
+
+    @Test
+    fun `consecutive upgrade 401s advance the count to the threshold`() {
+        var count = 0
+        repeat(DEAD_TOKEN_THRESHOLD) {
+            count = nextUpgradeAuthFailureCount(count, WebSocketException(REAL_UPGRADE_401))
+        }
+        assertEquals(DEAD_TOKEN_THRESHOLD, count)
+    }
+
+    // The acceptance criterion: a single transient 401 must not nuke a valid session.
+    @Test
+    fun `a one-off 401 followed by a transport failure never reaches the threshold`() {
+        var count = 0
+        repeat(10) {
+            count = nextUpgradeAuthFailureCount(count, WebSocketException(REAL_UPGRADE_401))
+            count = nextUpgradeAuthFailureCount(count, IOException("Connection reset"))
+            assertTrue(count < DEAD_TOKEN_THRESHOLD, "transient churn must not log out")
+        }
+    }
+
+    @Test
+    fun `a non-401 failure resets a partial streak`() {
+        var count = nextUpgradeAuthFailureCount(0, WebSocketException(REAL_UPGRADE_401))
+        count = nextUpgradeAuthFailureCount(count, WebSocketException(REAL_UPGRADE_401))
+        assertEquals(2, count)
+        assertEquals(0, nextUpgradeAuthFailureCount(count, IOException("Connection reset")))
+    }
+}
+
+private class CyclicThrowable : RuntimeException("boom") {
+    override val cause: Throwable get() = this
+}


### PR DESCRIPTION
Closes #1349.

## Step 1 — reproduced first, and the issue's hypothesis was wrong

Reproduced on a Redmi Note 5 Pro (Android 11) with a real owner-console revoke of the debug build's registration. The issue suspected a crash loop. **There is no crash** — the app is worse than that: it is permanently and silently stuck in a false "logged in" state.

```
E WebSocket: WS[2] connect loop caught exception:
  Handshake exception, expected status code 101 but was 401
io.ktor.client.plugins.websocket.WebSocketException: ...but was 401
    at io.ktor.client.plugins.websocket.WebSockets$Plugin$install$2.invokeSuspend(WebSockets.kt:233)
W WebSocket: WS[2] disconnected, retrying in 5000ms

I AuthLifecycle: AuthCC: SNAPSHOT[onConnectError] authState=Authenticated
  isConnecting=false isConnected=false dsmRunning=true
  driveStatuses={...all 9 drives: Completed}
```

64 handshake 401s and 40+ `UnauthorizedException`s in one window, zero new crash tombstones, same PID throughout, and a clean cold start straight back into the same state.

| Issue's claim | Reality |
|---|---|
| "only 2 scopes carry a `CoroutineExceptionHandler`; an unwrapped throw is fatal" | Inaccurate. `supervisedScope()` (`CoroutineExceptionHandlers.kt:52-56`) bakes one into 11 more scopes. The sync engine, outbox, and own-identity WS are all protected — which is exactly why it churns instead of crashing. |
| "crashes in an endless loop" | No crash. `Process.killProcess` is never reached. |
| WS reconnect-loops forever | Confirmed — steady 5s cadence, indefinitely. |
| No 401→logout path | Confirmed. `UnauthorizedException` has two references in the whole tree: its declaration and its throw site (`OdinApiProviderBase.kt:543`). |

## The fix

Count **consecutive** WS upgrade-401s in `AuthConnectionCoordinator.onConnectError` and log out at three via `youAuthFlowManager.logout(force = true)`.

`force = true` matters: the non-forced path calls `POST /auth/logout` first, which would itself 401 — a dead token would fail its own logout.

### Corroboration is repetition, not a second endpoint

The issue suggested verifying with `YouAuthProvider.hasValidToken()`. **That function is a booby trap and must not be used as-is**: it calls `httpClient.get(".../verifytoken")` with no `bearerAuth`, and `HttpClientProvider` installs no `Auth` plugin — so it returns `false` unconditionally and would log out every user on the first call. It has zero callers, which is the only reason nobody has been bitten.

Three consecutive upgrade-401s are already three separate server responses that each specifically rejected this token — same evidentiary strength, no new network code. Any success or non-401 failure resets the count:

| Scenario | What the WS throws | Counter |
|---|---|---|
| Offline / airplane mode | `UnknownHostException` | reset to 0 |
| Server down | `ConnectException` / timeout | reset to 0 |
| 502/503 (deploy, proxy restart) | `WebSocketException("…but was 502")` or raw `ProtocolException` | reset to 0 |
| TLS failure, captive portal | `SSLHandshakeException` | reset to 0 |
| **Token revoked** | `WebSocketException("…but was 401")` ×3 | fires |

An offline device can never trip it, and the logout itself needs no network.

### Two supporting fixes, both required to reach a genuinely quiet logged-out state

**Clear `lastAuthenticatedDrives` on `Unauthenticated`.** It gates `applyWsHold`'s `authResolved` check and was never cleared, so a foreground transition after logout rebuilt a WS with no credentials — and `connectOnce()` *returns false* rather than throwing, so the loop backed off and retried `"No active credentials"` forever at the 5s ceiling. Pre-existing; manual logout hits it too.

**Run the logout on `Dispatchers.Main.immediate`.** `logout()` flips `authState`, which makes this class close the Koin identity scope; `AppNavHost`'s body resolves five identity-scoped ViewModels *outside* its `isAuthenticated` gate. Off the main dispatcher a recomposition lands between the flip and the close and dies:

```
FATAL EXCEPTION: main
java.lang.IllegalStateException: Can't get Koin scope. Scope '['identity:…']' is closed
	at org.koin.compose.KoinApplicationKt.currentKoinScope(KoinApplication.kt:113)
	at id.homebase.core.ui.navigation.AppNavHostKt.AppNavHost(AppNavHost.kt:…)
```

Both existing callers already log out from `viewModelScope` (`Main.immediate`), so this matches an invariant the codebase already relies on — it is not a delay or a swallowed exception. The underlying gap (ungated resolutions in `AppNavHost`) is filed as #1373.

## Ktor coupling, and why it fails loudly

`WebSocketException` carries no status — the 401 survives only inside the message. OkHttp and Darwin both special-case 401 (KTOR-7363) so it arrives as that exception rather than a raw engine error the way 403/500 do; CIO produces it for any non-101. `DeadTokenLogoutTest` pins the exact wording captured on-device, so a Ktor upgrade that reworded it fails the build instead of silently disabling the logout.

## Verification

Unit — 8 tests in `DeadTokenLogoutTest`, covering the real Ktor message, non-matching of the `101`/`403`/`502` variants, wrapped and cyclic cause chains, and the threshold behaviour (including a 10-round transient-churn loop that must never log out). `WebSocketHoldPolicyTest:59` already covered the hold-policy half.

Builds — `homebase-api` + `homebase-common` JVM suites green; compiles on JVM, Android, iosSimulatorArm64, wasmJs.

Device, on a real revoke:
- Logout fires after 3 consecutive 401s → `onAuthStateChanged(Unauthenticated)` → `disconnect() end (wsClient nulled)` → `SessionEnded` → login screen.
- Process survives (same PID before/after), 0 `FATAL EXCEPTION`, 0 Koin ISE, no new tombstone.
- WS goes quiet after logout — no rebuilt client, 0 `"cannot connect"` lines.
- 60s in airplane mode: 5 × `UnknownHostException`, 0 logouts. Reconnects cleanly on restore.
- Re-login on the same process works, confirming the latch reset.

## Not included

- `OutboxFailureClassifier` has no 401 case, so a 401 burns the ~48h retry budget. Irrelevant here — `logout()` calls `clearStorage()` → `wipeAndRecreate()`, which destroys the outbox table, so those rows never survive to retry.
- 403 handling untouched: a revoked drive ACL still unmounts that one drive for the session.