### PR TITLE
Stop the Desktop save dialog crashing the app on cancel

### DIFF
--- a/homebase-common/src/jvmMain/kotlin/id/homebase/core/util/FileUtilities.jvm.kt
+++ b/homebase-common/src/jvmMain/kotlin/id/homebase/core/util/FileUtilities.jvm.kt
@@ -81,39 +81,41 @@ actual fun getUriHandler(): FileSystemHandler {
             onSuccess: (String) -> Unit,
             onError: (Throwable) -> Unit,
         ) {
-            try {
-                var chosenDir: String? = null
-                var chosenName: String? = null
-
-                val runDialog = Runnable {
+            // Must stay detached: callers reach us from a Compose effect dispatched on
+            // FlushCoroutineDispatcher (= the EDT), and a modal FileDialog's nested AWT loop
+            // re-enters Compose's per-frame flush from inside that dispatch, which is fatal.
+            javax.swing.SwingUtilities.invokeLater {
+                val dir: String
+                val name: String
+                try {
                     val parent = java.awt.Frame.getFrames().firstOrNull { it.isShowing }
                     val dialog = java.awt.FileDialog(parent, "Save File", java.awt.FileDialog.SAVE)
                     dialog.file = suggestedName
                     dialog.isVisible = true
-                    chosenDir = dialog.directory
-                    chosenName = dialog.file
+                    dir = dialog.directory ?: return@invokeLater
+                    name = dialog.file ?: return@invokeLater
+                } catch (e: Exception) {
+                    Logger.e(throwable = e, tag = TAG) { "Failed to show save dialog: ${e.message}" }
+                    onError(e)
+                    return@invokeLater
                 }
 
-                if (javax.swing.SwingUtilities.isEventDispatchThread()) {
-                    runDialog.run()
-                } else {
-                    javax.swing.SwingUtilities.invokeAndWait(runDialog)
-                }
-
-                val dir = chosenDir ?: return
-                val name = chosenName ?: return
-                val dest = java.io.File(dir, name)
-                java.io.File(file.toString()).copyTo(dest, overwrite = true)
-                onSuccess(dest.absolutePath)
-                if (Desktop.isDesktopSupported()) {
-                    val desktop = Desktop.getDesktop()
-                    if (desktop.isSupported(Desktop.Action.BROWSE_FILE_DIR)) {
-                        desktop.browseFileDirectory(dest)
+                Thread({
+                    try {
+                        val dest = java.io.File(dir, name)
+                        java.io.File(file.toString()).copyTo(dest, overwrite = true)
+                        onSuccess(dest.absolutePath)
+                        if (Desktop.isDesktopSupported()) {
+                            val desktop = Desktop.getDesktop()
+                            if (desktop.isSupported(Desktop.Action.BROWSE_FILE_DIR)) {
+                                desktop.browseFileDirectory(dest)
+                            }
+                        }
+                    } catch (e: Exception) {
+                        Logger.e(throwable = e, tag = TAG) { "Failed to save file: ${e.message}" }
+                        onError(e)
                     }
-                }
-            } catch (e: Exception) {
-                Logger.e(throwable = e, tag = TAG) { "Failed to save file: ${e.message}" }
-                onError(e)
+                }, "homebase-save-file").apply { isDaemon = true }.start()
             }
         }
 


### PR DESCRIPTION
Fixes #1382

## Root cause

`FileUtilities.jvm.kt`'s `saveFile()` showed a **modal** `java.awt.FileDialog` **synchronously** when it was already on the EDT:

```kotlin
if (SwingUtilities.isEventDispatchThread()) {
    runDialog.run()          // runs INLINE inside the current EDT dispatch
} else {
    SwingUtilities.invokeAndWait(runDialog)
}
```

All six callers reach it from a Compose `LaunchedEffect` event collector, and those continuations dispatch on Compose Desktop's `FlushCoroutineDispatcher` — which **is** the EDT. So the modal's nested AWT event loop was pumped *inside* a coroutine continuation's dispatch, on a stack that was already inside Compose's per-frame machinery.

The re-entrancy is what kills the app. `FlushCoroutineDispatcher.flush()` runs pending `DispatchedTask`s out of `immediateTasksSwap` while holding a **reentrant** `synchronized(runLock)`, and `BaseComposeScene.render()` calls it every frame via `ComposeSceneRecomposer.performScheduledEffects()`. Anything that renders a frame from inside the nested modal loop therefore re-enters `render()`/`flush()` on a stack already inside them. Cancel isn't special — it's just where the corrupted state resumes.

## The fix

Show the chooser from a fully detached `SwingUtilities.invokeLater { … }`, so `saveFile` returns immediately and the modal's nested loop runs on a later, fresh EDT event rather than inside the continuation. The outcome still comes back through the existing `onSuccess`/`onError` callbacks (every call site wraps them in `scope.launch { … }`, which is safe from any thread).

Two other things fixed along the way:

- **Cancel is a silent no-op** — `dialog.directory`/`dialog.file` are null, we return without firing either callback, so no snackbar.
- **The copy is off the EDT.** `File.copyTo` of a video on the EDT would freeze the UI. The copy and the `Desktop.browseFileDirectory` reveal now run on a short-lived daemon thread; the `try/catch → onError` behaviour is unchanged.

No new dependency — this is a few lines of AWT, not a reason to pull FileKit into `homebase-common`.

## Evidence

A throwaway standalone Compose Desktop harness (Kotlin 2.3.21 / Compose 1.10.3 / coroutines 1.10.2, matching the version catalog) reproduced the defect headed on macOS, driving the native save panel's Cancel with `osascript` Escape. It ran a verbatim copy of the old `saveFile` and the new one behind a flag, from a `LaunchedEffect` collector, with the collector instrumented to confirm it really was executing inside `flush()`.

**Old path — the collector is inside `flush()` when it shows the dialog, and the modal's nested AWT loop runs on top of it:**

```
at java.desktop/java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:124)
at java.desktop/java.awt.WaitDispatchSupport.enter(WaitDispatchSupport.java:234)
at java.desktop/java.awt.Dialog.show(Dialog.java:1080)              <- nested AWT event loop
at java.desktop/java.awt.Dialog.setVisible(Dialog.java:1016)
at ReproKt.saveFileOld(Repro.kt:59)
at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:100)
at androidx.compose.ui.platform.FlushCoroutineDispatcher.flush$lambda$0(FlushCoroutineDispatcher.skiko.kt:96)
at androidx.compose.ui.platform.FlushCoroutineDispatcher.performRun(FlushCoroutineDispatcher.skiko.kt:105)
at androidx.compose.ui.platform.FlushCoroutineDispatcher.flush(FlushCoroutineDispatcher.skiko.kt:83)
at androidx.compose.ui.scene.ComposeSceneRecomposer.performScheduledEffects(ComposeSceneRecomposer.skiko.kt:91)
at androidx.compose.ui.scene.BaseComposeScene.render(BaseComposeScene.skiko.kt:176)
```

Once a frame renders from inside that nested loop, the app dies (reproduced twice, both runs identical):

```
UNCAUGHT EXCEPTION  Thread: AWT-EventQueue-0
java.lang.IllegalStateException: Reentry into ignoringRedrawRequests is not allowed
  at androidx.compose.ui.viewinterop.SwingInteropContainer.postponingExecutingScheduledUpdates(SwingInteropContainer.desktop.kt:285)
  at androidx.compose.ui.scene.ComposeSceneMediator.onRender(ComposeSceneMediator.desktop.kt:675)
  at org.jetbrains.skiko.redrawer.MetalRedrawer$FrameScheduler.updateIfRequested(MetalRedrawer.kt:193)
  ...
  at java.desktop/java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:124)   <- nested modal loop
  at java.desktop/java.awt.Dialog.show(Dialog.java:1080)
  at ReproKt.saveFileOld(Repro.kt:59)
  at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:100)
  at androidx.compose.ui.platform.FlushCoroutineDispatcher.flush(FlushCoroutineDispatcher.skiko.kt:83)   <- outer flush
  at androidx.compose.ui.scene.BaseComposeScene.render(BaseComposeScene.skiko.kt:176)                    <- outer render
  Suppressed: kotlinx.coroutines.internal.DiagnosticCoroutineContextException: [StandaloneCoroutine{Cancelling}, SwingDispatcher]
```

**Note on the exception type.** The issue reports `CoroutinesInternalError` / `ClassCastException: CompletedContinuation cannot be cast to DispatchedContinuation` from `releaseInterceptedContinuation`. On Compose 1.10.3 (what `main` is on now) the reentrancy trips one guard earlier: `SwingInteropContainer.preventingRedrawRequests` has an explicit `check(needsRequestRedrawOnUpdateScheduled)` that fires before `flush()` can be re-entered and double-run the `DispatchedTask`. Same defect, same stack, same fatal outcome — the reporter's crash is what happens one guard deeper. I did not manufacture the exact `CoroutinesInternalError` text; what is above is what this machine actually produced.

**New path — same harness, same forced repaints, same cancel:**

```
[repro] spins=2 inFlush=true                                     <- collector still inside flush()
[repro] saveFile returned, collector still running               <- continuation completes before the dialog
[repro] PROBE#0..6 nestedPumpFrames=6 inFlush=false renderFrames=0   <- modal loop no longer inside flush()/render()
[repro] RESULT=NO_CRASH
```

Zero `onSuccess`/`onError` calls on cancel — the silent no-op required by the acceptance criteria.

**New path, actually saving** (driven with Return instead of Escape):

```
[repro] copy running on thread=repro-save EDT=false
[repro] wrote /Users/…/repro1382-out.pdf exists=true bytes=5
[repro] onSuccess: /Users/…/repro1382-out.pdf
[repro] RESULT=NO_CRASH
```

The harness was outside the repo and has been deleted.

## Acceptance criterion 4 — no other Desktop dialog has this defect

Audited the rest of `FileUtilities.jvm.kt`: `openFile` and `openFileBrowser` use `java.awt.Desktop` (`open` / `browseFileDirectory`), which hands off to the OS and is non-modal — no nested loop. `shareFile`/`shareText` are no-ops, `editFile`/`openAppStore` are `TODO()`. `openUrl` delegates to `BrowserUtils`. Nothing changed there.

Repo-wide there is one other `isEventDispatchThread()/invokeAndWait` pair, `CrashRecoveryDialog.showAndBlock`. It is deliberately blocking, is only reached from the uncaught-exception handler in `Main.kt`, and calls `exitProcess(1)` immediately after — there is no Compose continuation left to corrupt. Left alone.

## Verification

- `./gradlew :homebase-common:compileKotlinJvm` — green
- `./gradlew homebase-common:jvmTest` — green
- `./gradlew homebase-chat:jvmTest homebase-core:jvmTest` — green (the six `saveFile` call sites live in these modules)
