### PR TITLE
Sign and notarize the macOS desktop build with Developer ID

### DIFF
--- a/.github/workflows/build-desktop-release-prod.yml
+++ b/.github/workflows/build-desktop-release-prod.yml
@@ -74,25 +74,12 @@ jobs:
           echo "Updated version.properties:"
           cat gradle/version.properties         
 
-      - name: Build binaries
-        working-directory: ./desktopApp
-        run: ./gradlew clean createReleaseDistributable
-        env:
-          JDK_21: ${{ env.JAVA_HOME }}
-
       - name: Azure login (OIDC)
         uses: azure/login@v2
         with:
           client-id: ${{ secrets.AZURE_CODESIGN_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_CODESIGN_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_CODESIGN_SUBSCRIPTION_ID }}
-
-      - name: Fetch Azure code-signing access token
-        shell: bash
-        run: |
-          TOKEN=$(az account get-access-token --resource https://codesigning.azure.net --query accessToken -o tsv)
-          echo "::add-mask::$TOKEN"
-          echo "AZURE_ACCESS_TOKEN=$TOKEN" >> "$GITHUB_ENV"
 
       - name: Stage Apple signing material
         shell: bash
@@ -109,6 +96,20 @@ jobs:
           chmod 600 "$RUNNER_TEMP/apple"/*
           echo "APPLE_P12_PATH=$RUNNER_TEMP/apple/developerid.p12" >> "$GITHUB_ENV"
           echo "APPLE_NOTARIZATION_KEY=$RUNNER_TEMP/apple/AuthKey_$APPSTORE_API_KEY_ID.p8" >> "$GITHUB_ENV"
+
+      - name: Build binaries
+        working-directory: ./desktopApp
+        run: ./gradlew clean createReleaseDistributable
+        env:
+          JDK_21: ${{ env.JAVA_HOME }}
+
+      # Deliberately after the build: the token is short-lived.
+      - name: Fetch Azure code-signing access token
+        shell: bash
+        run: |
+          TOKEN=$(az account get-access-token --resource https://codesigning.azure.net --query accessToken -o tsv)
+          echo "::add-mask::$TOKEN"
+          echo "AZURE_ACCESS_TOKEN=$TOKEN" >> "$GITHUB_ENV"
 
       - name: Run Conveyor
         working-directory: ./desktopApp

--- a/.github/workflows/build-desktop-release-prod.yml
+++ b/.github/workflows/build-desktop-release-prod.yml
@@ -94,11 +94,30 @@ jobs:
           echo "::add-mask::$TOKEN"
           echo "AZURE_ACCESS_TOKEN=$TOKEN" >> "$GITHUB_ENV"
 
+      - name: Stage Apple signing material
+        shell: bash
+        env:
+          APPLE_SIGNING_KEY: ${{ secrets.APPLE_SIGNING_KEY }}
+          APPSTORE_API_KEY_ID: ${{ secrets.APPSTORE_API_KEY_ID }}
+          APPSTORE_API_PRIVATE_KEY: ${{ secrets.APPSTORE_API_PRIVATE_KEY }}
+        run: |
+          # Conveyor reads both of these from disk; neither can be passed inline.
+          mkdir -p "$RUNNER_TEMP/apple"
+          chmod 700 "$RUNNER_TEMP/apple"
+          printf '%s' "$APPLE_SIGNING_KEY" | base64 -d > "$RUNNER_TEMP/apple/developerid.p12"
+          printf '%s\n' "$APPSTORE_API_PRIVATE_KEY" > "$RUNNER_TEMP/apple/AuthKey_$APPSTORE_API_KEY_ID.p8"
+          chmod 600 "$RUNNER_TEMP/apple"/*
+          echo "APPLE_P12_PATH=$RUNNER_TEMP/apple/developerid.p12" >> "$GITHUB_ENV"
+          echo "APPLE_NOTARIZATION_KEY=$RUNNER_TEMP/apple/AuthKey_$APPSTORE_API_KEY_ID.p8" >> "$GITHUB_ENV"
+
       - name: Run Conveyor
         working-directory: ./desktopApp
         env:
           CONVEYOR_GITHUB_TOKEN: ${{ secrets.CONVEYOR_DESKTOP_DEV_GITHUB_TOKEN }}
           SIGNING_KEY: ${{ secrets.CONVEYOR_SIGNING_KEY }}
+          APPLE_SIGNING_KEY_PASS: ${{ secrets.APPLE_SIGNING_KEY_PASS }}
+          APPSTORE_API_ISSUER_ID: ${{ secrets.APPSTORE_API_ISSUER_ID }}
+          APPSTORE_API_KEY_ID: ${{ secrets.APPSTORE_API_KEY_ID }}
           CONVEYOR_AGREE_TO_LICENSE: 1
           JDK_21: ${{ env.JAVA_HOME }}
         shell: bash

--- a/desktopApp/conveyor_production.conf
+++ b/desktopApp/conveyor_production.conf
@@ -32,19 +32,17 @@ app {
   }
 
   mac {
+    certificate = ${env.APPLE_P12_PATH}
 
-     #deltas = 2
-     #certificate = ${env.APPLE_SIGNING_KEY}
+    signing-key.file = {
+      path = ${env.APPLE_P12_PATH}
+      password = ${env.APPLE_SIGNING_KEY_PASS}
+    }
 
-     #signing-key.file = {
-     #  path = ${env.APPLE_SIGNING_KEY}
-     #  password = ${env.APPLE_SIGNING_KEY_PASS}
-     #}
-
-     #notarization {
-     #   issuer-id = ${env.APPLE_SIGNING_ISSUER_ID}
-     #   key-id = ${env.APPLE_SIGNING_KEY_ID}
-     #   private-key = ${env.APPLE_NOTARIZATION_KEY}
-     #}
+    notarization {
+      issuer-id = ${env.APPSTORE_API_ISSUER_ID}
+      key-id = ${env.APPSTORE_API_KEY_ID}
+      private-key = ${env.APPLE_NOTARIZATION_KEY}
+    }
   }
 }


### PR DESCRIPTION
Follows the Windows signing work in #445. macOS builds were shipping unsigned, so Gatekeeper refused them with "cannot be opened because Apple cannot check it for malicious software."

- Signs with an Apple **Developer ID Application** certificate (`Vidence, LLC (Apps)`, team `JNJ85M8JM6`, G2 sub-CA, valid to 2031). This is Developer-ID distribution, not the Mac App Store — the existing `Apple Distribution` certificate used by the mobile workflows is a different type and cannot sign for outside-the-store distribution.
- Notarizes using the App Store Connect API key already stored for the mobile pipeline (`APPSTORE_API_*`), which holds the Admin role.
- A new step stages both credentials as files under `$RUNNER_TEMP`, because Conveyor reads the `.p12` and the `.p8` from disk and accepts neither inline.

Conveyor signs and notarizes macOS from Linux, so this stays on the existing `ubuntu-latest` job — no macOS runner and no workflow split.

New secrets: `APPLE_SIGNING_KEY` (base64 `.p12`, bundled with the Developer ID G2 intermediate so the chain is complete) and `APPLE_SIGNING_KEY_PASS`.

Note for release comms: as on Windows, the publisher identity changes, so existing macOS users are reinstalled and will need to sign in again. One time only.

Untested until dispatched — a successful run publishes a real production release.