### PR TITLE
Give the message and conversation lists a contentType

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
@@ -1155,6 +1155,27 @@ fun ConversationContent(
                                         else -> item.hashCode().toString()
                                     }
                                 },
+                                // One contentType per row shape, so scrolling reuses a recycled
+                                // item's composition instead of discarding and rebuilding it.
+                                // A 45 s device profile of an image-heavy thread (iPhone 15,
+                                // release K/N) put 44.8% of main-thread CPU in recomposition and
+                                // 35.4% in measure/layout, versus 1.14% for the placeholder blur
+                                // that #1370 suspected — reuse is the lever, not the blur.
+                                contentType = { item ->
+                                    when (item) {
+                                        is MessageListContentModel.Message -> "message"
+                                        is PendingOutgoingMessage -> "pending"
+                                        is MessageListContentModel.Section -> "section"
+                                        is MessageListContentModel.System -> "system"
+                                        is MessageListContentModel.Header -> "header"
+                                        is MessageListContentModel.UnreadSeparator -> "unread-separator"
+                                        // Both spinner rows render the same composable.
+                                        is MessageListContentModel.LoadingOlder,
+                                        is MessageListContentModel.LoadingNewer -> "loading"
+                                        is MessageListContentModel.LoadServerHistory -> "load-server-history"
+                                        else -> null
+                                    }
+                                },
                             ) { item ->
                                 when (item) {
                                     is MessageListContentModel.Header -> {

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationListPane.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationListPane.kt
@@ -487,6 +487,17 @@ fun ConversationListPane(
                                         is ConversationListContentModel.Header ->
                                             listItem.resource.key
                                     }
+                                },
+                                // Conversation rows, message-search hits and headers are three
+                                // different shapes; without a contentType the list tries to reuse
+                                // one as another and rebuilds the composition instead. See the
+                                // matching note on the message list in ConversationContent.kt.
+                                contentType = { listItem ->
+                                    when (listItem) {
+                                        is ConversationListContentModel.Conversation -> "conversation"
+                                        is ConversationListContentModel.Message -> "message"
+                                        is ConversationListContentModel.Header -> "header"
+                                    }
                                 }
                             ) { listItem ->
                                 ConversationLisContentItem(


### PR DESCRIPTION
Adds `contentType` to the two heterogeneous lazy lists in chat.

Both set `key` but no `contentType`. Omitting it doesn't disable reuse — it gives every row `null`, i.e. *the same* type — so `LazyColumn` hands a recycled header slot to a message bubble, fails to reuse it, and rebuilds the subtree. It only matters for heterogeneous lists:

| File | Row shapes |
|---|---|
| `ConversationContent.kt` | 9 — Message, Pending, Section, System, Header, UnreadSeparator, Loading×2, LoadServerHistory |
| `ConversationListPane.kt` | 3 — Conversation, Message, Header |

I checked ~20 other lazy lists in the codebase; the rest are homogeneous and would gain nothing, so they're untouched.

## Why

Fell out of investigating #1370, which suspected `Modifier.blur` on image placeholders was making iOS scrolling slow. Profiled on a physical **iPhone 15 (A16, iOS 26.6)** with a **release** Kotlin/Native framework (`iosApp Dev` scheme):

- **CPU** (Time Profiler, 45 s fling-scroll, 13,961 samples): Compose recomposition **44.8%** of main thread, measure/layout **35.4%**, Skia blur **1.14%**.
- **GPU** (Metal System Trace): app at **2.1%** utilisation; mean **2.72 ms**/frame, max **3.97 ms**; **zero** frames over even the 120 Hz budget of 8.33 ms.

The blur hypothesis is refuted from both sides. Full write-up in https://github.com/homebase-id/chat-kmp/issues/1370#issuecomment-5452074052.

## ⚠️ No performance claim attached

An A/B (rebuild, cold app restart, identical 45 s protocol) moved the recomposition share by ~5% relative — but the **unchanged** blur path moved **33%** between those same two runs. That's the run-to-run noise floor for hand-scrolled traces, and it's several times larger than the effect. The −13.5% drop in total main-thread CPU most plausibly just means the second scroll was less vigorous.

So this is **not** presented as a measured win. It's kept on correctness grounds: `contentType` is the documented Compose mechanism for exactly this situation, the change is behaviour-preserving, and it cannot make things worse. Quantifying it properly needs a deterministic scroll driver, or medians over 3–5 takes per side.

## Testing

`./gradlew homebase-chat:compileKotlinJvm homebase-chat:jvmTest --rerun-tasks` → **BUILD SUCCESSFUL, 1,222 tests, 0 failures**. Also built and ran on the physical device.

No unit test added: `contentType` is declarative render config with no observable return value outside the composable, so a test would assert the lambda against itself rather than any real behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
