### PR TITLE
Prune old desktop releases: keep 6 on prod, 3 on dev

### DIFF
--- a/.github/workflows/build-desktop-release-dev.yml
+++ b/.github/workflows/build-desktop-release-dev.yml
@@ -184,7 +184,7 @@ jobs:
           script: |
             const owner = 'homebase-id';
             const repo = 'chat-desktop-release-bleeding';
-            const KEEP = 6;
+            const KEEP = 3;
 
             const releases = await github.paginate(github.rest.repos.listReleases, {
               owner, repo, per_page: 100

--- a/.github/workflows/build-desktop-release-dev.yml
+++ b/.github/workflows/build-desktop-release-dev.yml
@@ -174,3 +174,47 @@ jobs:
             console.log(`\nRelease complete: ${release.html_url}`);
           
           
+      # Each release is ~1.6 GB and nothing else prunes them. Safe to delete:
+      # deltas come from the local .conveyor/cache, not from published releases,
+      # and installed apps resolve updates through releases/latest/download.
+      - name: Prune old releases in bleeding repo
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.CONVEYOR_DESKTOP_DEV_GITHUB_TOKEN }}
+          script: |
+            const owner = 'homebase-id';
+            const repo = 'chat-desktop-release-bleeding';
+            const KEEP = 6;
+
+            const releases = await github.paginate(github.rest.repos.listReleases, {
+              owner, repo, per_page: 100
+            });
+
+            // Every release tags the same commit, so created_at is identical across
+            // all of them and the API's default ordering is not meaningful here.
+            releases.sort((a, b) =>
+              Date.parse(b.published_at) - Date.parse(a.published_at) || b.id - a.id);
+
+            const stale = releases.slice(KEEP);
+            if (stale.length === 0) {
+              console.log(`${releases.length} release(s), keeping ${KEEP} — nothing to prune`);
+              return;
+            }
+
+            let freed = 0;
+            for (const release of stale) {
+              freed += release.assets.reduce((sum, a) => sum + a.size, 0);
+              await github.rest.repos.deleteRelease({ owner, repo, release_id: release.id });
+              // The create step makes a v-prefixed tag but publishes the release
+              // under the bare version, so both refs exist.
+              for (const tag of [release.tag_name, `v${release.tag_name}`]) {
+                try {
+                  await github.rest.git.deleteRef({ owner, repo, ref: `tags/${tag}` });
+                } catch (error) {
+                  console.log(`Could not delete tag ${tag}: ${error.message}`);
+                }
+              }
+              console.log(`Deleted release ${release.tag_name}`);
+            }
+
+            console.log(`Pruned ${stale.length} release(s), freed ${(freed / 1024 / 1024 / 1024).toFixed(2)} GB`);

--- a/.github/workflows/build-desktop-release-prod.yml
+++ b/.github/workflows/build-desktop-release-prod.yml
@@ -211,3 +211,48 @@ jobs:
             console.log(`\nRelease complete: ${release.html_url}`);
           
           
+
+      # Each release is ~1.6 GB and nothing else prunes them. Safe to delete:
+      # deltas come from the local .conveyor/cache, not from published releases,
+      # and installed apps resolve updates through releases/latest/download.
+      - name: Prune old releases in production repo
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.CONVEYOR_DESKTOP_DEV_GITHUB_TOKEN }}
+          script: |
+            const owner = 'homebase-id';
+            const repo = 'chat-desktop-release-production';
+            const KEEP = 6;
+
+            const releases = await github.paginate(github.rest.repos.listReleases, {
+              owner, repo, per_page: 100
+            });
+
+            // Every release tags the same commit, so created_at is identical across
+            // all of them and the API's default ordering is not meaningful here.
+            releases.sort((a, b) =>
+              Date.parse(b.published_at) - Date.parse(a.published_at) || b.id - a.id);
+
+            const stale = releases.slice(KEEP);
+            if (stale.length === 0) {
+              console.log(`${releases.length} release(s), keeping ${KEEP} — nothing to prune`);
+              return;
+            }
+
+            let freed = 0;
+            for (const release of stale) {
+              freed += release.assets.reduce((sum, a) => sum + a.size, 0);
+              await github.rest.repos.deleteRelease({ owner, repo, release_id: release.id });
+              // The create step makes a v-prefixed tag but publishes the release
+              // under the bare version, so both refs exist.
+              for (const tag of [release.tag_name, `v${release.tag_name}`]) {
+                try {
+                  await github.rest.git.deleteRef({ owner, repo, ref: `tags/${tag}` });
+                } catch (error) {
+                  console.log(`Could not delete tag ${tag}: ${error.message}`);
+                }
+              }
+              console.log(`Deleted release ${release.tag_name}`);
+            }
+
+            console.log(`Pruned ${stale.length} release(s), freed ${(freed / 1024 / 1024 / 1024).toFixed(2)} GB`);


### PR DESCRIPTION
Each desktop build publishes ~1.6 GB of Conveyor site output as release assets on
`chat-desktop-release-production` / `chat-desktop-release-bleeding`, and nothing ever
removed the old ones. Current state:

| repo | releases | total |
|---|---|---|
| `chat-desktop-release-production` | 13 | 20.2 GB |
| `chat-desktop-release-bleeding` | 12 | 18.4 GB |

This adds a `Prune old releases` step to the end of both desktop release workflows,
deleting everything past the newest N releases along with their tags. Prod keeps 6; the
dev channel keeps 3, since it builds more often and carries no rollback obligation.

| channel | keeps | first run deletes | steady state |
|---|---|---|---|
| production | 6 | 7 releases, 10.6 GB | ~10 GB |
| bleeding | 3 | 9 releases, 13.2 GB | ~5 GB |

### Why deleting old releases is safe

- **Deltas don't come from published releases.** Conveyor computes them from the local
  `.conveyor/cache` directory, which both workflows already persist across runs via the
  `conveyor-data-*` cache. Confirmed in the run log for 1.4.1520 — it built deltas from
  1513/1514/1515/1516/1519 with no fetch from the release repo.
- **Installed apps don't reference old releases.** `site.base-url` is
  `.../releases/latest/download`, which always resolves to the newest release, so an
  install on any version still finds its appcast and installer.
- What's lost is only the ability to manually download a build older than the window.

### Notes

- Sorts explicitly by `published_at` before slicing. Every release in these repos tags the
  same commit on the target repo's `main`, so `created_at` is identical across all of them
  and the API's default ordering isn't meaningful — worth not leaving to chance in a step
  that deletes things.
- Deletes both the bare `1.4.1520` tag the release uses and the `v1.4.1520` tag the create
  step separately makes; a missing ref is logged rather than fatal.
- Only runs after the release step succeeds, so a failed publish never prunes.

Longer term the better home for this is a static host (Cloudflare R2 behind a
`downloads.` domain, with lifecycle rules doing retention), but `site.base-url` is baked
into every installed app, so moving it needs an overlap period. This is the part that
works today with no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
