### PR TITLE
Fix desktop video crash from duplicate JNA on the classpath

### DIFF
--- a/desktopApp/build.gradle.kts
+++ b/desktopApp/build.gradle.kts
@@ -91,7 +91,12 @@ kotlin {
             }
             implementation(libs.sqlite.jdbc.crypt)
             implementation(libs.composenativetray)
-            implementation(libs.vlcj)
+            implementation(libs.vlcj.get().toString()) {
+                exclude(group = "net.java.dev.jna", module = "jna-jpms")
+                exclude(group = "net.java.dev.jna", module = "jna-platform-jpms")
+            }
+            implementation(libs.jna)
+            implementation(libs.jna.platform)
         }
 
         commonTest.dependencies {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,6 +27,7 @@ mp4parser = "1.9.39"
 androidx-pdf-viewer = "1.0.0-alpha18"
 pdfbox = "3.0.5"
 vlcj = "4.8.2"
+jna = "5.18.1"
 jetbrains-compose-material3 = "1.9.0"
 jetbrains-compose-material3-adaptive = "1.2.0"
 kotlinxHtmlJvm = "0.12.0"
@@ -151,6 +152,8 @@ ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx
 ktor-client-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }
 ktor-client-js = { module = "io.ktor:ktor-client-js", version.ref = "ktor" }
 vlcj = { module = "uk.co.caprica:vlcj", version.ref = "vlcj" }
+jna = { module = "net.java.dev.jna:jna", version.ref = "jna" }
+jna-platform = { module = "net.java.dev.jna:jna-platform", version.ref = "jna" }
 ktor-client-mock = { module = "io.ktor:ktor-client-mock", version.ref = "ktor" }
 ktor-client-encoding = { module = "io.ktor:ktor-client-encoding", version.ref = "ktor" }
 ktor-server-core = { module = "io.ktor:ktor-server-core", version.ref = "ktor" }

--- a/homebase-chat/build.gradle.kts
+++ b/homebase-chat/build.gradle.kts
@@ -123,7 +123,15 @@ kotlin {
         }
         jvmMain.dependencies {
             implementation(libs.ktor.client.cio)
-            implementation(libs.vlcj)
+            implementation(libs.vlcj.get().toString()) {
+                // jna-jpms is a second copy of com.sun.jna that Gradle cannot dedupe
+                // against jna; two versions leave Conveyor's native-library extraction
+                // with one libjnidispatch that mismatches whichever copy loads first.
+                exclude(group = "net.java.dev.jna", module = "jna-jpms")
+                exclude(group = "net.java.dev.jna", module = "jna-platform-jpms")
+            }
+            implementation(libs.jna)
+            implementation(libs.jna.platform)
         }
         // Uncomment when enabling the wasmJs target (post-pre-flight),
         // paired with the `wasmJs { browser() }` block above.

--- a/homebase-chat/src/jvmMain/kotlin/id/homebase/chat/widget/video/VideoPlayerSurface.jvm.kt
+++ b/homebase-chat/src/jvmMain/kotlin/id/homebase/chat/widget/video/VideoPlayerSurface.jvm.kt
@@ -25,6 +25,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
@@ -276,6 +277,14 @@ actual fun VideoPlayerSurface(
     }
 }
 
+// Discovery dlopens libvlccore; a broken or ABI-mismatched JNA raises UnsatisfiedLinkError,
+// an Error that would otherwise escape composition and kill the Compose render loop.
+private val vlcNativesAvailable: Boolean by lazy {
+    runCatching { NativeDiscovery().discover() }
+        .onFailure { Logger.e(tag = "VideoIO", throwable = it) { "libvlc discovery failed" } }
+        .getOrDefault(false)
+}
+
 @Composable
 internal fun VlcjPlayer(
     videoPath: String,
@@ -291,11 +300,17 @@ internal fun VlcjPlayer(
     onEnded: () -> Unit = {},
     replayToken: Int = 0,
 ) {
-    val vlcFound = remember { NativeDiscovery().discover() }
+    val vlcFound by produceState<Boolean?>(null) {
+        value = withContext(Dispatchers.IO) { vlcNativesAvailable }
+    }
 
-    if (!vlcFound) {
+    if (vlcFound != true) {
         Box(modifier, contentAlignment = Alignment.Center) {
-            Text(stringResource(MR.string.vlc_required))
+            if (vlcFound == null) {
+                CircularProgressIndicator()
+            } else {
+                Text(stringResource(MR.string.vlc_required))
+            }
         }
         return
     }


### PR DESCRIPTION
## What happened

Playing a video on the packaged macOS desktop app crashed the whole window:

```
java.lang.UnsatisfiedLinkError: Native library (com/sun/jna/darwin-aarch64/libjnidispatch.jnilib)
  not found in resource path (...)
    at com.sun.jna.Native.<clinit>(Native.java:221)
    at uk.co.caprica.vlcj.factory.discovery.strategy.OsxNativeDiscoveryStrategy.forceLoadLibVlcCore
    at id.homebase.chat.widget.video.VideoPlayerSurface_jvmKt.VlcjPlayer(VideoPlayerSurface.jvm.kt:294)
```

Two defects stacked.

### 1. Two copies of `com.sun.jna` ship in the app

```
vlcj:4.8.2 -> vlcj-natives:4.8.1 -> net.java.dev.jna:jna-jpms:5.12.1
                                 -> net.java.dev.jna:jna-platform-jpms:5.12.1
filekit-dialogs, wrywebview      -> net.java.dev.jna:jna:5.18.1
                                 -> net.java.dev.jna:jna-platform:5.18.1
```

`jna-jpms` is a different Maven coordinate carrying the same packages, so Gradle never dedupes it against `jna`. It sorts first on the packaged classpath, so `com.sun.jna.Native` resolves to **5.12.1** and demands native ABI **6.1.4**.

Meanwhile `conveyor_common.conf` sets `extract-native-libraries = true`. Conveyor strips `libjnidispatch.jnilib` out of *both* jars (the shipped jars retain only the AIX `.a` files) and leaves one extracted copy in `Contents/runtime/Contents/Home/lib` — the **5.18.1** one, ABI **7.0.2**.

Running the shipped bundle's own jars on its own classpath and `java.library.path` reproduces it deterministically:

```
java.lang.Error:
There is an incompatible JNA native library installed on this system
Expected: 6.1.4
Found:    7.0.2
```

And because the natives were stripped from the jars, JNA's last-resort classpath-extraction fallback can never recover — that is the `not found in resource path` message seen in the field.

### 2. The error escaped composition

`VlcjPlayer` called `NativeDiscovery().discover()` inline in a composable on `AWT-EventQueue-0`. The existing `if (!vlcFound)` fallback only handles `discover()` returning `false`; here it *threw* an `UnsatisfiedLinkError` — an `Error`, not an `Exception` — which blew through the Compose render loop to the crash screen.

## Changes

- **`gradle/libs.versions.toml`** — add `jna = "5.18.1"` plus `jna` / `jna-platform` entries.
- **`homebase-chat`, `desktopApp`** — exclude `jna-jpms` / `jna-platform-jpms` from `vlcj` and depend on `jna` / `jna-platform` directly, so one ABI ships. The KMP source-set blocks don't accept `implementation(provider) { … }`, so this uses the `libs.vlcj.get().toString()` idiom already used for the sqldelight driver exclusion.
- **`VideoPlayerSurface.jvm.kt`** — discovery moved to a file-level `lazy` wrapped in `runCatching` (catches `Throwable`) and resolved via `produceState` on `Dispatchers.IO` rather than running inline in composition. Tri-state: spinner while probing, `vlc_required` on failure, player on success.

## Verification

- `:desktopApp:jvmRuntimeClasspath` now resolves to `net.java.dev.jna:jna:5.18.1` and `jna-platform:5.18.1` only; no `jna-jpms`.
- Against the installed bundle's own files, with only jna 5.18.1 on the classpath and the same extracted 7.0.2 `libjnidispatch.jnilib`, `Native` initializes and completes a real native call (`POINTER_SIZE=8`). The pre-fix classpath fails with the ABI mismatch above.
- `:homebase-chat:jvmTest :homebase-common:jvmTest :desktopApp:jvmTest` pass; `:homebase-chat:compileKotlinJvm` and `:desktopApp:compileKotlinJvm` pass.

## Open points for the reviewer

- **One detail is unexplained.** The field crash took JNA's *not-found* branch; the shipped bits reproduce the *version-mismatch* branch. Same underlying defect, but I could not explain why `System.loadLibrary("jnidispatch")` failed outright in-process when `libMacTray.dylib` loads from that same directory via the same mechanism. Neither change depends on the answer — fix 1 removes the mismatch, fix 2 makes either variant non-fatal — but it is not a closed question.
- **`conveyor_common.conf` deliberately untouched.** Adding `jna.boot.library.path = <libpath>` would remove the dependence on `System.loadLibrary`'s `.jnilib` fallback entirely, which is exactly the unexplained part above. Conveyor is not installed on this machine, so the key placement could not be validated, and a bad key breaks the 25-minute signed release build. Worth a follow-up by someone who can run `conveyor make` locally.
- **Needs a packaged build to confirm end to end.** The failure only exists after Conveyor's native extraction, so `desktopApp:run` does not exercise it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)