### PR TITLE
Make optimistic rollback actually restore the local row

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/DriveMainIndexWrapper.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/DriveMainIndexWrapper.kt
@@ -232,6 +232,33 @@ class DriveMainIndexWrapper(
         }
     }
 
+    /**
+     * Undo one optimistic mutation, restoring [originalModified] rather than stamping
+     * past the stored value. Returns the number of rows changed: 0 means a host write
+     * landed after the optimistic one and correctly stands.
+     */
+    suspend fun rollbackOptimisticWrite(
+        identityId: Uuid,
+        driveId: Uuid,
+        fileId: Uuid,
+        fileState: Long,
+        archivalStatus: Long,
+        jsonHeader: String,
+        originalModified: Long,
+        optimisticModified: Long,
+    ): Long = databaseManager.withWriteValue {
+        delegate.rollbackOptimisticWrite(
+            fileState = fileState,
+            archivalStatus = archivalStatus,
+            jsonHeader = jsonHeader,
+            originalModified = originalModified,
+            identityId = identityId,
+            driveId = driveId,
+            fileId = fileId,
+            optimisticModified = optimisticModified,
+        ).value
+    }
+
     suspend fun upsertDriveMainIndex(
         identityId: Uuid,
         driveId: Uuid,

--- a/homebase-api/src/commonMain/sqldelight/id/homebase/api/sync/database/DriveMainIndex.sq
+++ b/homebase-api/src/commonMain/sqldelight/id/homebase/api/sync/database/DriveMainIndex.sq
@@ -90,6 +90,20 @@ SET uniqueId        = excluded.uniqueId,
     jsonHeader      = excluded.jsonHeader
 WHERE excluded.modified > DriveMainIndex.modified; -- Only update if the row is newer. Host guarantees it.
 
+-- Undo one optimistic mutation. `modified = :optimisticModified` is the load-bearing
+-- clause: it only fires while the row is still the optimistic write being undone, so a
+-- host write that landed in between changes 0 rows and correctly stands. Restoring
+-- :originalModified keeps the row at the server's real value, so a later host write
+-- carrying that value is not dropped by the guard above.
+rollbackOptimisticWrite:
+UPDATE DriveMainIndex
+SET fileState      = :fileState,
+    archivalStatus = :archivalStatus,
+    jsonHeader     = :jsonHeader,
+    modified       = :originalModified
+WHERE identityId = :identityId AND driveId = :driveId AND fileId = :fileId
+  AND modified = :optimisticModified;
+
 -- Select by identity and drive and file (get single row)
 selectByIdentityAndDriveAndFile:
 SELECT * FROM DriveMainIndex

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/outbox/OptimisticWriter.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/outbox/OptimisticWriter.kt
@@ -365,7 +365,7 @@ class OptimisticWriter(
             credentials.getIdentityId(), driveId, uid
         ) ?: throw IllegalStateException("no file by uid")
 
-        val lastModified = existingFile.fileMetadata.updated.addMilliseconds(1)
+        val lastModified = existingFile.optimisticStamp()
 
         val existing = existingFile.fileMetadata.localAppData
         val existingTags = existing?.tags.orEmpty()
@@ -504,7 +504,7 @@ class OptimisticWriter(
             credentials.getIdentityId(), driveId, uniqueId
         ) ?: return null
 
-        val lastModified = existingFile.fileMetadata.updated.addMilliseconds(1)
+        val lastModified = existingFile.optimisticStamp()
 
         val deletedFile = existingFile.copy(
             fileState = FileState.Deleted,
@@ -549,53 +549,52 @@ class OptimisticWriter(
         return existingFile
     }
 
-    /** Restores a file that was optimistically deleted. Call when the outbox enqueue fails. */
-    suspend fun rollbackWrite(driveId: Uuid, original: HomebaseFile) {
+    /**
+     * Restores a file that was optimistically mutated. Call when the outbox enqueue fails.
+     * Returns false when a host write landed after the optimistic one — that newer row
+     * stands and nothing is rolled back.
+     */
+    suspend fun rollbackWrite(driveId: Uuid, original: HomebaseFile): Boolean {
         val credentials = credentialsManager.requireActiveCredentials()
+        val identityId = credentials.getIdentityId()
         try {
-            val batch = listOf(restoredWithFreshTimestamp(credentials.getIdentityId(), driveId, original))
-            fileProcessor.baseUpsertEntryZapZap(
-                identityId = credentials.getIdentityId(),
+            val record =
+                fileProcessor.convertFileHeaderToDriveMainIndexRecord(identityId, driveId, original)
+            val restored = dbm.driveMainIndex.rollbackOptimisticWrite(
+                identityId = identityId,
                 driveId = driveId,
-                fileHeaders = batch,
-                cursor = null
-            )
+                fileId = record.fileId,
+                fileState = record.fileState,
+                archivalStatus = record.archivalStatus,
+                jsonHeader = record.jsonHeader,
+                originalModified = record.modified,
+                optimisticModified = original.optimisticStamp().milliseconds,
+            ) > 0L
+
+            if (!restored) {
+                Logger.w(tag = TAG) {
+                    "Optimistic rollback superseded for fileId=${original.fileId} — a newer write landed first"
+                }
+                return false
+            }
 
             eventBus.emit(
                 BackendEvent.DataEvent.BatchReceived(
                     driveId = driveId,
-                    batchData = batch,
+                    batchData = listOf(original),
                 )
             )
+            return true
         } catch (e: Exception) {
-            Logger.e(throwable = e, tag = TAG) { "Optimistic delete rollback failed for fileId=${original.fileId}" }
+            Logger.e(throwable = e, tag = TAG) { "Optimistic rollback failed for fileId=${original.fileId}" }
+            return false
         }
     }
 
-    // upsertDriveMainIndex only writes when excluded.modified > DriveMainIndex.modified,
-    // and `original` is by construction older than the optimistic write it undoes — so
-    // restoring it verbatim is silently dropped. Re-stamp the original content past
-    // whatever is stored instead of relaxing a guard that protects host-sourced writes.
-    private suspend fun restoredWithFreshTimestamp(
-        identityId: Uuid,
-        driveId: Uuid,
-        original: HomebaseFile,
-    ): HomebaseFile {
-        val uniqueId = original.fileMetadata.appData.uniqueId
-        val stored = uniqueId
-            ?.let { dbm.driveMainIndex.selectByIdentityAndDriveAndUnique(identityId, driveId, it) }
-            ?: dbm.driveMainIndex.selectByIdentityAndDriveAndFile(identityId, driveId, original.fileId)
-
-        val originalUpdated = original.fileMetadata.updated.milliseconds
-        val storedModified = stored?.modified ?: originalUpdated
-        if (storedModified < originalUpdated) return original
-
-        return original.copy(
-            fileMetadata = original.fileMetadata.copy(
-                updated = UnixTimeUtc(storedModified + 1)
-            )
-        )
-    }
+    // One definition, because rollbackWrite's compare-and-swap key must be exactly what
+    // the mutation wrote.
+    private fun HomebaseFile.optimisticStamp(): UnixTimeUtc =
+        fileMetadata.updated.addMilliseconds(1)
 
     /** Optimistically updates the reactionPreview AND localAppData.localReactions
      *  on a message and emits BatchReceived. Returns the original file for
@@ -611,7 +610,7 @@ class OptimisticWriter(
             credentials.getIdentityId(), driveId, uniqueId
         ) ?: return@withLock Pair(ToggleReactionResultType.None, null)
 
-        val lastModified = existingFile.fileMetadata.updated.addMilliseconds(1)
+        val lastModified = existingFile.optimisticStamp()
 
         // isAdding is per-user, not per-aggregate: in groups, another user
         // having reacted with the same emoji must not flip our toggle into a
@@ -809,7 +808,7 @@ class OptimisticWriter(
     ): UpdateLocalAppdataContentOutboxRequest? {
         val credentials = credentialsManager.requireActiveCredentials()
 
-        val lastModified = existingFile.fileMetadata.updated.addMilliseconds(1)
+        val lastModified = existingFile.optimisticStamp()
         val updatedFile = existingFile.copy(
             fileMetadata = existingFile.fileMetadata.copy(
                 localAppData = (existingFile.fileMetadata.localAppData ?: LocalAppMetadata()).copy(
@@ -882,7 +881,7 @@ class OptimisticWriter(
             credentials.getIdentityId(), driveId, uniqueId
         ) ?: return
 
-        val lastModified = existingFile.fileMetadata.updated.addMilliseconds(1)
+        val lastModified = existingFile.optimisticStamp()
 
         val updatedFile = existingFile.copy(
             fileMetadata = existingFile.fileMetadata.copy(

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/outbox/OptimisticWriter.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/outbox/OptimisticWriter.kt
@@ -553,7 +553,7 @@ class OptimisticWriter(
     suspend fun rollbackWrite(driveId: Uuid, original: HomebaseFile) {
         val credentials = credentialsManager.requireActiveCredentials()
         try {
-            val batch = listOf(original)
+            val batch = listOf(restoredWithFreshTimestamp(credentials.getIdentityId(), driveId, original))
             fileProcessor.baseUpsertEntryZapZap(
                 identityId = credentials.getIdentityId(),
                 driveId = driveId,
@@ -570,6 +570,31 @@ class OptimisticWriter(
         } catch (e: Exception) {
             Logger.e(throwable = e, tag = TAG) { "Optimistic delete rollback failed for fileId=${original.fileId}" }
         }
+    }
+
+    // upsertDriveMainIndex only writes when excluded.modified > DriveMainIndex.modified,
+    // and `original` is by construction older than the optimistic write it undoes — so
+    // restoring it verbatim is silently dropped. Re-stamp the original content past
+    // whatever is stored instead of relaxing a guard that protects host-sourced writes.
+    private suspend fun restoredWithFreshTimestamp(
+        identityId: Uuid,
+        driveId: Uuid,
+        original: HomebaseFile,
+    ): HomebaseFile {
+        val uniqueId = original.fileMetadata.appData.uniqueId
+        val stored = uniqueId
+            ?.let { dbm.driveMainIndex.selectByIdentityAndDriveAndUnique(identityId, driveId, it) }
+            ?: dbm.driveMainIndex.selectByIdentityAndDriveAndFile(identityId, driveId, original.fileId)
+
+        val originalUpdated = original.fileMetadata.updated.milliseconds
+        val storedModified = stored?.modified ?: originalUpdated
+        if (storedModified < originalUpdated) return original
+
+        return original.copy(
+            fileMetadata = original.fileMetadata.copy(
+                updated = UnixTimeUtc(storedModified + 1)
+            )
+        )
     }
 
     /** Optimistically updates the reactionPreview AND localAppData.localReactions

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/outbox/OptimisticWriterRollbackTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/outbox/OptimisticWriterRollbackTest.kt
@@ -11,11 +11,13 @@ import id.homebase.api.client.auth.ApiCredentials
 import id.homebase.api.client.auth.CredentialsManager
 import id.homebase.api.client.drives.HomebaseFile
 import id.homebase.api.client.drives.files.DeleteLocalFilesByFileIdRequest
+import id.homebase.api.client.eventbus.BackendEvent
 import id.homebase.api.client.eventbus.EventBus
 import id.homebase.api.common.OdinId
 import id.homebase.api.common.SecureByteArray
 import id.homebase.api.serialization.OdinSystemSerializer
 import id.homebase.api.sync.database.DatabaseManager
+import id.homebase.api.sync.database.DriveMainIndex
 import id.homebase.api.sync.database.MainIndexMetaHelpers
 import id.homebase.api.sync.database.OdinDatabase
 import id.homebase.api.sync.database.Outbox
@@ -29,19 +31,27 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import kotlin.uuid.Uuid
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 
 /**
- * Rollback of an optimistic write must actually restore the local row.
+ * Rollback of an optimistic write must actually restore the local row, at the
+ * original `modified` value.
  *
  * `writeDelete` stamps `updated + 1ms` so the mutated row wins the
  * `DriveMainIndex` monotonic guard (`WHERE excluded.modified >
- * DriveMainIndex.modified`). `rollbackWrite` then re-upserts the ORIGINAL file,
- * whose `updated` is 1ms older — the guard rejects it, `performBaseUpsert`
- * drops it silently, and the message stays deleted locally even though nothing
- * was ever queued for the server.
+ * DriveMainIndex.modified`). Re-upserting the ORIGINAL file through that guard
+ * loses (it is 1ms older) and is dropped silently; stamping the restore PAST
+ * the stored value wins but leaves the row claiming to be newer than the
+ * server's real `updated`, which then drops a host edit that was already in
+ * flight. The rollback is a compare-and-swap instead: restore the original
+ * `modified`, conditioned on the optimistic stamp still being the stored one.
  */
+@OptIn(ExperimentalCoroutinesApi::class)
 class OptimisticWriterRollbackTest {
 
     @Test
@@ -116,12 +126,119 @@ class OptimisticWriterRollbackTest {
         }
     }
 
+    /**
+     * The re-stamp implementation left the row at `optimistic + 1ms`, permanently ahead
+     * of the server's real `updated` for that file.
+     */
+    @Test
+    fun rollbackAfterDelete_restoresTheOriginalModified() = runTest {
+        Fixture().use { fx ->
+            fx.build(this)
+            val messageId = fx.seedMessage(updatedMs = 100_000L)
+
+            val original = fx.optimisticWriter.writeDelete(fx.chatDriveId, messageId)
+                ?: error("writeDelete returned null — nothing to roll back")
+
+            assertEquals(
+                100_001L,
+                fx.readIndexRow(messageId).modified,
+                "sanity: the optimistic delete stamps updated + 1ms",
+            )
+
+            assertTrue(fx.optimisticWriter.rollbackWrite(fx.chatDriveId, original))
+
+            assertEquals(
+                100_000L,
+                fx.readIndexRow(messageId).modified,
+                "rollback must restore the original modified, not stamp past the stored value",
+            )
+        }
+    }
+
+    /**
+     * A host write that lands between the optimistic write and the rollback owns the row.
+     * The CAS finds a `modified` that is no longer its own stamp and no-ops.
+     */
+    @Test
+    fun hostWriteBetweenOptimisticWriteAndRollback_isNotClobbered() = runTest {
+        Fixture().use { fx ->
+            fx.build(this)
+            val messageId = fx.seedMessage(updatedMs = 100_000L)
+
+            val original = fx.optimisticWriter.writeDelete(fx.chatDriveId, messageId)
+                ?: error("writeDelete returned null — nothing to roll back")
+
+            fx.seedMessage(
+                messageId = messageId,
+                fileId = original.fileId,
+                updatedMs = 200_000L,
+                content = "edited on another device",
+            )
+
+            advanceUntilIdle()
+            val eventsBefore = fx.received.size
+            assertFalse(
+                fx.optimisticWriter.rollbackWrite(fx.chatDriveId, original),
+                "rollback must report that it was superseded",
+            )
+
+            val afterRollback = fx.readRow(messageId)
+            assertEquals(
+                "edited on another device",
+                afterRollback.fileMetadata.appData.content,
+                "rollback clobbered a host write that landed after the optimistic one",
+            )
+            assertEquals(
+                200_000L,
+                fx.readIndexRow(messageId).modified,
+                "rollback must not touch the host row's modified",
+            )
+            advanceUntilIdle()
+            assertEquals(
+                eventsBefore,
+                fx.received.size,
+                "a rollback that changed no row must not emit BatchReceived",
+            )
+        }
+    }
+
+    /**
+     * The consequence of the re-stamp: it reserved `[original+1, original+2]` for itself,
+     * so a host edit already in flight when the rollback ran lost the guard and vanished.
+     */
+    @Test
+    fun hostWriteInTheWindowTheReStampReserved_isNoLongerDropped() = runTest {
+        Fixture().use { fx ->
+            fx.build(this)
+            val messageId = fx.seedMessage(updatedMs = 100_000L)
+
+            val original = fx.optimisticWriter.writeDelete(fx.chatDriveId, messageId)
+                ?: error("writeDelete returned null — nothing to roll back")
+            assertTrue(fx.optimisticWriter.rollbackWrite(fx.chatDriveId, original))
+
+            // An edit made on another device shortly BEFORE the rollback, arriving after it.
+            fx.seedMessage(
+                messageId = messageId,
+                fileId = original.fileId,
+                updatedMs = 100_001L,
+                content = "edited on another device",
+            )
+
+            assertEquals(
+                "edited on another device",
+                fx.readRow(messageId).fileMetadata.appData.content,
+                "the rollback left the row stamped ahead, so the host edit was silently dropped",
+            )
+        }
+    }
+
     private class Fixture : AutoCloseable {
         val testIdentityId: Uuid = Uuid.parse("7b1be23b-48bb-4304-bc7b-db5910c09a92")
         val chatDriveId: Uuid = Uuid.parse("9ff813af-f2d6-1e2f-9b9d-b189e72d1a11")
         val testDomain: String = "owner.test"
 
         val failOutboxInserts = AtomicBoolean(false)
+        val received = mutableListOf<BackendEvent>()
 
         lateinit var dbm: DatabaseManager
         lateinit var eventBus: EventBus
@@ -135,6 +252,9 @@ class OptimisticWriterRollbackTest {
                 RefusingOutboxInsertDriver(driver, failOutboxInserts)
             })
             eventBus = EventBus()
+            scope.backgroundScope.launch(UnconfinedTestDispatcher(scope.testScheduler)) {
+                eventBus.events.collect { received += it }
+            }
             outboxSync = OutboxSync(
                 databaseManager = dbm,
                 uploader = ThrowingUploader,
@@ -160,6 +280,13 @@ class OptimisticWriterRollbackTest {
             )
         }
 
+        suspend fun readIndexRow(messageId: Uuid): DriveMainIndex =
+            dbm.driveMainIndex.selectByIdentityAndDriveAndUnique(
+                identityId = testIdentityId,
+                driveId = chatDriveId,
+                uniqueId = messageId,
+            ) ?: error("no DriveMainIndex row for $messageId")
+
         suspend fun readRow(messageId: Uuid): HomebaseFile =
             dbm.driveMainIndex.selectHomebaseFileByUnique(
                 identityId = testIdentityId,
@@ -167,11 +294,16 @@ class OptimisticWriterRollbackTest {
                 uniqueId = messageId,
             ) ?: error("no DriveMainIndex row for $messageId")
 
-        /** Seeds an active chat message through the real upsert path. */
+        /**
+         * Seeds — or, when [messageId]/[fileId] name an existing row, host-writes over —
+         * an active chat message through the real guarded upsert path.
+         */
         suspend fun seedMessage(
             messageId: Uuid = Uuid.random(),
             fileId: Uuid = Uuid.random(),
             userDateMs: Long = 100_000L,
+            updatedMs: Long = userDateMs,
+            content: String = "hello world",
         ): Uuid {
             val header = OdinSystemSerializer.deserialize<HomebaseFile>(
                 """{
@@ -187,7 +319,7 @@ class OptimisticWriterRollbackTest {
                   "fileMetadata": {
                     "globalTransitId": "${Uuid.random()}",
                     "created": $userDateMs,
-                    "updated": $userDateMs,
+                    "updated": $updatedMs,
                     "transitCreated": $userDateMs,
                     "transitUpdated": 0,
                     "isEncrypted": false,
@@ -200,7 +332,7 @@ class OptimisticWriterRollbackTest {
                       "dataType": 0,
                       "groupId": "${Uuid.random()}",
                       "userDate": $userDateMs,
-                      "content": "hello world",
+                      "content": "$content",
                       "previewThumbnail": null,
                       "archivalStatus": 0
                     },

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/outbox/OptimisticWriterRollbackTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/outbox/OptimisticWriterRollbackTest.kt
@@ -1,0 +1,287 @@
+package id.homebase.chat.services.outbox
+
+import app.cash.sqldelight.Query
+import app.cash.sqldelight.Transacter
+import app.cash.sqldelight.db.QueryResult
+import app.cash.sqldelight.db.SqlCursor
+import app.cash.sqldelight.db.SqlDriver
+import app.cash.sqldelight.db.SqlPreparedStatement
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import id.homebase.api.client.auth.ApiCredentials
+import id.homebase.api.client.auth.CredentialsManager
+import id.homebase.api.client.drives.HomebaseFile
+import id.homebase.api.client.drives.files.DeleteLocalFilesByFileIdRequest
+import id.homebase.api.client.eventbus.EventBus
+import id.homebase.api.common.OdinId
+import id.homebase.api.common.SecureByteArray
+import id.homebase.api.serialization.OdinSystemSerializer
+import id.homebase.api.sync.database.DatabaseManager
+import id.homebase.api.sync.database.MainIndexMetaHelpers
+import id.homebase.api.sync.database.OdinDatabase
+import id.homebase.api.sync.database.Outbox
+import id.homebase.api.sync.database.OutboxSync
+import id.homebase.api.sync.database.OutboxUploader
+import id.homebase.api.sync.database.enqueued
+import id.homebase.chat.services.ChatProtocol
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.uuid.Uuid
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+
+/**
+ * Rollback of an optimistic write must actually restore the local row.
+ *
+ * `writeDelete` stamps `updated + 1ms` so the mutated row wins the
+ * `DriveMainIndex` monotonic guard (`WHERE excluded.modified >
+ * DriveMainIndex.modified`). `rollbackWrite` then re-upserts the ORIGINAL file,
+ * whose `updated` is 1ms older — the guard rejects it, `performBaseUpsert`
+ * drops it silently, and the message stays deleted locally even though nothing
+ * was ever queued for the server.
+ */
+class OptimisticWriterRollbackTest {
+
+    @Test
+    fun rollbackAfterDelete_restoresTheRow() = runTest {
+        Fixture().use { fx ->
+            fx.build(this)
+            val messageId = fx.seedMessage()
+
+            val original = fx.optimisticWriter.writeDelete(fx.chatDriveId, messageId)
+                ?: error("writeDelete returned null — nothing to roll back")
+
+            assertTrue(
+                fx.readRow(messageId).isSoftDeleted(),
+                "sanity: the optimistic delete should have landed",
+            )
+
+            fx.optimisticWriter.rollbackWrite(fx.chatDriveId, original)
+
+            val afterRollback = fx.readRow(messageId)
+            assertFalse(
+                afterRollback.isSoftDeleted(),
+                "rollback must restore the row: isSoftDeleted() is still true",
+            )
+            assertEquals(
+                original.fileState,
+                afterRollback.fileState,
+                "rollback must restore fileState",
+            )
+            assertEquals(
+                "hello world",
+                afterRollback.fileMetadata.appData.content,
+                "rollback must restore the message content",
+            )
+            assertEquals(0L, fx.dbm.outbox.count(), "nothing should be queued")
+        }
+    }
+
+    /**
+     * The same thing through the real refused-enqueue path the callers use:
+     * the outbox INSERT fails, `tryEnqueue` returns a non-enqueued result, and
+     * the caller rolls the optimistic write back.
+     */
+    @Test
+    fun refusedEnqueue_rollsBackToAnUndeletedRow() = runTest {
+        Fixture().use { fx ->
+            fx.build(this)
+            val messageId = fx.seedMessage()
+
+            val original = fx.optimisticWriter.writeDelete(fx.chatDriveId, messageId)
+                ?: error("writeDelete returned null — nothing to roll back")
+
+            fx.failOutboxInserts.set(true)
+            val result = fx.outboxSync.tryEnqueue(
+                request = DeleteLocalFilesByFileIdRequest(
+                    driveId = fx.chatDriveId,
+                    fileIds = listOf(original.fileId),
+                    recipients = null,
+                    hardDelete = false,
+                ),
+            )
+            fx.failOutboxInserts.set(false)
+            assertFalse(result.enqueued, "the outbox INSERT was supposed to be refused")
+
+            fx.optimisticWriter.rollbackWrite(fx.chatDriveId, original)
+
+            val afterRollback = fx.readRow(messageId)
+            assertEquals(0L, fx.dbm.outbox.count(), "the refused enqueue left no outbox row")
+            assertFalse(
+                afterRollback.isSoftDeleted(),
+                "refused enqueue + rollback left the message deleted locally with nothing queued",
+            )
+        }
+    }
+
+    private class Fixture : AutoCloseable {
+        val testIdentityId: Uuid = Uuid.parse("7b1be23b-48bb-4304-bc7b-db5910c09a92")
+        val chatDriveId: Uuid = Uuid.parse("9ff813af-f2d6-1e2f-9b9d-b189e72d1a11")
+        val testDomain: String = "owner.test"
+
+        val failOutboxInserts = AtomicBoolean(false)
+
+        lateinit var dbm: DatabaseManager
+        lateinit var eventBus: EventBus
+        lateinit var outboxSync: OutboxSync
+        lateinit var optimisticWriter: OptimisticWriter
+
+        suspend fun build(scope: TestScope) {
+            dbm = DatabaseManager({
+                val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+                OdinDatabase.Schema.create(driver)
+                RefusingOutboxInsertDriver(driver, failOutboxInserts)
+            })
+            eventBus = EventBus()
+            outboxSync = OutboxSync(
+                databaseManager = dbm,
+                uploader = ThrowingUploader,
+                eventBus = eventBus,
+                scope = scope,
+            ).also { it.setOnline(false) }
+
+            val credentialsManager = CredentialsManager().also {
+                it.setActiveCredentials(
+                    ApiCredentials.create(
+                        domain = OdinId(testDomain),
+                        clientAccessToken = "test-token",
+                        sharedSecret = SecureByteArray(ByteArray(16)),
+                    )
+                )
+            }
+
+            optimisticWriter = OptimisticWriter(
+                credentialsManager = credentialsManager,
+                dbm = dbm,
+                eventBus = eventBus,
+                outboxSync = outboxSync,
+            )
+        }
+
+        suspend fun readRow(messageId: Uuid): HomebaseFile =
+            dbm.driveMainIndex.selectHomebaseFileByUnique(
+                identityId = testIdentityId,
+                driveId = chatDriveId,
+                uniqueId = messageId,
+            ) ?: error("no DriveMainIndex row for $messageId")
+
+        /** Seeds an active chat message through the real upsert path. */
+        suspend fun seedMessage(
+            messageId: Uuid = Uuid.random(),
+            fileId: Uuid = Uuid.random(),
+            userDateMs: Long = 100_000L,
+        ): Uuid {
+            val header = OdinSystemSerializer.deserialize<HomebaseFile>(
+                """{
+                  "fileId": "$fileId",
+                  "driveId": "$chatDriveId",
+                  "fileState": "active",
+                  "fileSystemType": "standard",
+                  "serverFileIsEncrypted": "false",
+                  "keyHeader": {
+                    "iv": [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],
+                    "aesKey": {"bytes": [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]}
+                  },
+                  "fileMetadata": {
+                    "globalTransitId": "${Uuid.random()}",
+                    "created": $userDateMs,
+                    "updated": $userDateMs,
+                    "transitCreated": $userDateMs,
+                    "transitUpdated": 0,
+                    "isEncrypted": false,
+                    "senderOdinId": "$testDomain",
+                    "originalAuthor": "$testDomain",
+                    "appData": {
+                      "uniqueId": "$messageId",
+                      "tags": null,
+                      "fileType": ${ChatProtocol.MessageFileType},
+                      "dataType": 0,
+                      "groupId": "${Uuid.random()}",
+                      "userDate": $userDateMs,
+                      "content": "hello world",
+                      "previewThumbnail": null,
+                      "archivalStatus": 0
+                    },
+                    "localAppData": null,
+                    "referencedFile": null,
+                    "reactionPreview": null,
+                    "versionTag": "${Uuid.random()}",
+                    "payloads": [],
+                    "dataSource": null
+                  },
+                  "serverMetadata": {
+                    "accessControlList": {
+                      "requiredSecurityGroup": "owner",
+                      "circleIdList": null,
+                      "odinIdList": null
+                    },
+                    "doNotIndex": false,
+                    "allowDistribution": true,
+                    "fileSystemType": "standard",
+                    "fileByteCount": 50,
+                    "originalRecipientCount": 1,
+                    "transferHistory": null
+                  },
+                  "priority": 300,
+                  "fileByteCount": 50
+                }"""
+            )
+            MainIndexMetaHelpers.HomebaseFileProcessor(dbm)
+                .baseUpsertEntryZapZap(testIdentityId, chatDriveId, listOf(header), null)
+            return messageId
+        }
+
+        override fun close() {
+            if (::dbm.isInitialized) dbm.close()
+        }
+    }
+}
+
+private object ThrowingUploader : OutboxUploader {
+    override suspend fun upload(outboxRecord: Outbox, eventBus: EventBus) =
+        error("uploader must not run — the outbox is offline in this test")
+}
+
+/** Fails `INSERT INTO Outbox` while armed, so `tryEnqueue` reports a refusal. */
+private class RefusingOutboxInsertDriver(
+    private val delegate: SqlDriver,
+    private val refusing: AtomicBoolean,
+) : SqlDriver {
+
+    override fun execute(
+        identifier: Int?,
+        sql: String,
+        parameters: Int,
+        binders: (SqlPreparedStatement.() -> Unit)?,
+    ): QueryResult<Long> {
+        if (refusing.get() && sql.contains("INSERT INTO Outbox")) {
+            throw IllegalStateException("simulated outbox INSERT failure")
+        }
+        return delegate.execute(identifier, sql, parameters, binders)
+    }
+
+    override fun <R> executeQuery(
+        identifier: Int?,
+        sql: String,
+        mapper: (SqlCursor) -> QueryResult<R>,
+        parameters: Int,
+        binders: (SqlPreparedStatement.() -> Unit)?,
+    ): QueryResult<R> = delegate.executeQuery(identifier, sql, mapper, parameters, binders)
+
+    override fun newTransaction(): QueryResult<Transacter.Transaction> = delegate.newTransaction()
+
+    override fun currentTransaction(): Transacter.Transaction? = delegate.currentTransaction()
+
+    override fun addListener(vararg queryKeys: String, listener: Query.Listener) =
+        delegate.addListener(queryKeys = queryKeys, listener = listener)
+
+    override fun removeListener(vararg queryKeys: String, listener: Query.Listener) =
+        delegate.removeListener(queryKeys = queryKeys, listener = listener)
+
+    override fun notifyListeners(vararg queryKeys: String) =
+        delegate.notifyListeners(queryKeys = queryKeys)
+
+    override fun close() = delegate.close()
+}


### PR DESCRIPTION
Fixes #1171

## Does it still reproduce on current main?

Yes — verified against `origin/main`, all four moving parts unchanged:

- `OptimisticWriter.rollbackWrite` still re-upserted the **original** `HomebaseFile` verbatim.
- `writeDelete` / `writeUpdate` / `writeReactionToggle` still stamp `existingFile.fileMetadata.updated.addMilliseconds(1)`.
- `MainIndexMeta.kt:130` still maps `modified = header.fileMetadata.updated.milliseconds`.
- Both `ON CONFLICT` branches of `upsertDriveMainIndex` (`DriveMainIndex.sq`) still end with `WHERE excluded.modified > DriveMainIndex.modified`.

So the original file's `modified` is always 1 ms *older* than the optimistic write it undoes, the guard's predicate is false, the UPDATE matches zero rows, and `performBaseUpsert` drops it silently (`n > 0L` is false, so the header isn't even added to `written`).

Caller line numbers have drifted since the issue was filed, but every caller is still there: `FeedPostSenderService.kt:41`, `PostCommentsService.kt:563` and `:567`, `PostReactionService.kt:94`, `ChatMessageActionService.kt:270, 275, 361, 367`, `MomentActionService.kt:132, 136, 219, 223, 253, 257`.

## The fix — compare-and-swap, not a forward stamp

The rollback does not need to win a recency contest. It needs to undo **one specific write that it
made**. So it restores the original `modified` value, conditioned on the optimistic value still
being the one in the row (`DriveMainIndex.sq`):

```sql
rollbackOptimisticWrite:
UPDATE DriveMainIndex
SET fileState      = :fileState,
    archivalStatus = :archivalStatus,
    jsonHeader     = :jsonHeader,
    modified       = :originalModified
WHERE identityId = :identityId AND driveId = :driveId AND fileId = :fileId
  AND modified = :optimisticModified;
```

Three properties this buys:

1. **No forward stamp.** The row goes back to the server's real value, so nothing below it is dropped afterwards.
2. **A host write that landed mid-flight wins automatically.** If anything arrived between the optimistic write and the rollback, `modified` no longer equals `:optimisticModified`, the UPDATE touches 0 rows, and the newer host data correctly stands.
3. **The guard stays untouched.** `WHERE excluded.modified > DriveMainIndex.modified` keeps protecting host-sourced writes on the normal upsert path. This is a *new* statement, not a relaxation of the existing one — no unguarded upsert is added to `homebase-api` for a future caller to reach for.

New statement only: no schema change, no `DATABASE_VERSION` bump.

### Which columns are restored, and why those

`jsonHeader` plus `fileState` and `archivalStatus` — the only `DriveMainIndex` index columns that
`writeDelete` and `writeReactionToggle`, the two optimistic paths actually paired with
`rollbackWrite`, mutate. Neither touches `appData.tags` or `localAppData.tags`, so `DriveTagIndex` /
`DriveLocalTagIndex` already hold the original values and the rollback does not need to rewrite
them. The projection is read back from `convertFileHeaderToDriveMainIndexRecord`, the same function
the upsert path uses, so the column values cannot drift from what a normal write would have stored.

### Where `:optimisticModified` comes from

From the caller's own `original`, never re-read from the DB at rollback time — re-reading would
reintroduce exactly the race the CAS exists to close. Every optimistic mutation stamps
`updated + 1 ms`; that convention now has a single definition (`HomebaseFile.optimisticStamp()`) used
by all five mutation sites *and* by `rollbackWrite`, so the CAS key is by construction the value the
mutation wrote.

### `BatchReceived` on a 0-row rollback

Not emitted. Publishing the pre-optimistic header for a row that was *not* rolled back would push
stale content at the UI — the host's newer version is what is in the DB, and the UI would revert to
the old content until the next cold load. This is the same rule `performBaseUpsert` already
documents: callers emit from `written`, not from the incoming batch, so a header the guard rejected
never reaches the UI. The superseded case is logged distinctly instead
(`"Optimistic rollback superseded … a newer write landed first"`), and `rollbackWrite` now returns
`Boolean` so callers can tell the two outcomes apart.

## Evidence — failing tests first

`homebase-chat/src/jvmTest/.../outbox/OptimisticWriterRollbackTest.kt` seeds an active chat message
through the real upsert path (`baseUpsertEntryZapZap`), runs `writeDelete`, and rolls back. Two of
the five cases are faithful to the reported trigger: a `SqlDriver` wrapper refuses
`INSERT INTO Outbox` so `outboxSync.tryEnqueue(DeleteLocalFilesByFileIdRequest)` returns a
non-enqueued result, exactly the branch that calls `rollbackWrite`.

Against **unfixed main** (rollback drops the restore entirely):

```
FAILED rollbackAfterDelete_restoresTheRow
    rollback must restore the row: isSoftDeleted() is still true
FAILED refusedEnqueue_rollsBackToAnUndeletedRow
    refused enqueue + rollback left the message deleted locally with nothing queued
```

Against the **re-stamp implementation** this PR previously carried (kept compiling, body swapped
back, so only behaviour differs) — the three new cases fail:

```
FAILED rollbackAfterDelete_restoresTheOriginalModified
    rollback must restore the original modified, not stamp past the stored value
    expected:<100000> but was:<100002>
FAILED hostWriteBetweenOptimisticWriteAndRollback_isNotClobbered
    rollback must report that it was superseded
    (and: content reverted to "hello world", modified stamped to 200001)
FAILED hostWriteInTheWindowTheReStampReserved_isNoLongerDropped
    the rollback left the row stamped ahead, so the host edit was silently dropped
    expected:<[edited on another device]> but was:<[hello world]>
```

After the CAS fix, all five pass:

```
<testsuite name="OptimisticWriterRollbackTest[jvm]" tests="5" skipped="0" failures="0" errors="0">
  rollbackAfterDelete_restoresTheRow
  refusedEnqueue_rollsBackToAnUndeletedRow
  rollbackAfterDelete_restoresTheOriginalModified
  hostWriteBetweenOptimisticWriteAndRollback_isNotClobbered
  hostWriteInTheWindowTheReStampReserved_isNoLongerDropped
```

The third case is the lost-edit scenario in miniature: an edit made on another device *before* the
rollback arrives carrying an `updated` inside the `[original+1, original+2]` window the re-stamp
reserved for itself. With the forward stamp it lost the guard and vanished; with the CAS the row
sits at the server's real value and the edit lands.

## Regressions

```
./gradlew homebase-chat:jvmTest homebase-auth:jvmTest homebase-common:jvmTest homebase-api:jvmTest --rerun-tasks
BUILD SUCCESSFUL

homebase-chat:   tests=1246 failures=0 errors=0 skipped=6
homebase-auth:   tests=14   failures=0 errors=0 skipped=0
homebase-common: tests=556  failures=0 errors=0 skipped=0
homebase-api:    tests=1217 failures=0 errors=0 skipped=0
TOTAL:           tests=3033 failures=0 errors=0 skipped=6
```

Cross-target compile checks (the change spans `homebase-api` and `homebase-chat` `commonMain`):

```
./gradlew :homebase-api:compileKotlinJvm  :homebase-api:compileAndroidMain \
          :homebase-api:compileKotlinWasmJs :homebase-api:compileKotlinIosSimulatorArm64 \
          :homebase-chat:compileKotlinJvm :homebase-chat:compileAndroidMain \
          :homebase-chat:compileKotlinWasmJs :homebase-chat:compileKotlinIosSimulatorArm64
BUILD SUCCESSFUL

./gradlew :homebase-core:compileKotlinJvm homebase-core:jvmTest
BUILD SUCCESSFUL
```


## Why not enqueue first?

Fair question, and the answer is that we should. The write-first ordering at these eight sites was never a deliberate choice, and inverting it removes the need for a rollback path at all — which is already the house style (`UploadService` documents enqueue-as-success-gate; `markAsRead` does it a hundred lines above `toggleReaction`). That is tracked as #1415 and lands in its own PR.

This PR is still the right fix for the ordering that exists today: the rollback is currently silently dropped by the `DriveMainIndex` upsert guard, and the inversion will delete this code cleanly when it lands.
