### PR TITLE
Order and count late-arriving chat messages by arrival, matching web

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/HomebaseFile.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/HomebaseFile.kt
@@ -56,6 +56,20 @@ data class HomebaseFile(
     fun sqlUserDateMs(): Long =
         fileMetadata.appData.userDate ?: fileMetadata.created.milliseconds
 
+    /**
+     * Ordering / unread key, matching dotyoucore-js, which orders and counts
+     * unread on `transitCreated || created` (arrival) while labelling the
+     * bubble with `appData.userDate` (compose time). `max` rather than plain
+     * `created` so a row with no server stamp keeps its userDate.
+     *
+     * Mirrors `MAX(userDate, created)` in ChatReadCount.sq — un-clamped, like
+     * that column. `MessageUiModel.sortDate` is the display-safe twin: it maxes
+     * over the *clamped* userDate so a sender with a fast clock can't jump to
+     * the tail. Never under-counts relative to the old userDate-only filter.
+     */
+    fun orderingDateMs(): Long =
+        maxOf(sqlUserDateMs(), fileMetadata.created.milliseconds)
+
     fun assertOriginalAuthor(odinId: OdinId) {
         val originalAuthor = fileMetadata.originalAuthor
         if (originalAuthor == null) {

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/ChatReadCountWrapper.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/ChatReadCountWrapper.kt
@@ -13,8 +13,8 @@ data class ConversationWithLastMessage(
     val conversation: HomebaseFile,
     val message: HomebaseFile?,
     /**
-     * Authoritative `DriveMainIndex.userDate` (epoch ms) of the last message,
-     * straight from the SQL column. Null when there's no last message yet.
+     * Authoritative ordering key `MAX(DriveMainIndex.userDate, created)` (epoch ms)
+     * of the last message, straight from the SQL. Null when there's no last message yet.
      *
      * Carried separately from `message` because `ChatMessageStream.mapToMessageData`
      * clamps the in-memory `MessageUiModel.userDate` to `metadata.transitCreated`

--- a/homebase-api/src/commonMain/sqldelight/id/homebase/api/sync/database/ChatReadCount.sq
+++ b/homebase-api/src/commonMain/sqldelight/id/homebase/api/sync/database/ChatReadCount.sq
@@ -18,11 +18,15 @@ CREATE INDEX IF NOT EXISTS idx_chatmessage_convid_userDate ON DriveMainIndex(gro
 -- correlated last-message subquery) all use this as a covering index.
 --
 -- This is the correct shape — it replaces the former fileType-leading
--- idx_messages_filetype_datatype_groupid_userDate. No migration code: it's just a schema
--- index, so new installs get it directly and existing installs that still carry the old index
--- simply shed it whenever the DB is next rebuilt on a major (version-bump) upgrade.
-CREATE INDEX IF NOT EXISTS idx_unread_cover
-  ON DriveMainIndex(identityId, fileType, dataType, groupId, userDate, originalAuthor, fileState, archivalStatus);
+-- idx_messages_filetype_datatype_groupid_userDate and, in turn, idx_unread_cover (which
+-- lacked `created`, so the MAX(userDate, created) unread predicate below fell back to a
+-- per-row table lookup). No migration code: it's just a schema index, so new installs get it
+-- directly, Schema.create() adds it to existing installs on next open, and the superseded
+-- index is shed whenever the DB is next rebuilt on a major (version-bump) upgrade.
+-- A NEW NAME is required for exactly that reason — CREATE INDEX IF NOT EXISTS would leave an
+-- existing install on the old shape.
+CREATE INDEX IF NOT EXISTS idx_unread_cover_v2
+  ON DriveMainIndex(identityId, fileType, dataType, groupId, userDate, created, originalAuthor, fileState, archivalStatus);
 
 -- Get full list of conversations (8888) from the DriveMainIndex table
 -- here to not contaminate it. Can also be easily fetched with QB()
@@ -44,7 +48,7 @@ selectAllConversationPlusLastMessage:
 SELECT
   d.jsonHeader AS convJsonHeader,
   m.jsonHeader AS msgJsonHeader,
-  m.userDate   AS msgUserDate
+  MAX(m.userDate, m.created) AS msgUserDate
 FROM DriveMainIndex AS d
 LEFT JOIN DriveMainIndex AS m
   ON m.rowId = (
@@ -70,7 +74,7 @@ LEFT JOIN ChatReadCount c ON d.groupId = c.groupId
 WHERE d.identityId = ?
   AND d.groupId = ?
   AND d.fileType = 7878 AND d.dataType = 0
-  AND (c.lastReadTime IS NULL OR d.userDate > c.lastReadTime)
+  AND (c.lastReadTime IS NULL OR MAX(d.userDate, d.created) > c.lastReadTime)
   AND d.originalAuthor IS NOT NULL
   AND d.originalAuthor != ?
   -- Exclude soft-deleted messages. We check BOTH markers because
@@ -109,7 +113,7 @@ LEFT JOIN ChatReadCount c ON d.groupId = c.groupId
 WHERE d.identityId = ?
   AND d.fileType = 7878
   AND d.dataType = 0
-  AND (c.lastReadTime IS NULL OR d.userDate > c.lastReadTime)
+  AND (c.lastReadTime IS NULL OR MAX(d.userDate, d.created) > c.lastReadTime)
   AND d.groupId IS NOT NULL
   -- NULL originalAuthor is treated as self: drive-sync echoes of your own
   -- messages (and older self-authored rows) land with originalAuthor=NULL

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/database/DriveMainIndexCreateOrderTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/database/DriveMainIndexCreateOrderTest.kt
@@ -69,8 +69,8 @@ class DriveMainIndexCreateOrderTest {
                 column = 0,
             )
             assertTrue(
-                indexes.contains("idx_unread_cover"),
-                "Opened schema should include idx_unread_cover, has: $indexes",
+                indexes.contains("idx_unread_cover_v2"),
+                "Opened schema should include idx_unread_cover_v2, has: $indexes",
             )
         }
     }
@@ -102,8 +102,8 @@ class DriveMainIndexCreateOrderTest {
             column = 0,
         )
         assertTrue(
-            indexes.contains("idx_unread_cover"),
-            "Recreated schema should include idx_unread_cover, has: $indexes",
+            indexes.contains("idx_unread_cover_v2"),
+            "Recreated schema should include idx_unread_cover_v2, has: $indexes",
         )
         val rowCount = queryStrings(raw, "SELECT COUNT(*) FROM DriveMainIndex", column = 0)
         assertEquals(listOf("0"), rowCount, "Recreated DriveMainIndex should be empty")

--- a/homebase-api/src/jvmTest/kotlin/id/homebase/api/sync/database/UnreadCountLateArrivalTest.kt
+++ b/homebase-api/src/jvmTest/kotlin/id/homebase/api/sync/database/UnreadCountLateArrivalTest.kt
@@ -1,0 +1,155 @@
+@file:OptIn(ExperimentalUuidApi::class)
+
+package id.homebase.api.sync.database
+
+import app.cash.sqldelight.db.QueryResult
+import app.cash.sqldelight.db.SqlDriver
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+/**
+ * #1199 — a message that sat in the sender's outbox arrives stamped with its
+ * compose time, so `DriveMainIndex.userDate` lands *below* `lastReadTime` and
+ * the old `d.userDate > c.lastReadTime` filter never counted it unread.
+ * dotyoucore-js counts unread on `transitCreated || created` (arrival); these
+ * pin the ported `MAX(userDate, created)` predicate and the covering index that
+ * keeps it off a per-row table lookup.
+ */
+class UnreadCountLateArrivalTest {
+
+    private val identityId = Uuid.parse("00000000-0000-0000-0000-0000000000aa")
+    private val groupId = Uuid.parse("00000000-0000-0000-0000-0000000000bb")
+    private val self = "owner.test"
+    private val peer = "peer.test"
+
+    // 12:00, and a message composed at 10:30 that only reached us at 12:02.
+    private val readMessageMs = 1_780_000_000_000L
+    private val lateComposedMs = readMessageMs - 90 * 60_000L
+    private val lateArrivedMs = readMessageMs + 2 * 60_000L
+
+    private fun queries(driver: SqlDriver) = ChatReadCountQueries(
+        driver,
+        DriveMainIndex.Adapter(
+            identityIdAdapter = UuidAdapter,
+            driveIdAdapter = UuidAdapter,
+            fileIdAdapter = UuidAdapter,
+            globalTransitIdAdapter = UuidAdapter,
+            groupIdAdapter = UuidAdapter,
+            uniqueIdAdapter = UuidAdapter,
+        ),
+        ChatReadCount.Adapter(groupIdAdapter = UuidAdapter),
+    )
+
+    private fun seed(driver: SqlDriver) {
+        fun insert(userDate: Long, created: Long) = driver.execute(
+            null,
+            """
+            INSERT INTO DriveMainIndex(
+                identityId, driveId, fileId, groupId, originalAuthor, fileType, dataType,
+                archivalStatus, fileState, historyStatus, userDate, created, modified,
+                fileSystemType, jsonHeader)
+            VALUES (x'000000000000000000000000000000aa', x'01', randomblob(16),
+                    x'000000000000000000000000000000bb', '$peer', 7878, 0,
+                    0, 1, 0, $userDate, $created, $created, 0, 'hdr')
+            """.trimIndent(),
+            0,
+        )
+        // Already read: composed and delivered at 12:00.
+        insert(readMessageMs, readMessageMs)
+        // The #1199 message: composed 10:30, arrived 12:02.
+        insert(lateComposedMs, lateArrivedMs)
+
+        // Read up to the 12:00 message.
+        queries(driver).upsertLastReadTime(groupId, readMessageMs)
+    }
+
+    private fun openSeeded(): SqlDriver {
+        val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+        OdinDatabase.Schema.create(driver)
+        seed(driver)
+        return driver
+    }
+
+    @Test
+    fun lateArrivingMessageIsCountedUnread() {
+        val driver = openSeeded()
+        val rows = queries(driver).selectAllUnreadCount(identityId, self).executeAsList()
+        assertEquals(1, rows.size, "expected the one conversation to report unread")
+        assertEquals(groupId, rows.single().groupId)
+        assertEquals(
+            1L,
+            rows.single().unreadCount,
+            "the message composed 90 min before lastReadTime but delivered after it must count",
+        )
+        driver.close()
+    }
+
+    @Test
+    fun perConversationUnreadCountAgreesWithTheListQuery() {
+        val driver = openSeeded()
+        val count = queries(driver)
+            .selectUnreadCountForConversation(identityId, groupId, self)
+            .executeAsOne()
+        assertEquals(1L, count)
+        driver.close()
+    }
+
+    @Test
+    fun composeTimeOnlyPredicateMissesIt() {
+        // The pre-fix predicate, run against the same rows, to keep the
+        // regression it fixes visible.
+        val driver = openSeeded()
+        val count = driver.executeQuery(
+            null,
+            """
+            SELECT COUNT(*) FROM DriveMainIndex d
+            LEFT JOIN ChatReadCount c ON d.groupId = c.groupId
+            WHERE d.identityId = x'000000000000000000000000000000aa'
+              AND d.fileType = 7878 AND d.dataType = 0
+              AND (c.lastReadTime IS NULL OR d.userDate > c.lastReadTime)
+              AND d.originalAuthor IS NOT NULL AND d.originalAuthor != '$self'
+              AND d.fileState != 0 AND d.archivalStatus != 2
+            """.trimIndent(),
+            { cursor -> QueryResult.Value(cursor.next().value.let { cursor.getLong(0) }) },
+            0,
+        ).value
+        assertEquals(0L, count, "sanity: compose-time-only filtering is what lost the message")
+        driver.close()
+    }
+
+    @Test
+    fun unreadCountStaysOnACoveringIndex() {
+        val driver = openSeeded()
+        val plan = StringBuilder()
+        driver.executeQuery(
+            null,
+            """
+            EXPLAIN QUERY PLAN
+            SELECT d.groupId, COUNT(*) AS unreadCount, MAX(c.lastReadTime) AS lastReadTime
+            FROM DriveMainIndex AS d
+            LEFT JOIN ChatReadCount c ON d.groupId = c.groupId
+            WHERE d.identityId = x'000000000000000000000000000000aa'
+              AND d.fileType = 7878 AND d.dataType = 0
+              AND (c.lastReadTime IS NULL OR MAX(d.userDate, d.created) > c.lastReadTime)
+              AND d.groupId IS NOT NULL
+              AND d.originalAuthor IS NOT NULL AND d.originalAuthor != '$self'
+              AND d.fileState != 0 AND d.archivalStatus != 2
+            GROUP BY d.groupId
+            """.trimIndent(),
+            { cursor ->
+                while (cursor.next().value) plan.appendLine(cursor.getString(3))
+                QueryResult.Value(Unit)
+            },
+            0,
+        )
+        assertTrue(
+            plan.contains("COVERING INDEX idx_unread_cover_v2"),
+            "unread scan must stay index-covering (no per-row table lookup); was:\n$plan",
+        )
+        driver.close()
+    }
+}

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
@@ -1959,8 +1959,8 @@ class ConversationListViewModel(
                                 val messages = windowMessages.filterNot { it.isHiddenByExit(exitedAt) }
                                 val timezone = TimeZone.currentSystemDefault()
                                 val groupedMessages =
-                                    messages.sortedBy { it.userDate }.groupBy { message ->
-                                        val date = message.userDate.toLocalDateTime(timezone).date
+                                    messages.sortedBy { it.sortDate }.groupBy { message ->
+                                        val date = message.sortDate.toLocalDateTime(timezone).date
                                         date
                                     }
                                 // Top of the list: spinner while older messages page in,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/data/MessageUiModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/data/MessageUiModel.kt
@@ -38,6 +38,14 @@ data class MessageUiModel(
      * synthetic models that have no SQL row.
      */
     val sqlUserDate: Instant = userDate,
+    /**
+     * Where the message sits in the list: `max(userDate, arrival)`, the same
+     * key dotyoucore-js orders on (`fileMetadata.created`). A message that sat
+     * in the sender's outbox arrives stamped with its compose time; ordering
+     * on [userDate] would bury it that far up the scrollback while web shows
+     * it at the tail. [userDate] stays the *displayed* time.
+     */
+    val sortDate: Instant = userDate,
     val modified: Instant?, // When the message was last modified
     val created: Instant, // Server-side creation timestamp
     val originalAuthor: OdinId?,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageActionService.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageActionService.kt
@@ -107,15 +107,17 @@ class ChatMessageActionService(
         // Advance no further than the newest message the user actually saw.
         // `MessageUiModel.userDate` is the *clamped* display value
         // (`min(appData.userDate, transitCreated)`) while selectAllUnreadCount
-        // filters on the un-clamped DriveMainIndex.userDate — so read-bookkeeping
-        // runs on `sqlUserDate`, which is that same SQL column. Using the clamped
-        // value here is what stuck the badge at 1 for a message that had been read.
+        // filters on `MAX(DriveMainIndex.userDate, DriveMainIndex.created)` — so
+        // read-bookkeeping runs on `max(sqlUserDate, created)`, the same two SQL
+        // columns. Using the clamped value here is what stuck the badge at 1 for a
+        // message that had been read; using userDate alone is what left a
+        // late-arriving message permanently uncounted (#1199).
         //
         // The conversation's `latestMessageTimestamp` is deliberately NOT used as a
         // floor: it belongs to the newest message in the DB, which is not necessarily
         // one that ever reached the window. Marking that read (#1135) clears the badge
         // that is the only signal the tail is missing.
-        val newReadTime = viewedRecords.maxOf { it.sqlUserDate }
+        val newReadTime = viewedRecords.maxOf { maxOf(it.sqlUserDate, it.created) }
         val convoLatest =
             participantLookup.getConversationById(conversationId)?.latestMessageTimestamp
         Logger.d(tag = TAG) {

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/MessageMapper.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/MessageMapper.kt
@@ -174,6 +174,7 @@ suspend fun mapToMessageData(
                 conversationId = appData.groupId!!,
                 userDate = deletedUserDate.toInstant(),
                 sqlUserDate = Instant.fromEpochMilliseconds(header.sqlUserDateMs()),
+                sortDate = maxOf(deletedUserDate, metadata.created).toInstant(),
                 modified = metadata.updated.toInstant(),
                 created = metadata.created.toInstant(),
                 originalAuthor = metadata.originalAuthor,
@@ -324,6 +325,9 @@ suspend fun mapToMessageData(
             content = messageAppData.getMessage(),
             userDate = userDate.toInstant(),
             sqlUserDate = Instant.fromEpochMilliseconds(header.sqlUserDateMs()),
+            // Built on the CLAMPED userDate, not header.orderingDateMs(): a sender with a
+            // fast clock must not jump to the tail, which the clamp already prevents.
+            sortDate = maxOf(userDate, metadata.created).toInstant(),
             modified = metadata.updated.toInstant(),
             created = metadata.created.toInstant(),
             originalAuthor = metadata.originalAuthor,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationMapper.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationMapper.kt
@@ -372,7 +372,7 @@ class ConversationMapper(
 
         return if (lastMsg != null) {
             val domain = credentialsManager.requireActiveDomain()
-            applyLastMessage(withAdmins, lastMsg, domain, sqlUserDateMs = lastMsg.sqlUserDateMs())
+            applyLastMessage(withAdmins, lastMsg, domain, sqlUserDateMs = lastMsg.orderingDateMs())
         } else withAdmins
     }
 

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
@@ -472,8 +472,9 @@ class ConversationStream(
 
         // For each file in the batch, map to model (fetch last message from DB if needed).
         // Keep the original HomebaseFile alongside the mapped MessageUiModel so we can
-        // pull the SQL-faithful userDate via `file.sqlUserDateMs()` — `MessageUiModel.userDate`
-        // is clamped to `transitCreated` for display and can underrun the SQL column.
+        // pull the SQL-faithful ordering key via `file.orderingDateMs()` —
+        // `MessageUiModel.userDate` is clamped to `transitCreated` for display and can
+        // underrun the SQL columns.
         val incoming = ArrayList<Pair<HomebaseFile, MessageUiModel>>(messageFiles.size)
         for (file in messageFiles) {
             val mapped = mapToMessageData(file, credentialsManager, ::resolveDisplayName)
@@ -539,7 +540,7 @@ class ConversationStream(
                 _conversations.value = _conversations.value.copy(
                     items = _conversations.value.items.map { if (it.id == revived.id) revived else it }
                 )
-                updateConversationFromNewMessage(revived, m, file.sqlUserDateMs())
+                updateConversationFromNewMessage(revived, m, file.orderingDateMs())
 
                 // Intentionally do NOT trigger server-side recovery here. A
                 // drive-sync batch handler is the wrong place to enqueue
@@ -580,7 +581,7 @@ class ConversationStream(
                         id = m.conversationId,
                         name = "Conversation missing...",
                         lastMessage = m.content,
-                        latestMessageTimestamp = Instant.fromEpochMilliseconds(file.sqlUserDateMs()),
+                        latestMessageTimestamp = Instant.fromEpochMilliseconds(file.orderingDateMs()),
                         admins = (if (m.originalAuthor == null) emptySet() else setOf(m.originalAuthor)),
                         unreadCount = 0,
                         avatarTiny = null,
@@ -668,7 +669,7 @@ class ConversationStream(
                 }
                 // endregion
             } else {
-                updateConversationFromNewMessage(matchingConversation, m, file.sqlUserDateMs())
+                updateConversationFromNewMessage(matchingConversation, m, file.orderingDateMs())
             }
         }
 
@@ -1138,11 +1139,11 @@ class ConversationStream(
         val rows = dbm.chatReadCount.selectAllConversationPlusLastMessage(c.getIdentityId())
         val afterQuery = Clock.System.now().toEpochMilliseconds()
 
-        // Carry the SQL `msgUserDate` (DriveMainIndex.userDate) alongside the
-        // file. The conversation list's `latestMessageTimestamp` must use this
-        // SQL value, not the clamped `MessageUiModel.userDate`, so it stays in
-        // lock-step with what `selectAllUnreadCount` filters on. See
-        // `HomebaseFile.sqlUserDateMs()` for the formula.
+        // Carry the SQL `msgUserDate` (MAX(DriveMainIndex.userDate, created))
+        // alongside the file. The conversation list's `latestMessageTimestamp` must
+        // use this SQL value, not the clamped `MessageUiModel.userDate`, so it stays
+        // in lock-step with what `selectAllUnreadCount` filters on. See
+        // `HomebaseFile.orderingDateMs()` for the formula.
         val msgByConversation = HashMap<Uuid, Pair<id.homebase.api.client.drives.HomebaseFile, Long?>>(rows.size)
         for (row in rows) {
             val convoId = row.conversation.fileMetadata.appData.uniqueId ?: continue

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/MessageMapperLateArrivalOrderingTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/MessageMapperLateArrivalOrderingTest.kt
@@ -1,0 +1,160 @@
+@file:OptIn(ExperimentalUuidApi::class)
+
+package id.homebase.chat.services
+
+import id.homebase.api.client.auth.ApiCredentials
+import id.homebase.api.client.auth.CredentialsManager
+import id.homebase.api.client.drives.HomebaseFile
+import id.homebase.api.common.OdinId
+import id.homebase.api.common.SecureByteArray
+import id.homebase.api.serialization.OdinSystemSerializer
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+import kotlinx.coroutines.test.runTest
+
+/**
+ * #1199 — a message that sat in the sender's outbox arrives stamped with its
+ * compose time. dotyoucore-js orders the chat list on `fileMetadata.created`
+ * (arrival) and labels the bubble with `appData.userDate` (compose time); these
+ * pin the same split for `MessageUiModel.sortDate` vs `userDate`.
+ */
+class MessageMapperLateArrivalOrderingTest {
+
+    private val self = "owner.test"
+    private val peer = "peer.test"
+
+    // 12:00 wall clock, the reported shape: composed 10:30, delivered 12:02.
+    private val noon = 1_780_000_000_000L
+    private val lateComposedMs = noon - 90 * 60_000L
+    private val lateArrivedMs = noon + 2 * 60_000L
+
+    private suspend fun credentials(): CredentialsManager = CredentialsManager().apply {
+        setActiveCredentials(
+            ApiCredentials.create(
+                domain = OdinId(self),
+                clientAccessToken = "test-token",
+                sharedSecret = SecureByteArray(ByteArray(16)),
+            )
+        )
+    }
+
+    private fun header(
+        author: String,
+        userDateMs: Long,
+        arrivedMs: Long,
+    ): HomebaseFile = OdinSystemSerializer.deserialize<HomebaseFile>(
+        """{
+            "fileId": "${Uuid.random()}",
+            "driveId": "${Uuid.random()}",
+            "fileState": "active",
+            "fileSystemType": "standard",
+            "serverFileIsEncrypted": false,
+            "keyHeader": {
+                "iv": [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],
+                "aesKey": {"bytes": [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]}
+            },
+            "fileMetadata": {
+                "globalTransitId": "${Uuid.random()}",
+                "created": $arrivedMs,
+                "updated": $arrivedMs,
+                "transitCreated": $arrivedMs,
+                "transitUpdated": 0,
+                "isEncrypted": false,
+                "senderOdinId": "$author",
+                "originalAuthor": "$author",
+                "appData": {
+                    "uniqueId": "${Uuid.random()}",
+                    "tags": null,
+                    "fileType": ${ChatProtocol.MessageFileType},
+                    "dataType": 0,
+                    "groupId": "00000000-0000-0000-0000-0000000000bb",
+                    "userDate": $userDateMs,
+                    "content": "{\"message\":\"hi\",\"deliveryStatus\":20}",
+                    "previewThumbnail": null,
+                    "archivalStatus": 0
+                },
+                "localAppData": null,
+                "referencedFile": null,
+                "reactionPreview": null,
+                "versionTag": "${Uuid.random()}",
+                "payloads": [],
+                "dataSource": null
+            },
+            "serverMetadata": {
+                "accessControlList": {
+                    "requiredSecurityGroup": "owner",
+                    "circleIdList": null,
+                    "odinIdList": null
+                },
+                "doNotIndex": false,
+                "allowDistribution": true,
+                "fileSystemType": "standard",
+                "fileByteCount": 100,
+                "originalRecipientCount": 1,
+                "transferHistory": null
+            },
+            "priority": 300,
+            "fileByteCount": 100
+        }"""
+    )
+
+    private suspend fun map(header: HomebaseFile) =
+        mapToMessageData(header, credentials()) { it.fileMetadata.originalAuthor?.domainName ?: "" }!!
+
+    @Test
+    fun lateArrivalSortsToTheTailButStillDisplaysItsComposeTime() = runTest {
+        // Three ordinary messages: delivered a second or so after they were composed.
+        val ordinary = (0..2).map { i ->
+            val composed = noon - (2 - i) * 60_000L
+            map(header(peer, userDateMs = composed, arrivedMs = composed + 1_200L))
+        }
+        val late = map(header(peer, userDateMs = lateComposedMs, arrivedMs = lateArrivedMs))
+
+        val ordered = (ordinary + late).sortedBy { it.sortDate }
+
+        assertEquals(
+            late.id,
+            ordered.last().id,
+            "a message delivered 92 min after it was composed belongs at the tail, as web shows it",
+        )
+        assertEquals(
+            ordinary.map { it.id },
+            ordered.dropLast(1).map { it.id },
+            "ordinary send latency must not reshuffle anything",
+        )
+        assertEquals(
+            lateComposedMs,
+            late.userDate.toEpochMilliseconds(),
+            "the bubble still reads 10:30 — only the position moved",
+        )
+        assertEquals(lateArrivedMs, late.sortDate.toEpochMilliseconds())
+    }
+
+    @Test
+    fun sortingOnComposeTimeIsWhatBuriedIt() {
+        // Sanity: the ordering this replaces. Kept so the regression stays visible.
+        val composed = listOf(noon - 120_000L, noon - 60_000L, noon, lateComposedMs)
+        assertEquals(lateComposedMs, composed.sorted().first())
+    }
+
+    @Test
+    fun ownMessageHeldInOurOwnOutboxAlsoSortsByArrival() = runTest {
+        // Our own late send: the file is only created on our identity once the
+        // upload finally lands, so `created` is the arrival stamp there too.
+        val own = map(header(self, userDateMs = lateComposedMs, arrivedMs = lateArrivedMs))
+        assertEquals(lateArrivedMs, own.sortDate.toEpochMilliseconds())
+        assertEquals(lateComposedMs, own.userDate.toEpochMilliseconds())
+    }
+
+    @Test
+    fun aSenderClockAheadOfTheServerStillClampsToArrival() = runTest {
+        // The pre-existing one-sided clamp must survive: a peer an hour ahead is
+        // pulled back for display AND for position — sortDate maxes over the
+        // clamped value, so it can't jump to the tail.
+        val fastClock = map(header(peer, userDateMs = noon + 3_600_000L, arrivedMs = noon))
+        assertEquals(noon, fastClock.userDate.toEpochMilliseconds())
+        assertEquals(noon, fastClock.sortDate.toEpochMilliseconds())
+    }
+}


### PR DESCRIPTION
Fixes #1199

## Phase 1 — the web baseline (this was the blocker)

**dotyoucore-js orders live-arriving chat messages on arrival (`fileMetadata.created`), never on `appData.userDate`, and it counts unread on the same key while the bubble renders `userDate`.** `userDate` appears nowhere in a web sort. That is the whole answer, and it holds on both the cold-load and the websocket path.

**Cold load.** `getChatMessages` passes no `sorting`, so it takes the server default:

```ts
// chat-app/src/providers/ChatProvider.ts:118
const ro: GetBatchQueryResultOptions = {
  maxRecords: pageSize,
  cursorState: cursorState,
  includeMetadataHeader: true,
  includeTransferHistory: true,
};
const response = await queryBatch(dotYouClient, params, ro);
```

```ts
// js-lib/src/core/DriveData/Drive/DriveTypes.ts:86
sorting?: 'fileId' | 'userDate' | 'createdDate' | 'anyChangeDate' | 'onlyModifiedDate' // default is 'fileId'
```

Server-side that default resolves to the `created` column, newest first:

```csharp
// DotYouCore/src/services/.../QueryBatchResultOptions.cs:12
public QueryBatchSortField Sorting { get; set; } = QueryBatchSortField.CreatedDate;

// DotYouCore/src/core/.../QueryBatch.cs:276
if ((sortField == QueryBatchSortField.CreatedDate) || (sortField == QueryBatchSortField.FileId))
    timeField = "created";
```

(Both the documented `fileId` default and the actual `CreatedDate` default map to the same column, so it doesn't matter which the client thinks it is getting.) `ChatHistory.tsx` then flattens the pages with **no client-side re-sort** — server order *is* display order. Posts, by contrast, do pass `sorting: 'userDate'` explicitly (`PostProvider.ts:59`) — chat deliberately does not.

**Live arrival.** `useChatWebsocket` hands a `fileAdded` straight to `insertNewMessage` → `internalInsertNewMessage`, which prepends into page 0 and re-sorts that page:

```ts
// chat-app/src/hooks/chat/useChatMessages.ts:329
searchResults:
  index === 0
    ? [newMessage, ...filteredSearchResults].sort(
        (a, b) => (b.fileMetadata.created || 0) - (a.fileMetadata.created || 0)
      ) // Re-sort the first page, as the new message might be older than the first message in the page;
    : filteredSearchResults,
```

So it is not a naive tail-append — it is an explicit re-sort on `created`, with a comment saying exactly why. Same key as the cold load, so restarting the web client does not move the message.

**Display vs sort really are different fields in web:**

```ts
// chat-app/src/components/Chat/Detail/ChatSentTimeIndicator.tsx:22
(msg.fileMetadata.appData.userDate && new Date(msg.fileMetadata.appData.userDate)) || undefined
```

and even the day separator is keyed on arrival, not compose time (`ChatHistory.tsx:166`, `const currentDate = msg?.fileMetadata.created`).

**Unread, in web, uses the same arrival key** — and this turned out to be a second, independent finding:

```ts
// chat-app/src/hooks/chat/useMarkMessagesAsRead.ts:33
const unreadMessages = messages.filter(
  (msg) =>
    (msg?.fileMetadata.transitCreated || msg?.fileMetadata.created) >
      (conversation.fileMetadata.localAppData?.content?.lastReadTime || 0) && …
```

and it writes `lastReadTime` back as `max(transitCreated || created)`. That is the **shared, synced** `localAppData.lastReadTime` on the conversation file. chat-kmp has been writing that same field from `viewedRecords.maxOf { it.sqlUserDate }` — a compose-time value into a slot web reads as an arrival time. The two clients have been disagreeing about read state, not just ordering.

Finally, on the recipient's drive `created` genuinely is arrival: `driveMainIndex` is inserted with `created = SqlNow()` (`TableDriveMainIndex.cs:88`), `PeerFileWriter.cs:262` stamps `TransitCreated = UnixTimeUtc.Now()` in the same write, and `DriveQuery.cs:248` serves the row's `created` back to the client. Our local mirror already stores it: `DriveMainIndex.created = header.fileMetadata.created.milliseconds`.

So the screenshots are fully explained, and there is no other explanation to fall back on: web put Shelly's message at the tail because it sorts on arrival (11:53) and labelled it `10.17` because it renders `userDate`. We sorted on `10.17`.

## Phase 2 — policy

**Option 1: sort by arrival, display compose time.** It is what web does, so it is what parity requires.

- **Option 2 (lag guard, the #1158 recommendation) rejected.** Web has no threshold. Any threshold means the two clients agree only above it and quietly disagree below it, which is the failure mode this issue exists to close. It was attractive only as a way to avoid the one-time unread recount noted below — not a good enough reason to ship a deliberate divergence.
- **Option 3 (affordance only) rejected** as the whole fix, per the issue: it leaves the cross-client mismatch in place. Worth having on its own merits later; not this PR.

The key is spelled the same way in all three layers: `max(userDate, arrival)`. `max` rather than a bare `created` so a row without a server stamp (an optimistic/pending write) keeps its `userDate` instead of falling to the epoch, and so the change can never move a message *earlier* than it sits today.

## Phase 3 — the change

**Ordering**

- `MessageUiModel.sortDate` — new field, defaults to `userDate` for synthetic models.
- `MessageMapper` sets it to `maxOf(userDate, metadata.created)` — deliberately built on the **clamped** `userDate`, not on the raw column. The existing one-sided clamp (`min(rawUserDate, authorSpecificDate)`) is what stops a sender with a fast clock from jumping to the bottom; maxing over the clamped value preserves that. A test pins it.
- `ConversationListViewModel` sorts and day-groups the rendered list on `sortDate` (web groups its separator on `created` too). This is the render sort the `MessageWindow` KDoc already delegates to — the in-memory window and its paging cursors stay on `userDate`, so `QueryBatchSortField.UserDate`, `idx_chatmessage_convid_userDate` and the trim/append/prepend invariants are untouched.

**Unread**

- `ChatReadCount.sq`: `selectAllUnreadCount` and `selectUnreadCountForConversation` now filter `MAX(d.userDate, d.created) > c.lastReadTime`; `selectAllConversationPlusLastMessage` returns `MAX(m.userDate, m.created)` as `msgUserDate`.
- `ChatMessageActionService.markAsReadByFiles` advances `lastReadTime` from `maxOf(sqlUserDate, created)` — the same two columns, so the write side and the filter can't drift (and we stop writing a compose time into the field web reads as an arrival time).
- `HomebaseFile.orderingDateMs()` is the single definition of the SQL-scale key; `ConversationStream`'s live bump and `ConversationMapper`'s cold-load last-message use it, so a late arrival bumps the conversation's preview and badge immediately instead of falling into `applyIncomingMessageBump`'s "older than the last message → leave untouched" branch, which is where the reported "no unread affordance" came from.

**Index.** `MAX(d.userDate, d.created)` needs `created`, which `idx_unread_cover` doesn't carry, so the unread scan would drop to a per-row table lookup — the ~2.9s cold `GROUP BY` that index exists to prevent. `idx_unread_cover_v2` adds it. A **new name** is required: `CREATE INDEX IF NOT EXISTS` under the old name would leave every existing install on the old shape. `Schema.create()` runs on every open and `created` has been on the table since v5, so existing installs pick the new index up on next launch — **no `DATABASE_VERSION` bump, no wipe, no re-sync.** `EXPLAIN QUERY PLAN` is asserted in a test.

## Known one-time effect

Stored `ChatReadCount.lastReadTime` values written by older builds are compose-time. Against the new predicate, a conversation whose last read message was peer-authored can show `1` unread once, because that message's `created` is a few hundred ms past the stored boundary. It clears the moment the conversation is opened. I did not add a grace window to hide it: the scale correction is the point (see the `lastReadTime` finding above), and a fudge factor is the threshold that Phase 2 rejected, wearing a different hat.

## Deferred, deliberately

`selectAllConversationPlusLastMessage` still picks *which* row is the last message with `ORDER BY m2.userDate DESC LIMIT 1`. Re-keying that needs an expression index over `MAX(userDate, created)` to replace the `(groupId, fileType, userDate DESC)` seek, and that is a real cold-boot perf risk for a cosmetic gain. Consequence: in the late-arrival case, the conversation-list *preview text* can revert to the second-newest message after a cold restart. The badge and the message's position in the conversation are correct. Worth a follow-up issue if it is ever seen in the wild.

## Tests

Two new files, both red before the change.

`MessageMapperLateArrivalOrderingTest` — a message delivered 92 min after it was composed sorts to the tail while its bubble still reads 10:30; three ordinary messages with sub-second send latency do not reshuffle; our own late send behaves the same; a peer an hour ahead of the server still clamps (this one caught a real bug in the first draft, where `sortDate` was built on the un-clamped column and would have undone the existing fast-clock protection).

`UnreadCountLateArrivalTest` — the late message is counted unread by both `selectAllUnreadCount` and `selectUnreadCountForConversation`; the pre-fix predicate is run against the same rows and returns 0, so the regression stays visible; `EXPLAIN QUERY PLAN` asserts the scan stays covering.

```
$ ./gradlew homebase-chat:jvmTest homebase-common:jvmTest homebase-auth:jvmTest homebase-api:jvmTest --rerun-tasks
> Task :homebase-auth:jvmTest
> Task :homebase-common:jvmTest
> Task :homebase-api:jvmTest
> Task :homebase-chat:jvmTest

BUILD SUCCESSFUL in 1m 56s
76 actionable tasks: 76 executed
```

Per-module totals from the JUnit XML:

```
homebase-api:    tests=1204 failures=0 errors=0 skipped=0
homebase-chat:   tests=1226 failures=0 errors=0 skipped=6
homebase-common: tests=529  failures=0 errors=0 skipped=0
homebase-auth:   tests=14   failures=0 errors=0 skipped=0
```

The two new suites:

```
<testsuite name="MessageMapperLateArrivalOrderingTest[jvm]" tests="4" skipped="0" failures="0" errors="0" time="0.282">
  <testcase name="sortingOnComposeTimeIsWhatBuriedIt[jvm]" time="0.019"/>
  <testcase name="lateArrivalSortsToTheTailButStillDisplaysItsComposeTime[jvm]" time="0.248"/>
  <testcase name="aSenderClockAheadOfTheServerStillClampsToArrival[jvm]" time="0.002"/>
  <testcase name="ownMessageHeldInOurOwnOutboxAlsoSortsByArrival[jvm]" time="0.007"/>

<testsuite name="UnreadCountLateArrivalTest[jvm]" tests="4" skipped="0" failures="0" errors="0" time="1.172">
  <testcase name="unreadCountStaysOnACoveringIndex[jvm]" time="1.142"/>
  <testcase name="composeTimeOnlyPredicateMissesIt[jvm]" time="0.01"/>
  <testcase name="lateArrivingMessageIsCountedUnread[jvm]" time="0.006"/>
  <testcase name="perConversationUnreadCountAgreesWithTheListQuery[jvm]" time="0.009"/>
```

`DriveMainIndexCreateOrderTest` was updated for the index rename — it asserts the stale-schema recovery produces the covering index by name, and its scenario (a new index over a column a v4 table lacks) is unchanged.

Cross-target compile, since `homebase-api` was touched:

```
$ ./gradlew :homebase-api:compileKotlinIosSimulatorArm64 :homebase-api:compileKotlinWasmJs \
            :homebase-chat:compileKotlinIosSimulatorArm64 :homebase-chat:compileKotlinWasmJs
BUILD SUCCESSFUL in 1m 6s
58 actionable tasks: 42 executed, 2 from cache, 14 up-to-date
```

Not device-verified: reproducing this needs a peer to compose a message offline and reconnect ~90 minutes later, which I can't stage without sending from a real account.

## Acceptance

- [x] Confirmed, in writing, what dotyoucore-js orders live-arriving messages on — arrival (`fileMetadata.created`), quoted above from both the cold-load and websocket paths.
- [x] A message arriving ≫ its compose time is visible and countable as unread.
- [x] chat-kmp and web place the same message at the same position — same key (`created`), same day-separator key, same display field.
- [x] `selectAllUnreadCount` re-checked against the chosen ordering: same key, and the covering index re-established with an `EXPLAIN QUERY PLAN` assertion.
