### PR TITLE
Give the attachment caption its own emoji picker

### DIFF
--- a/androidApp/src/main/kotlin/id/homebase/feed/share/ShareReceiverActivity.kt
+++ b/androidApp/src/main/kotlin/id/homebase/feed/share/ShareReceiverActivity.kt
@@ -326,6 +326,7 @@ class ShareReceiverActivity : ComponentActivity(), KoinComponent {
                     is ShareScreenState.Previewing -> {
                         val textFieldState = remember { RichTextState() }
                         var currentPage by remember { mutableStateOf(0) }
+                        var captionEmojiPickerOpen by remember { mutableStateOf(false) }
 
                         if (editorAttachments.isEmpty()) {
                             // User removed all files — go back to picker
@@ -376,11 +377,11 @@ class ShareReceiverActivity : ComponentActivity(), KoinComponent {
                                         )
                                     }
                                 },
+                                collapseSecondaryChrome = captionEmojiPickerOpen,
                                 bottomBar = {
                                     MessageTextFieldForAttachment(
                                         modifier = Modifier.fillMaxWidth().padding(16.dp).imePadding(),
                                         state = textFieldState,
-                                        onSmileyClick = {},
                                         onSendMessage = {
                                             sendEditedFiles(
                                                 conversationIds = state.selectedConversationIds,
@@ -388,6 +389,7 @@ class ShareReceiverActivity : ComponentActivity(), KoinComponent {
                                                 files = editorAttachments,
                                             )
                                         },
+                                        onEmojiPickerVisibilityChanged = { captionEmojiPickerOpen = it },
                                     )
                                 },
                             )

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationMessagesPane.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationMessagesPane.kt
@@ -364,6 +364,7 @@ fun ConversationMessagesPane(
                     }
 
                     is FullScreenOverlay.AttachmentData -> {
+                        var captionEmojiPickerOpen by remember { mutableStateOf(false) }
                         MediaAttachmentEditor(
                             attachments = data.attachments,
                             currentPage = currentGalleryPage,
@@ -428,14 +429,15 @@ fun ConversationMessagesPane(
                                     )
                                 }
                             },
+                            collapseSecondaryChrome = captionEmojiPickerOpen,
                             bottomBar = {
                                 MessageTextFieldForAttachment(
                                     modifier = Modifier.fillMaxWidth().padding(16.dp).imePadding(),
                                     state = textFieldState,
-                                    onSmileyClick = {},
                                     onSendMessage = {
                                         onUiAction(SendFile(data.conversationId, textFieldState.toMessageMarkdown(), data.attachments))
                                     },
+                                    onEmojiPickerVisibilityChanged = { captionEmojiPickerOpen = it },
                                 )
                             },
                         )

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageInputBar.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageInputBar.kt
@@ -72,7 +72,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.backhandler.BackHandler
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
@@ -90,7 +92,9 @@ import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.font.FontStyle
@@ -124,7 +128,9 @@ import id.homebase.core.ui.theme.HomebaseTheme
 import id.homebase.core.util.isDesktopOrWeb
 import id.homebase.core.util.isMobile
 import id.homebase.core.util.keyboardAsState
+import id.homebase.core.util.programmaticBackspace
 import id.homebase.core.util.toMessageMarkdown
+import id.homebase.core.widget.EmojiSelection
 import id.homebase.resources.MR
 import id.homebase.resources.cancel
 import id.homebase.resources.chat_message_attachment_options
@@ -161,6 +167,12 @@ import org.koin.compose.koinInject
 import kotlin.math.roundToInt
 
 internal const val COMPOSER_EXPAND_TOGGLE_TAG = "composer_expand_toggle"
+internal const val ATTACHMENT_CAPTION_FIELD_TAG = "attachment_caption_field"
+internal const val ATTACHMENT_EMOJI_BUTTON_TAG = "attachment_emoji_button"
+internal const val ATTACHMENT_EMOJI_PICKER_TAG = "attachment_emoji_picker"
+
+private val EMOJI_PANEL_HEIGHT = 300.dp
+private const val EMOJI_PANEL_MAX_HEIGHT_FRACTION = 0.45f
 
 // Link previews are auto-detected from typed URLs, so on their own they don't signal intent to send.
 private fun hasSendableContent(state: RichTextState, payloadRenderers: List<PayloadRenderer>) =
@@ -1189,21 +1201,31 @@ private fun MessageEditMessageInfo(
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalComposeUiApi::class)
 @Composable
 fun MessageTextFieldForAttachment(
     modifier: Modifier = Modifier,
     state: RichTextState,
-    onSmileyClick: () -> Unit,
     onSendMessage: () -> Unit,
     // Mirror the chat composer: the rich-text formatting toolbar is desktop/web-only.
     // On mobile (Android/iOS) the caption editor hides it. Injectable so both branches
     // are unit-testable without a device.
     showFormattingToolbar: Boolean = isDesktopOrWeb(),
+    onEmojiPickerVisibilityChanged: (Boolean) -> Unit = {},
 ) {
     var hasSent by remember { mutableStateOf(false) }
+    var showEmojiPicker by remember { mutableStateOf(false) }
     val isKeyboardVisible by keyboardAsState()
     val keyboardController = LocalSoftwareKeyboardController.current
+    val focusManager = LocalFocusManager.current
+
+    fun setEmojiPicker(visible: Boolean) {
+        if (showEmojiPicker == visible) return
+        showEmojiPicker = visible
+        onEmojiPickerVisibilityChanged(visible)
+    }
+
+    @Suppress("DEPRECATION") BackHandler(showEmojiPicker) { setEmojiPicker(false) }
 
     EmojiShortcodeEffect(state)
 
@@ -1221,27 +1243,41 @@ fun MessageTextFieldForAttachment(
         ) {
             RichTextEditor(
                 state = state,
-                modifier = Modifier.weight(1f).onPreviewKeyEvent { keyEvent ->
-                    if (isDesktopOrWeb() && keyEvent.key == Key.Enter && keyEvent.type == KeyEventType.KeyDown) {
-                        if (keyEvent.isShiftPressed) {
-                            state.addTextAfterSelection("\n")
-                            true
-                        } else if (!hasSent) {
-                            hasSent = true
-                            onSendMessage()
-                            true
+                modifier = Modifier.weight(1f).testTag(ATTACHMENT_CAPTION_FIELD_TAG)
+                    // Tapping into the caption closes the panel; the keyboard reclaims the space.
+                    .onFocusChanged { if (it.isFocused) setEmojiPicker(false) }
+                    .onPreviewKeyEvent { keyEvent ->
+                        if (isDesktopOrWeb() && keyEvent.key == Key.Enter && keyEvent.type == KeyEventType.KeyDown) {
+                            if (keyEvent.isShiftPressed) {
+                                state.addTextAfterSelection("\n")
+                                true
+                            } else if (!hasSent) {
+                                hasSent = true
+                                onSendMessage()
+                                true
+                            } else {
+                                true
+                            }
                         } else {
-                            true
+                            false
                         }
-                    } else {
-                        false
-                    }
-                },
+                    },
                 placeholder = {
                     Text(stringResource(MR.string.chat_new_message_placeholder))
                 },
                 leadingIcon = {
-                    IconButton(onClick = onSmileyClick) {
+                    IconButton(
+                        onClick = {
+                            if (showEmojiPicker) {
+                                setEmojiPicker(false)
+                            } else {
+                                keyboardController?.hide()
+                                focusManager.clearFocus()
+                                setEmojiPicker(true)
+                            }
+                        },
+                        modifier = Modifier.testTag(ATTACHMENT_EMOJI_BUTTON_TAG),
+                    ) {
                         Icon(
                             imageVector = Icons.Default.EmojiEmotions,
                             contentDescription = stringResource(
@@ -1295,6 +1331,27 @@ fun MessageTextFieldForAttachment(
                     )
                 }
             }
+        }
+
+        // Emoji only, no sticker/GIF tabs: a caption is text, and a sticker isn't.
+        AnimatedVisibility(visible = showEmojiPicker) {
+            // MediaAttachmentEditor's media pager is the only weighted child of its
+            // Column, so it absorbs every dp this panel takes; a flat 300 dp measures
+            // it to 0 on a landscape phone and the attachment disappears. Cap against
+            // the viewport (the StickerMessage idiom) so the pager always keeps room.
+            val viewportHeightPx = LocalWindowInfo.current.containerSize.height
+            val panelHeight = with(LocalDensity.current) {
+                if (viewportHeightPx > 0)
+                    minOf(EMOJI_PANEL_HEIGHT, viewportHeightPx.toDp() * EMOJI_PANEL_MAX_HEIGHT_FRACTION)
+                else EMOJI_PANEL_HEIGHT
+            }
+            EmojiSelection(
+                modifier = Modifier.fillMaxWidth().height(panelHeight)
+                    .testTag(ATTACHMENT_EMOJI_PICKER_TAG),
+                messageInputMode = true,
+                onBackSpace = { state.programmaticBackspace() },
+                onEmojiSelected = { state.addTextAfterSelection(it) },
+            )
         }
     }
 }

--- a/homebase-chat/src/commonTest/kotlin/id/homebase/chat/widget/AttachmentToolbarVisibilityTest.kt
+++ b/homebase-chat/src/commonTest/kotlin/id/homebase/chat/widget/AttachmentToolbarVisibilityTest.kt
@@ -1,11 +1,15 @@
 package id.homebase.chat.widget
 
 import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsNotFocused
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.requestFocus
 import androidx.compose.ui.test.runComposeUiTest
 import com.mohamedrejeb.richeditor.model.rememberRichTextState
 import id.homebase.core.ui.theme.HomebaseTheme
 import kotlin.test.Test
+import kotlin.test.assertEquals
 
 /**
  * The fullscreen attachment editor's caption field must hide its rich-text
@@ -22,7 +26,6 @@ class AttachmentToolbarVisibilityTest {
             HomebaseTheme {
                 MessageTextFieldForAttachment(
                     state = rememberRichTextState(),
-                    onSmileyClick = {},
                     onSendMessage = {},
                     showFormattingToolbar = false,
                 )
@@ -38,7 +41,6 @@ class AttachmentToolbarVisibilityTest {
             HomebaseTheme {
                 MessageTextFieldForAttachment(
                     state = rememberRichTextState(),
-                    onSmileyClick = {},
                     onSendMessage = {},
                     showFormattingToolbar = true,
                 )
@@ -46,5 +48,60 @@ class AttachmentToolbarVisibilityTest {
         }
         waitForIdle()
         onNodeWithTag("attachment_formatting_toolbar").assertExists()
+    }
+
+    @Test
+    fun emojiButtonTogglesPicker() = runComposeUiTest {
+        setContent {
+            HomebaseTheme {
+                MessageTextFieldForAttachment(
+                    state = rememberRichTextState(),
+                    onSendMessage = {},
+                    showFormattingToolbar = false,
+                )
+            }
+        }
+        waitForIdle()
+        onNodeWithTag(ATTACHMENT_EMOJI_PICKER_TAG).assertDoesNotExist()
+
+        onNodeWithTag(ATTACHMENT_EMOJI_BUTTON_TAG).performClick()
+        waitForIdle()
+        onNodeWithTag(ATTACHMENT_EMOJI_PICKER_TAG).assertExists()
+
+        onNodeWithTag(ATTACHMENT_EMOJI_BUTTON_TAG).performClick()
+        waitForIdle()
+        onNodeWithTag(ATTACHMENT_EMOJI_PICKER_TAG).assertDoesNotExist()
+    }
+
+    @Test
+    fun emojiPickerSurvivesUnfocusedCaptionAndClosesWhenItRegainsFocus() = runComposeUiTest {
+        var reportedVisible: Boolean? = null
+        setContent {
+            HomebaseTheme {
+                MessageTextFieldForAttachment(
+                    state = rememberRichTextState(),
+                    onSendMessage = {},
+                    showFormattingToolbar = false,
+                    onEmojiPickerVisibilityChanged = { reportedVisible = it },
+                )
+            }
+        }
+        waitForIdle()
+
+        onNodeWithTag(ATTACHMENT_EMOJI_BUTTON_TAG).performClick()
+        waitForIdle()
+        onNodeWithTag(ATTACHMENT_EMOJI_PICKER_TAG).assertExists()
+        assertEquals(true, reportedVisible)
+
+        // The panel owns a search field of its own, so it has to stay up while the
+        // caption field is unfocused -- closing it on keyboard visibility instead
+        // tore it out the moment the user tapped the panel's own magnifier.
+        onNodeWithTag(ATTACHMENT_CAPTION_FIELD_TAG).assertIsNotFocused()
+        onNodeWithTag(ATTACHMENT_EMOJI_PICKER_TAG).assertExists()
+
+        onNodeWithTag(ATTACHMENT_CAPTION_FIELD_TAG).requestFocus()
+        waitForIdle()
+        onNodeWithTag(ATTACHMENT_EMOJI_PICKER_TAG).assertDoesNotExist()
+        assertEquals(false, reportedVisible)
     }
 }


### PR DESCRIPTION
Fixes #1393

## Root cause — it was never Windows-specific, and never a layout bug

The issue's hypothesis 1 asks whether this is attachment-specific or desktop-emoji-general.
It is neither: **the caption composer's emoji button was wired to nothing, on every platform.**

`MessageTextFieldForAttachment` — the caption editor that `MediaAttachmentEditor` renders as its
`bottomBar` — took an `onSmileyClick: () -> Unit`, and all three call sites passed `{}`:

| call site | value |
|---|---|
| `ConversationMessagesPane.kt` (chat, staged attachment) | `onSmileyClick = {}` |
| `ShareReceiverActivity.kt` (Android share sheet) | `onSmileyClick = {}` |
| `MomentDescriptionField.kt` (Moments composer — see below) | `onSmileyClick = {}` (default) |

So the button rendered, took the click, and dropped it. No IME-offset math, no z-order, no
`showEmojiSheet` involved — the issue's hypotheses 2/3/4 all concern
`ConversationContent`'s emoji sheet, which is a *different* panel belonging to the normal
composer and works fine. The reporter hit it on Windows, but Android/iOS/macOS/Linux were
equally dead.

**Scope answer for the acceptance criteria:** all Desktop platforms, not Windows-only; and
attachment-specific in the sense that only the *caption* editor was affected — the
no-attachment composer's emoji button is a separate code path and is untouched here.

## Fix

The parameter is deleted and the composable owns the panel itself: a local `showEmojiPicker`
plus an `EmojiSelection` (emoji only — no sticker/GIF tabs, a caption is text) that inserts at
the cursor with `state.addTextAfterSelection(...)`, the same call the working chat composer uses.

**Source-breaking change:** `MessageTextFieldForAttachment` is a public composable and
`onSmileyClick` was a required parameter. Both in-repo callers are updated in this PR. A new
optional `onEmojiPickerVisibilityChanged: (Boolean) -> Unit = {}` is added (see below).

## Review fixes folded in

1. **The panel's own search no longer closes the panel.** The first cut closed on
   `keyboardAsState()`, but `EmojiSelection(messageInputMode = true)` renders a magnifier that
   focus-requests a real search field — opening the IME and tearing the panel out from under the
   user, making emoji search unusable on mobile. Now it closes on *caption-field focus*
   (`.onFocusChanged { if (it.isFocused) … }`), matching both in-repo precedents:
   `ConversationContent.kt`'s `onFocused = { showEmojiSheet = false }` and
   `CommentComposer.kt:232`.

2. **Opening clears focus.** The button now pairs `keyboardController?.hide()` with
   `focusManager.clearFocus()`, as `ConversationContent.kt:1705-1706` and
   `CommentComposer.kt:242-243` both do. Without it the field stayed first responder with the
   keyboard down, and it's what makes (1)'s focus-based close fire on the next tap.

3. **The panel no longer starves the media pager.** `MediaAttachmentEditor` is a
   `Column(fillMaxSize)` whose pager `Box` is the only weighted child, so it absorbs every dp the
   panel takes. Two changes:
   - `onEmojiPickerVisibilityChanged` is hoisted in `ConversationMessagesPane` and
     `ShareReceiverActivity` and fed to the existing `collapseSecondaryChrome`, which hides the
     attachment strip + tool row while the picker is up (~132 dp back). This follows
     `MomentComposeScreen.kt:262`'s `collapseSecondaryChrome = descriptionFocused` exactly.
   - The panel height is capped to `min(300.dp, 45% of the viewport)` — the same
     viewport-fraction guard `StickerMessage.kt:81-87` uses. Collapsing the chrome alone still
     left ~23 dp for the pager in phone landscape (rotation does not recreate the composition:
     `MainActivity` declares `configChanges="orientation|screenSize|…"`, so the picker rotates in
     still open). With the cap, a 411 dp-tall landscape window gives the panel ~185 dp and the
     pager keeps ~90 dp — verified by render, see 05 below.

4. **BackHandler.** `BackHandler(showEmojiPicker) { … }` now swallows the back press.
   Previously back fell past the whole attachment editor, dropping the staged attachments and
   the typed caption.

Nits: the two test tags were `public const val` wedged mid-file; they are now `internal` and sit
with `COMPOSER_EXPAND_TOGGLE_TAG` in the file-level constant group.

**On `keyboardHeight.coerceAtLeast(300.dp)`:** deliberately not used here. That idiom works in
`ConversationContent` because it caches the *last* IME height in a `var`; the reachable helper,
`keyboardHeightAsState()`, reports the *live* inset — which is 0 exactly when the panel is up —
and its iOS actual is `TODO("Not yet implemented")`. The viewport cap in (3) is the bound that
actually does something here.

## Verification

All from the worktree, real output:

```
./gradlew :homebase-chat:compileKotlinJvm                    BUILD SUCCESSFUL in 16s
./gradlew :androidApp:compileDebugKotlin                     BUILD SUCCESSFUL in 36s
./gradlew :homebase-chat:compileKotlinIosSimulatorArm64      BUILD SUCCESSFUL in 31s
./gradlew :homebase-chat:compileKotlinWasmJs                 BUILD SUCCESSFUL in 17s

./gradlew homebase-chat:jvmTest homebase-common:jvmTest homebase-auth:jvmTest homebase-api:jvmTest
  homebase-chat:   tests=1224 failures=0 errors=0
  homebase-common: tests=529  failures=0 errors=0
  homebase-auth:   tests=14   failures=0 errors=0
  homebase-api:    tests=1200 failures=0 errors=0
  total 2967, 0 failures

./gradlew homebase-chat:jvmTest --tests "*AttachmentToolbarVisibilityTest*" --rerun-tasks
  <testsuite name="AttachmentToolbarVisibilityTest[jvm]" tests="4" skipped="0" failures="0" errors="0">
    emojiPickerSurvivesUnfocusedCaptionAndClosesWhenItRegainsFocus[jvm]
    emojiButtonTogglesPicker[jvm]
    toolbarHiddenWhenFlagFalse[jvm]
    toolbarShownWhenFlagTrue[jvm]
```

### Mutation-resistance (both mutations reverted afterwards)

```
# button onClick -> {}
emojiPickerSurvivesUnfocusedCaptionAndClosesWhenItRegainsFocus[jvm] FAILED
emojiButtonTogglesPicker[jvm]                                       FAILED

# .onFocusChanged { if (it.isFocused) setEmojiPicker(false) } removed
emojiPickerSurvivesUnfocusedCaptionAndClosesWhenItRegainsFocus[jvm] FAILED
  AssertionError at AttachmentToolbarVisibilityTest.kt:77
```

### Desktop verification

`screencapture` and `java.awt.Robot` are both blocked on this machine (no macOS Screen Recording
permission), so the running `desktopApp:run` window cannot be clicked or photographed by an
agent. Instead the acceptance criteria were driven on the **same Compose Desktop (skiko/JVM)
runtime the desktop app uses**, via a throwaway `runDesktopComposeUiTest` + `captureToImage()`
harness (deleted before commit), rendering the caption editor under a stand-in media pager
shaped like `MediaAttachmentEditor`'s Column:

- **(a) emoji button opens the picker** — 900x700 desktop window, caption `"look at this  photo"`
  typed, media staged: clicking the button renders the full emoji grid. PASS.
- **(b) emoji inserts at the cursor** — cursor set to offset 12 (right after `this`), one grid
  cell clicked; harness stdout: `HARNESS caption after emoji click = 'look at this🗨️  photo'`.
  Inserted at the cursor, not appended. PASS.
- **(c) no regression to the no-attachment composer** — that button is `MessageInputBar`'s own
  `onEmojiClick` → `ConversationContent`'s `showEmojiSheet`; this PR does not touch either, and
  the existing desktop `ComposerExpandToggleTest` over `MessageInputBar` still passes.
- **05-landscape** — an 890x411 window (phone-landscape shaped) with the picker open: the pager
  still measures ~90 dp rather than 0. PASS.

`./gradlew desktopApp:run` also boots the app clean from this worktree.

## Known sibling, deliberately out of scope

`MomentDescriptionField.kt:41` has the identical dead `onSmileyClick: () -> Unit = {}` button on
the Moments composer. Same bug, different screen — left for a separate PR rather than widening
this one.

## Residual limitation

On a phone in landscape the emoji panel is inherently cramped: even with the chrome collapsed and
the 45%-viewport cap, the pager gets roughly 90 dp of a 411 dp window. The attachment stays
visible and the grid stays scrollable, which is the bar this PR sets; a landscape-specific layout
(panel beside the pager rather than under it) would be a larger change and is not attempted here.
