### PR TITLE
Swipe a conversation row to archive or mark as read

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/archivedconversations/ArchivedConversationsScreen.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/archivedconversations/ArchivedConversationsScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
@@ -32,7 +33,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import id.homebase.chat.conversationlist.showTimedSnackbar
 import id.homebase.chat.widget.ConversationItem
+import id.homebase.core.localization.TranslationUtil
 import id.homebase.core.widget.HomebaseVerticalScrollbar
 import id.homebase.resources.MR
 import id.homebase.resources.chat_archived_chats
@@ -54,32 +57,36 @@ fun ArchivedConversationsScreen(
     val snackbarHostState = remember { SnackbarHostState() }
     val scope = rememberCoroutineScope()
 
-    LaunchedEffect(uiState.uiEvent) {
-        when (val event = uiState.uiEvent) {
-            null -> {}
-            is ArchivedConversationsUiEvent.Back -> {
-                viewModel.eventConsumed()
-                onNavigateBack()
-            }
+    LaunchedEffect(Unit) {
+        viewModel.uiEvents.collect { event ->
+            when (event) {
+                is ArchivedConversationsUiEvent.Back -> onNavigateBack()
 
-            is ArchivedConversationsUiEvent.Error -> {
-                viewModel.eventConsumed()
-                scope.launch { snackbarHostState.showSnackbar(message = event.errorMessage) }
-            }
+                is ArchivedConversationsUiEvent.Error -> {
+                    scope.launch { snackbarHostState.showSnackbar(message = event.errorMessage) }
+                }
 
-            is ArchivedConversationsUiEvent.NavigateToConversation -> {
-                viewModel.eventConsumed()
-                onShowConversation(event.conversationId)
-            }
+                is ArchivedConversationsUiEvent.ShowInfoMessage -> {
+                    val text = TranslationUtil.getString(event.res)
+                    val actionLabel = event.actionLabel?.let { TranslationUtil.getString(it) }
+                    // Launched on `scope`: showSnackbar suspends for the snackbar's whole
+                    // visible life, which would stall every event queued behind it.
+                    scope.launch {
+                        val result = snackbarHostState.showTimedSnackbar(text, actionLabel)
+                        if (result == SnackbarResult.ActionPerformed) {
+                            event.action?.let(viewModel::onUiAction)
+                        }
+                    }
+                }
 
-            is ArchivedConversationsUiEvent.NavigateToConversationSettings -> {
-                viewModel.eventConsumed()
-                onNavigateToConversationSettings(event.conversationId)
-            }
+                is ArchivedConversationsUiEvent.NavigateToConversation ->
+                    onShowConversation(event.conversationId)
 
-            is ArchivedConversationsUiEvent.NavigateToGroupSettings -> {
-                viewModel.eventConsumed()
-                onNavigateToGroupSettings(event.conversationId)
+                is ArchivedConversationsUiEvent.NavigateToConversationSettings ->
+                    onNavigateToConversationSettings(event.conversationId)
+
+                is ArchivedConversationsUiEvent.NavigateToGroupSettings ->
+                    onNavigateToGroupSettings(event.conversationId)
             }
         }
     }
@@ -143,20 +150,25 @@ fun ArchivedConversationsUi(
                             modifier = Modifier.fillMaxSize(),
                             state = listState,
                         ) {
-                            items(uiState.conversations) { conversation ->
-                                ConversationItem(
-                                    enrichedData = conversation,
-                                    onClick = {
-                                        onUiAction(ArchivedConversationsUiAction.ShowConversation(conversation.conversation.id))
-                                    },
-                                    onContactClick = {
-                                        onUiAction(ArchivedConversationsUiAction.ShowConversationSettings(conversation.conversation))
-                                    },
-                                    onArchiveClick = {
-                                        onUiAction(ArchivedConversationsUiAction.UnarchiveConversation(conversation.conversation.id))
-                                    },
-                                    isSelected = selectedConversationId == conversation.conversation.id,
-                                )
+                            items(
+                                uiState.conversations,
+                                key = { it.conversation.id },
+                            ) { conversation ->
+                                Box(modifier = Modifier.animateItem()) {
+                                    ConversationItem(
+                                        enrichedData = conversation,
+                                        onClick = {
+                                            onUiAction(ArchivedConversationsUiAction.ShowConversation(conversation.conversation.id))
+                                        },
+                                        onContactClick = {
+                                            onUiAction(ArchivedConversationsUiAction.ShowConversationSettings(conversation.conversation))
+                                        },
+                                        onArchiveClick = {
+                                            onUiAction(ArchivedConversationsUiAction.UnarchiveConversation(conversation.conversation.id))
+                                        },
+                                        isSelected = selectedConversationId == conversation.conversation.id,
+                                    )
+                                }
                             }
                         }
                         HomebaseVerticalScrollbar(

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/archivedconversations/ArchivedConversationsViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/archivedconversations/ArchivedConversationsViewModel.kt
@@ -3,6 +3,7 @@ package id.homebase.chat.archivedconversations
 import androidx.compose.runtime.Immutable
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import co.touchlab.kermit.Logger
 import id.homebase.api.client.auth.OwnerSessionRepository
 import id.homebase.chat.data.ConversationState
 import id.homebase.chat.data.ConversationUiModel
@@ -13,15 +14,23 @@ import id.homebase.chat.services.convo.EnrichedConversationUiModel
 import id.homebase.chat.services.convo.contact.ConnectionService
 import id.homebase.chat.services.convo.contact.ContactService
 import id.homebase.chat.services.requests.ConnectionRequestService
+import id.homebase.resources.MR
+import id.homebase.resources.action_undo
+import id.homebase.resources.chat_conversation_restored_confirmation
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toPersistentList
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.onFailure
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import org.jetbrains.compose.resources.StringResource
 import kotlin.uuid.Uuid
 
 private data class ArchivedConnectionContext(
@@ -42,6 +51,9 @@ class ArchivedConversationsViewModel(
     private val enricher = ConversationEnricher()
     private val _uiState = MutableStateFlow(ArchivedConversationsUiState())
     val uiState: StateFlow<ArchivedConversationsUiState> = _uiState.asStateFlow()
+
+    private val events = Channel<ArchivedConversationsUiEvent>(capacity = Channel.BUFFERED)
+    val uiEvents: Flow<ArchivedConversationsUiEvent> = events.receiveAsFlow()
 
     init {
         viewModelScope.launch {
@@ -107,54 +119,74 @@ class ArchivedConversationsViewModel(
     fun onUiAction(action: ArchivedConversationsUiAction) {
         when (action) {
             is ArchivedConversationsUiAction.BackClicked -> {
-                _uiState.update { it.copy(uiEvent = ArchivedConversationsUiEvent.Back) }
+                sendEvent(ArchivedConversationsUiEvent.Back)
             }
 
             is ArchivedConversationsUiAction.ShowConversation -> {
-                _uiState.update {
-                    it.copy(uiEvent = ArchivedConversationsUiEvent.NavigateToConversation(action.conversationId))
-                }
+                sendEvent(ArchivedConversationsUiEvent.NavigateToConversation(action.conversationId))
             }
 
             is ArchivedConversationsUiAction.UnarchiveConversation -> {
                 viewModelScope.launch {
                     try {
                         conversationService.unarchiveConversation(action.conversationId)
-                    } catch (e: Exception) {
-                        _uiState.update {
-                            it.copy(
-                                uiEvent = ArchivedConversationsUiEvent.Error(
-                                    e.message ?: "Failed to unarchive conversation"
-                                )
+                        sendEvent(
+                            ArchivedConversationsUiEvent.ShowInfoMessage(
+                                res = MR.string.chat_conversation_restored_confirmation,
+                                actionLabel = MR.string.action_undo,
+                                action = ArchivedConversationsUiAction.ArchiveConversation(
+                                    action.conversationId
+                                ),
                             )
-                        }
+                        )
+                    } catch (e: Exception) {
+                        sendEvent(
+                            ArchivedConversationsUiEvent.Error(
+                                e.message ?: "Failed to unarchive conversation"
+                            )
+                        )
                     }
                 }
             }
+
+            is ArchivedConversationsUiAction.ArchiveConversation -> {
+                viewModelScope.launch {
+                    try {
+                        conversationService.archiveConversation(action.conversationId)
+                    } catch (e: Exception) {
+                        sendEvent(
+                            ArchivedConversationsUiEvent.Error(
+                                e.message ?: "Failed to archive conversation"
+                            )
+                        )
+                    }
+                }
+            }
+
             is ArchivedConversationsUiAction.ShowConversationSettings -> {
                 if (action.conversation.isGroupConversation) {
-                    _uiState.update {
-                        it.copy(
-                            uiEvent = ArchivedConversationsUiEvent.NavigateToGroupSettings(
-                                (action.conversation.id.toString())
-                            )
+                    sendEvent(
+                        ArchivedConversationsUiEvent.NavigateToGroupSettings(
+                            action.conversation.id.toString()
                         )
-                    }
+                    )
                 } else {
-                    _uiState.update {
-                        it.copy(
-                            uiEvent = ArchivedConversationsUiEvent.NavigateToConversationSettings(
-                                (action.conversation.id.toString())
-                            )
+                    sendEvent(
+                        ArchivedConversationsUiEvent.NavigateToConversationSettings(
+                            action.conversation.id.toString()
                         )
-                    }
+                    )
                 }
             }
         }
     }
 
-    fun eventConsumed() {
-        _uiState.update { it.copy(uiEvent = null) }
+    private fun sendEvent(event: ArchivedConversationsUiEvent) {
+        events.trySend(event).onFailure {
+            Logger.w(throwable = it, tag = "ArchivedConversationsViewModel") {
+                "dropped ${event::class.simpleName}"
+            }
+        }
     }
 }
 
@@ -162,12 +194,16 @@ class ArchivedConversationsViewModel(
 data class ArchivedConversationsUiState(
     val isLoading: Boolean = true,
     val conversations: ImmutableList<EnrichedConversationUiModel> = persistentListOf(),
-    val uiEvent: ArchivedConversationsUiEvent? = null,
 )
 
 sealed interface ArchivedConversationsUiEvent {
     data object Back : ArchivedConversationsUiEvent
     data class Error(val errorMessage: String) : ArchivedConversationsUiEvent
+    data class ShowInfoMessage(
+        val res: StringResource,
+        val actionLabel: StringResource? = null,
+        val action: ArchivedConversationsUiAction? = null,
+    ) : ArchivedConversationsUiEvent
     data class NavigateToConversation(val conversationId: Uuid) : ArchivedConversationsUiEvent
     data class NavigateToGroupSettings(val conversationId: String) : ArchivedConversationsUiEvent
     data class NavigateToConversationSettings(val conversationId: String) : ArchivedConversationsUiEvent
@@ -177,6 +213,7 @@ sealed interface ArchivedConversationsUiAction {
     data object BackClicked : ArchivedConversationsUiAction
     data class ShowConversation(val conversationId: Uuid) : ArchivedConversationsUiAction
     data class UnarchiveConversation(val conversationId: Uuid) : ArchivedConversationsUiAction
+    data class ArchiveConversation(val conversationId: Uuid) : ArchivedConversationsUiAction
     data class ShowConversationSettings(val conversation: ConversationUiModel) :
         ArchivedConversationsUiAction
 }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationLifecycleHandler.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationLifecycleHandler.kt
@@ -22,6 +22,7 @@ import id.homebase.core.config.AppConfig
 import id.homebase.core.util.buildBlockUrl
 import id.homebase.core.util.buildConnectToIdentityUrl
 import id.homebase.resources.MR
+import id.homebase.resources.action_undo
 import id.homebase.resources.auto_connect_blocked
 import id.homebase.resources.auto_connect_duplicate_introductory_request
 import id.homebase.resources.auto_connect_failed_generic
@@ -33,7 +34,9 @@ import id.homebase.resources.auto_connect_recipient_not_configured
 import id.homebase.resources.auto_connect_recipient_rejected
 import id.homebase.resources.auto_connect_recipient_requires_upgrade
 import id.homebase.resources.auto_connect_recipient_unreachable
+import id.homebase.resources.chat_conversation_archived_confirmation
 import id.homebase.resources.chat_conversation_deleted_confirmation
+import id.homebase.resources.chat_conversation_restored_confirmation
 import id.homebase.resources.chat_conversation_deleting_in_progress
 import id.homebase.resources.chat_conversation_leaving_and_deleting_in_progress
 import id.homebase.resources.chat_error_accept_rejoin
@@ -99,28 +102,18 @@ internal class ConversationLifecycleHandler(
     fun handleShowContactInfo(action: ConversationListUiAction.ShowContactInfo) {
         if (action.odinId == uiState.value.ownerSession?.odinId?.domainName) {
             // Show self-conversation settings as owner profile
-            uiState.update {
-                it.copy(
-                    uiEvent = NavigateToConversationSettings(
-                        ChatProtocol.ConversationWithYourselfId.toString()
-                    )
+            sendEvent(
+                NavigateToConversationSettings(
+                    ChatProtocol.ConversationWithYourselfId.toString()
                 )
-            }
+            )
         } else {
-            uiState.update {
-                it.copy(
-                    uiEvent = NavigateToContactInfo(action.odinId)
-                )
-            }
+            sendEvent(NavigateToContactInfo(action.odinId))
         }
     }
 
     fun handleShowMessageInfo(action: ConversationListUiAction.ShowMessageInfo) {
-        uiState.update {
-            it.copy(
-                uiEvent = NavigateToMessageInfo((action.message))
-            )
-        }
+        sendEvent(NavigateToMessageInfo(action.message))
     }
 
     fun handleDismissSheet() {
@@ -142,7 +135,7 @@ internal class ConversationLifecycleHandler(
     fun handleConnectToIdentity(action: ConversationListUiAction.ConnectToIdentity) {
         uiState.value.ownerSession?.odinId?.let { currentUser ->
             val url = currentUser.buildConnectToIdentityUrl(action.odinId)
-            uiState.update { it.copy(uiEvent = ConversationListUiEvent.OpenUrl(url)) }
+            sendEvent(ConversationListUiEvent.OpenUrl(url))
         }
     }
 
@@ -154,18 +147,12 @@ internal class ConversationLifecycleHandler(
         uiState.value.ownerSession?.odinId?.let { currentUser ->
             val url =
                 "https://${currentUser.domainName}/owner/connections/${action.odinId.domainName}"
-            uiState.update { it.copy(uiEvent = ConversationListUiEvent.OpenUrl(url)) }
+            sendEvent(ConversationListUiEvent.OpenUrl(url))
         }
     }
 
     fun handleOpenSendConnectionRequestDialog(action: ConversationListUiAction.OpenSendConnectionRequestDialog) {
-        uiState.update {
-            it.copy(
-                uiEvent = ConversationListUiEvent.OpenSendConnectionRequestDialog(
-                    action.odinId
-                )
-            )
-        }
+        sendEvent(ConversationListUiEvent.OpenSendConnectionRequestDialog(action.odinId))
     }
 
     /* Conversation options */
@@ -180,23 +167,11 @@ internal class ConversationLifecycleHandler(
         val ownerOdinId = uiState.value.ownerSession?.odinId
         val peerOdinId = conversation.participants.firstOrNull { it != ownerOdinId }?.domainName
         if (conversation.isGroupConversation) {
-            uiState.update {
-                it.copy(
-                    uiEvent = NavigateToGroupSettings(
-                        (action.conversation.id.toString())
-                    )
-                )
-            }
+            sendEvent(NavigateToGroupSettings(action.conversation.id.toString()))
         } else if (!conversation.isWithSelf && peerOdinId != null) {
-            uiState.update { it.copy(uiEvent = NavigateToContactInfo(peerOdinId)) }
+            sendEvent(NavigateToContactInfo(peerOdinId))
         } else {
-            uiState.update {
-                it.copy(
-                    uiEvent = NavigateToConversationSettings(
-                        (action.conversation.id.toString())
-                    )
-                )
-            }
+            sendEvent(NavigateToConversationSettings(action.conversation.id.toString()))
         }
     }
 
@@ -268,6 +243,16 @@ internal class ConversationLifecycleHandler(
         scope.launch {
             try {
                 conversationService.archiveConversation(action.conversationId)
+                if (!action.isUndo) sendEvent(
+                    ShowInfoMessage(
+                        res = MR.string.chat_conversation_archived_confirmation,
+                        actionLabel = MR.string.action_undo,
+                        action = ConversationListUiAction.UnarchiveConversation(
+                            conversationId = action.conversationId,
+                            isUndo = true,
+                        ),
+                    )
+                )
             } catch (e: Exception) {
                 Logger.e(throwable = e, tag = "ConversationListViewModel") {
                     "Failed to archive conversation: ${e.message}"
@@ -281,6 +266,16 @@ internal class ConversationLifecycleHandler(
         scope.launch {
             try {
                 conversationService.unarchiveConversation(action.conversationId)
+                if (!action.isUndo) sendEvent(
+                    ShowInfoMessage(
+                        res = MR.string.chat_conversation_restored_confirmation,
+                        actionLabel = MR.string.action_undo,
+                        action = ConversationListUiAction.ArchiveConversation(
+                            conversationId = action.conversationId,
+                            isUndo = true,
+                        ),
+                    )
+                )
             } catch (e: Exception) {
                 Logger.e(throwable = e, tag = "ConversationListViewModel") {
                     "Failed to unarchive conversation: ${e.message}"

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListEvents.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListEvents.kt
@@ -1,0 +1,25 @@
+package id.homebase.chat.conversationlist
+
+import co.touchlab.kermit.Logger
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.onFailure
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.receiveAsFlow
+
+/**
+ * One-time UI events for the conversation list. Buffered because the single
+ * `uiState.uiEvent` slot this replaced overwrote an unconsumed event.
+ */
+internal class ConversationListEvents {
+    private val channel = Channel<ConversationListUiEvent>(capacity = Channel.BUFFERED)
+
+    val events: Flow<ConversationListUiEvent> = channel.receiveAsFlow()
+
+    fun send(event: ConversationListUiEvent) {
+        channel.trySend(event).onFailure {
+            Logger.w(throwable = it, tag = "ConversationListEvents") {
+                "dropped ${event::class.simpleName}"
+            }
+        }
+    }
+}

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListScreen.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListScreen.kt
@@ -16,8 +16,10 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.LocalMinimumInteractiveComponentSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -134,6 +136,20 @@ private const val LIST_PANE_MIN_PERCENT = 25
 private const val LIST_PANE_MAX_PERCENT = 50
 private val SPLITTER_HIT_WIDTH = 8.dp
 
+/**
+ * showSnackbar defaults to `Indefinite` whenever an action label is set, which pins the
+ * snackbar over the FAB and blocks every later snackbar on its mutex until the user taps
+ * the action — so the duration is always explicit here.
+ */
+internal suspend fun SnackbarHostState.showTimedSnackbar(
+    message: String,
+    actionLabel: String?,
+): SnackbarResult = showSnackbar(
+    message = message,
+    actionLabel = actionLabel,
+    duration = SnackbarDuration.Short,
+)
+
 @Composable
 fun ConversationListScreen(
     viewModel: ConversationListViewModel,
@@ -187,89 +203,65 @@ fun ConversationListScreen(
         }
     }
 
-    val infoString = (conversationsUiState.uiEvent as? ConversationListUiEvent.ShowInfoMessage)?.res?.let { stringResource(it) } ?: ""
-    LaunchedEffect(conversationsUiState.uiEvent) {
-        when (val event = conversationsUiState.uiEvent) {
-            is ConversationListUiEvent.NavigateBack -> {
-                viewModel.eventConsumed()
-                onNavigateBack()
-            }
+    LaunchedEffect(Unit) {
+        viewModel.uiEvents.collect { event ->
+            when (event) {
+                is ConversationListUiEvent.NavigateBack -> onNavigateBack()
 
-            is ConversationListUiEvent.ShowErrorMessage -> {
-                viewModel.eventConsumed()
-                scope.launch {
+                is ConversationListUiEvent.ShowErrorMessage -> {
                     val text = event.detail?.let { detail ->
                         TranslationUtil.getString(
                             event.res,
                             detail.ifBlank { TranslationUtil.getString(MR.string.error_unknown) },
                         )
                     } ?: TranslationUtil.getString(event.res)
-                    snackbarHostState.showSnackbar(message = text)
+                    scope.launch { snackbarHostState.showSnackbar(message = text) }
                 }
-            }
 
-            is ConversationListUiEvent.ShowInfoMessage -> {
-                viewModel.eventConsumed()
-                scope.launch { snackbarHostState.showSnackbar(message = infoString) }
-            }
+                is ConversationListUiEvent.ShowInfoMessage -> {
+                    val text = TranslationUtil.getString(event.res)
+                    val actionLabel = event.actionLabel?.let { TranslationUtil.getString(it) }
+                    // Launched on `scope` rather than awaited inline: showSnackbar suspends for
+                    // the snackbar's whole visible life, and blocking the collector would stall
+                    // every event queued behind it.
+                    scope.launch {
+                        val result = snackbarHostState.showTimedSnackbar(text, actionLabel)
+                        if (result == SnackbarResult.ActionPerformed) {
+                            event.action?.let(viewModel::onAction)
+                        }
+                    }
+                }
 
-            is ConversationListUiEvent.NavigateToNewConversation -> {
-                viewModel.eventConsumed()
-                onNavigateToNewConversation()
-            }
+                is ConversationListUiEvent.NavigateToNewConversation -> onNavigateToNewConversation()
 
-            is ConversationListUiEvent.NavigateToLiveLocationMap -> {
-                viewModel.eventConsumed()
-                onNavigateToLiveLocationMap()
-            }
+                is ConversationListUiEvent.NavigateToLiveLocationMap -> onNavigateToLiveLocationMap()
 
-            is ConversationListUiEvent.NavigateToLocationSetup -> {
-                viewModel.eventConsumed()
-                onNavigateToLocationSetup()
-            }
+                is ConversationListUiEvent.NavigateToLocationSetup -> onNavigateToLocationSetup()
 
-            is ConversationListUiEvent.NavigateToShareLocation -> {
-                viewModel.eventConsumed()
-                onNavigateToShareLocation(event.conversationId)
-            }
+                is ConversationListUiEvent.NavigateToShareLocation ->
+                    onNavigateToShareLocation(event.conversationId)
 
-            is ConversationListUiEvent.NavigateToShareContact -> {
-                viewModel.eventConsumed()
-                onNavigateToShareContact(event.conversationId)
-            }
+                is ConversationListUiEvent.NavigateToShareContact ->
+                    onNavigateToShareContact(event.conversationId)
 
-            is ConversationListUiEvent.NavigateToContactInfo -> {
-                viewModel.eventConsumed()
-                onNavigateToContactInfo(event.odinId)
-            }
+                is ConversationListUiEvent.NavigateToContactInfo ->
+                    onNavigateToContactInfo(event.odinId)
 
-            is ConversationListUiEvent.NavigateToGroupSettings -> {
-                viewModel.eventConsumed()
-                onNavigateToGroupSettings(event.conversationId)
-            }
+                is ConversationListUiEvent.NavigateToGroupSettings ->
+                    onNavigateToGroupSettings(event.conversationId)
 
-            is ConversationListUiEvent.NavigateToConversationSettings -> {
-                viewModel.eventConsumed()
-                onNavigateToConversationSettings(event.conversationId)
-            }
+                is ConversationListUiEvent.NavigateToConversationSettings ->
+                    onNavigateToConversationSettings(event.conversationId)
 
-            is ConversationListUiEvent.NavigateToMessageInfo -> {
-                viewModel.eventConsumed()
-                onNavigateToMessageInfo(
+                is ConversationListUiEvent.NavigateToMessageInfo -> onNavigateToMessageInfo(
                     event.message.conversationId,
                     event.message.id,
                     event.message.fileId,
                 )
-            }
 
-            is ConversationListUiEvent.ShareText -> {
-                viewModel.eventConsumed()
-                fileSystemHandler.shareText(event.text)
-            }
+                is ConversationListUiEvent.ShareText -> fileSystemHandler.shareText(event.text)
 
-            is ConversationListUiEvent.ShareFile -> {
-                viewModel.eventConsumed()
-                fileSystemHandler.shareFile(
+                is ConversationListUiEvent.ShareFile -> fileSystemHandler.shareFile(
                     file = Path(event.filePath),
                     onError = { error ->
                         scope.launch {
@@ -283,16 +275,11 @@ fun ConversationListScreen(
                         }
                     },
                 )
-            }
 
-            is ConversationListUiEvent.OpenFile -> {
-                viewModel.eventConsumed()
-                fileSystemHandler.openFile(Path(event.filePath), showChooser = true)
-            }
+                is ConversationListUiEvent.OpenFile ->
+                    fileSystemHandler.openFile(Path(event.filePath), showChooser = true)
 
-            is ConversationListUiEvent.SaveFileToDevice -> {
-                viewModel.eventConsumed()
-                fileSystemHandler.saveFile(
+                is ConversationListUiEvent.SaveFileToDevice -> fileSystemHandler.saveFile(
                     file = Path(event.filePath),
                     suggestedName = event.suggestedName,
                     onSuccess = { location ->
@@ -313,36 +300,21 @@ fun ConversationListScreen(
                         }
                     },
                 )
-            }
 
-            is ConversationListUiEvent.OpenUrl -> {
-                viewModel.eventConsumed()
-                fileSystemHandler.openUrl(event.url)
-            }
+                is ConversationListUiEvent.OpenUrl -> fileSystemHandler.openUrl(event.url)
 
-            is ConversationListUiEvent.OpenSendConnectionRequestDialog -> {
-                viewModel.eventConsumed()
-                connectRequestViewModel.onAction(
-                    ConnectRequestAction.OpenDialogWithRecipient(event.odinId)
-                )
-            }
+                is ConversationListUiEvent.OpenSendConnectionRequestDialog ->
+                    connectRequestViewModel.onAction(
+                        ConnectRequestAction.OpenDialogWithRecipient(event.odinId)
+                    )
 
-            is ConversationListUiEvent.NavigateToCropper -> {
-                viewModel.eventConsumed()
-                onNavigateToCropper(event.requestId)
-            }
+                is ConversationListUiEvent.NavigateToCropper -> onNavigateToCropper(event.requestId)
 
-            is ConversationListUiEvent.NavigateToDrawer -> {
-                viewModel.eventConsumed()
-                onNavigateToDrawer(event.requestId)
-            }
+                is ConversationListUiEvent.NavigateToDrawer -> onNavigateToDrawer(event.requestId)
 
-            is ConversationListUiEvent.NavigateToSaveContactCard -> {
-                viewModel.eventConsumed()
-                onSaveContactCard(event.descriptor)
+                is ConversationListUiEvent.NavigateToSaveContactCard ->
+                    onSaveContactCard(event.descriptor)
             }
-
-            null -> {}
         }
     }
 
@@ -557,7 +529,6 @@ fun ConversationListScreen(
             messageInputTextFieldState = viewModel.messageInputTextState,
             messagesSearchTextState = viewModel.messagesSearchTextState,
             onUiAction = viewModel::onAction,
-            onEventConsumed = viewModel::eventConsumed,
             onNavigateToSettingsScreen = onNavigateToSettingsScreen,
             onDetailPaneVisibilityChanged = onDetailPaneVisibilityChanged
         )
@@ -775,7 +746,6 @@ fun ConversationListUi(
      *  the in-scope scaffoldNavigator). Defaults to no-op so the existing call
      *  site at the bottom of the file (ConversationListUiPreview) and any other
      *  caller that doesn't drive events still compiles. */
-    onEventConsumed: () -> Unit = {},
     onNavigateToSettingsScreen: () -> Unit,
     onDetailPaneVisibilityChanged: (Boolean) -> Unit = {},
 ) {
@@ -827,9 +797,7 @@ fun ConversationListUi(
 
     // closeDetailPaneRequest handler — has to live inside ConversationListUi (not
     // the outer screen) because scaffoldNavigator + backNavigationBehavior are in
-    // scope here. Uses a dedicated state field rather than uiEvent because the
-    // delete flow also fires a snackbar event back-to-back, and uiEvent is a
-    // single slot — the snackbar would overwrite the close request.
+    // scope here.
     //
     // Pops the detail pane with PopUntilContentChange (same mechanic the
     // BackHandler uses) so this works in BOTH expanded (desktop) and compact
@@ -938,6 +906,14 @@ fun ConversationListUi(
                                     }
                                     is ArchivedConversationsUiAction.UnarchiveConversation -> {
                                         onUiAction(ConversationListUiAction.UnarchiveConversation(action.conversationId))
+                                    }
+                                    is ArchivedConversationsUiAction.ArchiveConversation -> {
+                                        onUiAction(
+                                            ConversationListUiAction.ArchiveConversation(
+                                                conversationId = action.conversationId,
+                                                isUndo = true,
+                                            )
+                                        )
                                     }
                                 }
                             },

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiAction.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiAction.kt
@@ -154,9 +154,16 @@ sealed interface ConversationListUiAction {
 
     data class DeleteConversation(val conversationId: Uuid) : ConversationListUiAction
     data class ConfirmDeleteConversation(val conversationId: Uuid) : ConversationListUiAction
-    data class ArchiveConversation(val conversationId: Uuid) : ConversationListUiAction
+    /** [isUndo] marks the inverse of a just-confirmed archive, which must not offer an undo of its own. */
+    data class ArchiveConversation(
+        val conversationId: Uuid,
+        val isUndo: Boolean = false,
+    ) : ConversationListUiAction
 
-    data class UnarchiveConversation(val conversationId: Uuid) : ConversationListUiAction
+    data class UnarchiveConversation(
+        val conversationId: Uuid,
+        val isUndo: Boolean = false,
+    ) : ConversationListUiAction
 
 
     data class ClearConversation(val conversationId: Uuid) : ConversationListUiAction

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiEvent.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiEvent.kt
@@ -13,7 +13,16 @@ sealed interface ConversationListUiEvent {
     data class NavigateToConversationSettings(val conversationId: String) : ConversationListUiEvent
     data class NavigateToMessageInfo(val message: MessageUiModel) : ConversationListUiEvent
     data class ShowErrorMessage(val res: StringResource, val detail: String? = null) : ConversationListUiEvent
-    data class ShowInfoMessage(val res: StringResource) : ConversationListUiEvent
+    /**
+     * Snackbar. [action] is dispatched back through `onAction` when the user taps
+     * [actionLabel] — a plain value rather than a lambda so the event stays
+     * comparable and testable off-device.
+     */
+    data class ShowInfoMessage(
+        val res: StringResource,
+        val actionLabel: StringResource? = null,
+        val action: ConversationListUiAction? = null,
+    ) : ConversationListUiEvent
     data class ShareText(val text: String) : ConversationListUiEvent
     data class ShareFile(val filePath: String) : ConversationListUiEvent
     data class OpenFile(val filePath: String) : ConversationListUiEvent

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiState.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiState.kt
@@ -54,7 +54,6 @@ data class ConversationListUiState(
      */
     val liveSharePinAnyUntilMs: Long? = null,
     val uiDialog: ConversationListUiDialog? = null,
-    val uiEvent: ConversationListUiEvent? = null,
     /** Non-null while a long-ish service op is in flight. Drives the full-screen
      *  scrim+spinner overlay so the user gets visible feedback that something is
      *  happening; otherwise the brief delay between tap and follow-up UI feels
@@ -65,11 +64,8 @@ data class ConversationListUiState(
      *  Null means no overlay. Cleared on both success and error. */
     val inFlightOperationLabel: StringResource? = null,
     /** When non-null, the screen should pop the scaffold detail pane (i.e. close the
-     *  open conversation). Use a dedicated state field rather than [uiEvent] because
-     *  delete fires multiple events back-to-back (close + snackbar) and `uiEvent` is
-     *  a single slot — successive sends overwrite each other and the close was being
-     *  eaten by the snackbar. The screen calls [closeDetailPaneRequestConsumed] when
-     *  it has handled the request. */
+     *  open conversation). The screen calls [closeDetailPaneRequestConsumed] when it
+     *  has handled the request. */
     val closeDetailPaneRequest: Uuid? = null,
 )
 

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
@@ -200,6 +200,9 @@ class ConversationListViewModel(
     private val _uiState = MutableStateFlow(ConversationListUiState())
     val uiState: StateFlow<ConversationListUiState> = _uiState.asStateFlow()
 
+    private val events = ConversationListEvents()
+    val uiEvents: Flow<ConversationListUiEvent> = events.events
+
     private val _messagesUiState = MutableStateFlow(
         MessageListUiState(
             userDefaultReactions = userPreferences.preferredUserReactions
@@ -1098,10 +1101,6 @@ class ConversationListViewModel(
         }.onFailure { Logger.e(throwable = it, tag = "LiveRelay") { "live-share update failed" } }
     }
 
-    fun eventConsumed() {
-        _uiState.update { it.copy(uiEvent = null) }
-    }
-
     fun dialogClosed() {
         _uiState.update { it.copy(uiDialog = null) }
     }
@@ -1269,9 +1268,7 @@ class ConversationListViewModel(
             }
 
             is ConversationListUiAction.NewConversationClicked -> {
-                _uiState.value = _uiState.value.copy(
-                    uiEvent = NavigateToNewConversation
-                )
+                sendEvent(NavigateToNewConversation)
             }
 
             is ConversationListUiAction.ClearSelection -> {
@@ -2205,7 +2202,7 @@ class ConversationListViewModel(
     }
 
     private fun sendEvent(event: ConversationListUiEvent) {
-        _uiState.update { it.copy(uiEvent = event) }
+        events.send(event)
     }
 
     /**

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationItem.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationItem.kt
@@ -1,12 +1,21 @@
 package id.homebase.chat.widget
 
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.absolutePadding
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -14,7 +23,10 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Archive
+import androidx.compose.material.icons.filled.MarkChatRead
 import androidx.compose.material.icons.filled.PushPin
+import androidx.compose.material.icons.filled.Unarchive
 import androidx.compose.material3.Badge
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -25,15 +37,22 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.AbsoluteAlignment
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.CustomAccessibilityAction
+import androidx.compose.ui.semantics.customActions
 import androidx.compose.ui.semantics.selected
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -51,8 +70,10 @@ import id.homebase.core.ui.theme.withEmojiFont
 import id.homebase.core.util.formatTimestamp
 import id.homebase.core.util.ifTrue
 import id.homebase.core.util.isDesktopOrWeb
+import id.homebase.core.util.isMobile
 import id.homebase.core.util.stripComposerLineBreakArtifacts
 import id.homebase.resources.MR
+import id.homebase.resources.chat_archive
 import id.homebase.resources.chat_archived
 import id.homebase.resources.chat_connection_invitation_received
 import id.homebase.resources.chat_connection_invitation_sent
@@ -62,12 +83,20 @@ import id.homebase.resources.chat_connection_wants_to_connect
 import id.homebase.resources.chat_conversation_draft
 import id.homebase.resources.chat_group_legacy
 import id.homebase.resources.chat_group_rejoin_pending
+import id.homebase.resources.chat_mark_all_as_read
 import id.homebase.resources.chat_no_messages
 import id.homebase.resources.chat_note_to_self
 import id.homebase.resources.chat_preview_sender_label
 import id.homebase.resources.chat_search_result_pinned
+import id.homebase.resources.chat_unarchive
 import id.homebase.resources.you
 import org.jetbrains.compose.resources.stringResource
+import kotlin.math.absoluteValue
+
+// Deliberately hard to reach: an accidental archive costs the user more than a missed swipe.
+private const val COMMIT_FRACTION_OF_ROW = 0.4f
+private const val MAX_TRAVEL_FRACTION_OF_ROW = 0.55f
+private const val FLICK_ESCAPE_VELOCITY_DP_PER_SECOND = 1000f
 
 @Composable
 fun ConversationItem(
@@ -78,271 +107,383 @@ fun ConversationItem(
     onMarkAsReadClick: (() -> Unit)? = null,
     onContactClick: (odinId: OdinId) -> Unit,
     isSelected: Boolean,
+    allowSwipeActions: Boolean = true,
 ) {
     var showMenu by rememberSaveable { mutableStateOf(false) }
 
     // Pointer rows follow Signal Desktop: one step down the type scale, title+preview as one block.
     val compact = isDesktopOrWeb()
 
-    Row(
+    val isArchived = enrichedData.conversation.conversationState == ConversationState.Archived
+    val archiveLabel = stringResource(
+        if (isArchived) MR.string.chat_unarchive else MR.string.chat_archive
+    )
+    val markAsReadLabel = stringResource(MR.string.chat_mark_all_as_read)
+    // Nothing to mark on an already-read row, so that direction stays inert rather than
+    // offering a no-op.
+    val markAsRead = onMarkAsReadClick?.takeIf { enrichedData.conversation.unreadCount > 0 }
+
+    // SwipeRevealBox works in physical screen space, so the RTL mirroring happens here.
+    val isRtl = LocalLayoutDirection.current == LayoutDirection.Rtl
+    val onSwipeRight = if (isRtl) markAsRead else onArchiveClick
+    val onSwipeLeft = if (isRtl) onArchiveClick else markAsRead
+
+    SwipeRevealBox(
+        onSwipeRight = onSwipeRight,
+        onSwipeLeft = onSwipeLeft,
+        enabled = allowSwipeActions && isMobile(),
         modifier = Modifier
             .fillMaxWidth()
             .padding(horizontal = if (compact) 8.dp else 16.dp)
-            .clip(RoundedCornerShape(8.dp))
-            .ifTrue(isSelected) {
-                Modifier.background(MaterialTheme.colorScheme.secondaryContainer)
-            }
-            .combinedClickable(
-                onClick = onClick,
-                onLongClick = { showMenu = true }
+            .clip(RoundedCornerShape(8.dp)),
+        commitThreshold = SwipeDistance.Fraction(COMMIT_FRACTION_OF_ROW),
+        maxOffset = SwipeDistance.Fraction(MAX_TRAVEL_FRACTION_OF_ROW),
+        escapeVelocityDpPerSecond = FLICK_ESCAPE_VELOCITY_DP_PER_SECOND,
+        // Archive/restore drops the row from this list, so it leaves rather than snapping
+        // back. Mark-as-read keeps the row, so that direction still springs back.
+        slideOutOnSwipeRight = !isRtl,
+        slideOutOnSwipeLeft = isRtl,
+        reveal = { state ->
+            val revealingArchive = (state.offsetPx > 0f) != isRtl
+            ConversationSwipeReveal(
+                state = state,
+                atLeftEdge = state.offsetPx > 0f,
+                icon = when {
+                    !revealingArchive -> Icons.Default.MarkChatRead
+                    isArchived -> Icons.Default.Unarchive
+                    else -> Icons.Default.Archive
+                },
+                label = if (revealingArchive) archiveLabel else markAsReadLabel,
+                // `tertiary` is unusable here — the app theme never defines it, so it
+                // falls back to Material's baseline purple.
+                container = if (revealingArchive) MaterialTheme.colorScheme.primary
+                else MaterialTheme.colorScheme.secondary,
+                onContainer = if (revealingArchive) MaterialTheme.colorScheme.onPrimary
+                else MaterialTheme.colorScheme.onSecondary,
             )
-            .semantics { selected = isSelected }
-            .padding(horizontal = if (compact) 10.dp else 12.dp, vertical = 12.dp),
-        verticalAlignment = Alignment.CenterVertically
+        },
     ) {
-        ConversationAvatar(
-            avatarModel = enrichedData.conversation.avatarModel,
-            modifier = Modifier.padding(if (compact) 0.dp else 8.dp),
-            options = AvatarOptions(onClick = { enrichedData.participants.firstOrNull()?.odinId?.let { onContactClick(it) } })
-        )
-
-        Spacer(modifier = Modifier.width(12.dp))
-
-        // Content
-        Column(modifier = Modifier.weight(1f)) {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                val title = if (enrichedData.conversation.isWithSelf)
-                    stringResource(MR.string.chat_note_to_self)
-                else enrichedData.getDisplayName(youLabel = stringResource(MR.string.you))
-                Text(
-                    text = title.withEmojiFont(),
-                    style = if (compact) MaterialTheme.typography.bodyMedium
-                    else MaterialTheme.typography.bodyLarge,
-                    fontWeight = if (enrichedData.conversation.unreadCount > 0) FontWeight.Bold else FontWeight.Normal,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                    modifier = Modifier.weight(1f)
-                )
-
-                Spacer(modifier = Modifier.width(8.dp))
-
-                if (enrichedData.conversation.isPinned) {
-                    Icon(
-                        imageVector = Icons.Default.PushPin,
-                        contentDescription = stringResource(MR.string.chat_search_result_pinned),
-                        modifier = Modifier.size(14.dp),
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                    Spacer(modifier = Modifier.width(4.dp))
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .ifTrue(isSelected) {
+                    Modifier.background(MaterialTheme.colorScheme.secondaryContainer)
                 }
-
-                Text(
-                    text = formatTimestamp(enrichedData.conversation.latestMessageTimestamp),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = if (enrichedData.conversation.unreadCount > 0) MaterialTheme.colorScheme.primary
-                    else MaterialTheme.colorScheme.onSurfaceVariant,
-                    fontWeight = if (enrichedData.conversation.unreadCount > 0) FontWeight.SemiBold else FontWeight.Normal
+                .combinedClickable(
+                    onClick = onClick,
+                    onLongClick = { showMenu = true }
                 )
-            }
-
-            Spacer(modifier = Modifier.height(if (compact) 0.dp else 4.dp))
-
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.Start,
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                // Strip richeditor's `<br>` empty-paragraph artifacts so a legacy `<br>` message
-                // shows its real text in the list preview, not a stray break / blank line (#1104).
-                val lastMessagePreview = remember(enrichedData.conversation.lastMessage) {
-                    enrichedData.conversation.lastMessage.stripComposerLineBreakArtifacts()
-                }
-                val contentLabel = messageContentLabel(
-                    textContent = lastMessagePreview,
-                    isDeleted = enrichedData.conversation.lastMessageIsDeleted,
-                    firstPayload = enrichedData.conversation.lastMessageFirstPayload,
-                    hasMultiplePayloads = enrichedData.conversation.lastMessageHasMultiplePayloads,
-                    messageContent = enrichedData.conversation.lastMessageContent,
-                )
-
-                // When there's no history for a 1:1 conversation with a pending connection
-                // request, swap the default "No messages yet" fallback for a line that
-                // actually tells the user what's happening.
-                val pendingSubtitle: String? = if (
-                    contentLabel == null &&
-                    lastMessagePreview.isBlank()
-                ) {
-                    when (enrichedData.oneOnOneConnectionStatus) {
-                        is OneOnOneConnectionStatus.OutgoingRequestPending ->
-                            stringResource(MR.string.chat_connection_invitation_sent)
-                        is OneOnOneConnectionStatus.IncomingRequestPending ->
-                            stringResource(MR.string.chat_connection_invitation_received)
-                        is OneOnOneConnectionStatus.NotConnected ->
-                            stringResource(MR.string.chat_connection_not_connected)
-                        else -> null
+                .semantics {
+                    selected = isSelected
+                    // A screen reader can't perform the swipe.
+                    customActions = buildList {
+                        add(CustomAccessibilityAction(archiveLabel) { onArchiveClick(); true })
+                        markAsRead?.let {
+                            add(CustomAccessibilityAction(markAsReadLabel) { it(); true })
+                        }
                     }
-                } else null
+                }
+                .padding(horizontal = if (compact) 10.dp else 12.dp, vertical = 12.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            ConversationAvatar(
+                avatarModel = enrichedData.conversation.avatarModel,
+                modifier = Modifier.padding(if (compact) 0.dp else 8.dp),
+                options = AvatarOptions(onClick = { enrichedData.participants.firstOrNull()?.odinId?.let { onContactClick(it) } })
+            )
 
-                val rawPreview = pendingSubtitle
-                    ?: contentLabel?.text
-                    ?: lastMessagePreview
-                val groupSenderName: String? = remember(
-                    enrichedData.conversation.isGroupConversation,
-                    enrichedData.conversation.lastMessageSender,
-                    enrichedData.participants,
+            Spacer(modifier = Modifier.width(12.dp))
+
+            // Content
+            Column(modifier = Modifier.weight(1f)) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
                 ) {
-                    if (!enrichedData.conversation.isGroupConversation) null
-                    else enrichedData.participants
-                        .firstOrNull { it.odinId == enrichedData.conversation.lastMessageSender }
-                        ?.name?.takeIf { it.isNotBlank() }
-                        ?.substringBefore(' ')
-                }
-                val senderLabel: String? = when {
-                    pendingSubtitle != null -> null
-                    enrichedData.conversation.isWithSelf -> null
-                    enrichedData.conversation.lastMessageIsFromActiveUser -> stringResource(MR.string.you)
-                    else -> groupSenderName
-                }
-                // Render the sender prefix ("You:" / a group member's name) BEFORE the
-                // content-type icon so it reads "You: <icon> Image", not "<icon> You: Image".
-                val senderPrefix = if (senderLabel != null && rawPreview.isNotBlank()) {
-                    stringResource(MR.string.chat_preview_sender_label, senderLabel)
-                } else {
-                    null
-                }
-                val iconRes = if (pendingSubtitle != null) null else contentLabel?.icon
+                    val title = if (enrichedData.conversation.isWithSelf)
+                        stringResource(MR.string.chat_note_to_self)
+                    else enrichedData.getDisplayName(youLabel = stringResource(MR.string.you))
+                    Text(
+                        text = title.withEmojiFont(),
+                        style = if (compact) MaterialTheme.typography.bodyMedium
+                        else MaterialTheme.typography.bodyLarge,
+                        fontWeight = if (enrichedData.conversation.unreadCount > 0) FontWeight.Bold else FontWeight.Normal,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.weight(1f)
+                    )
 
-                // A non-blank draft takes over the preview line ("Draft: …", tinted)
-                // so the row advertises unsent text the way every messenger does.
-                val draftRaw = enrichedData.conversation.draft
-                val draftPreview = remember(draftRaw) {
-                    draftRaw?.stripComposerLineBreakArtifacts()?.takeIf { it.isNotBlank() }
-                }
-                val draftLabel = stringResource(
-                    MR.string.chat_preview_sender_label,
-                    stringResource(MR.string.chat_conversation_draft),
-                )
-
-                ConversationMessagePreview(
-                    text = draftPreview ?: rawPreview,
-                    prefix = if (draftPreview != null) draftLabel else senderPrefix,
-                    prefixColor = if (draftPreview != null) MaterialTheme.colorScheme.error
-                    else MaterialTheme.colorScheme.onSurfaceVariant,
-                    iconRes = if (draftPreview != null) null else iconRes,
-                    isDeleted = draftPreview == null && enrichedData.conversation.lastMessageIsDeleted,
-                    modifier = Modifier.weight(1f)
-                )
-
-                if (enrichedData.conversation.unreadCount > 0) {
                     Spacer(modifier = Modifier.width(8.dp))
 
-                    Badge(
-                        containerColor = HomebaseTheme.extendedColors.bubbleSentSurface,
-                        contentColor = HomebaseTheme.extendedColors.bubbleSentOnSurface,
-                    ) {
-                        Text(
-                            modifier = Modifier.padding(4.dp),
-                            text = enrichedData.conversation.unreadCount.toString(),
-                            style = MaterialTheme.typography.labelSmall,
-                            fontWeight = FontWeight.Bold
+                    if (enrichedData.conversation.isPinned) {
+                        Icon(
+                            imageVector = Icons.Default.PushPin,
+                            contentDescription = stringResource(MR.string.chat_search_result_pinned),
+                            modifier = Modifier.size(14.dp),
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
                         )
+                        Spacer(modifier = Modifier.width(4.dp))
                     }
-                } else if (draftPreview == null && enrichedData.conversation.lastMessageIsFromActiveUser && enrichedData.conversation.lastMessageDeliveryStatus != null) {
-                    Spacer(modifier = Modifier.width(4.dp))
-                    DeliveryStatus(
-                        isPendingSend = enrichedData.conversation.lastMessageIsPendingSend,
-                        deliveryStatus = enrichedData.conversation.lastMessageDeliveryStatus,
-                        contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                }
-                if (enrichedData.conversation.conversationState == ConversationState.Archived) {
-                    Spacer(modifier = Modifier.width(12.dp))
-                    Text(stringResource(MR.string.chat_archived),
-                        modifier = Modifier
-                            .background(MaterialTheme.colorScheme.secondaryContainer, RoundedCornerShape(4.dp))
-                            .padding(horizontal = 4.dp, vertical = 4.dp),
-                        style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSecondaryContainer
-                    )
-                }
-                if (enrichedData.conversation.conversationState == ConversationState.RejoinPending) {
-                    Spacer(modifier = Modifier.width(12.dp))
-                    Text(stringResource(MR.string.chat_group_rejoin_pending),
-                        modifier = Modifier
-                            .background(MaterialTheme.colorScheme.tertiaryContainer, RoundedCornerShape(4.dp))
-                            .padding(horizontal = 4.dp, vertical = 4.dp),
-                        style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onTertiaryContainer
-                    )
-                }
-                if (enrichedData.conversation.isLegacyGroup) {
-                    Spacer(modifier = Modifier.width(12.dp))
-                    Text(stringResource(MR.string.chat_group_legacy),
-                        modifier = Modifier
-                            .background(MaterialTheme.colorScheme.surfaceVariant, RoundedCornerShape(4.dp))
-                            .padding(horizontal = 4.dp, vertical = 4.dp),
-                        style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                }
-                when (enrichedData.oneOnOneConnectionStatus) {
-                    is OneOnOneConnectionStatus.OutgoingRequestPending -> {
-                        Spacer(modifier = Modifier.width(12.dp))
-                        Text(
-                            stringResource(MR.string.chat_connection_invited),
-                            modifier = Modifier
-                                .background(
-                                    MaterialTheme.colorScheme.tertiaryContainer,
-                                    RoundedCornerShape(4.dp)
-                                )
-                                .padding(horizontal = 4.dp, vertical = 4.dp),
-                            style = MaterialTheme.typography.labelSmall,
-                            color = MaterialTheme.colorScheme.onTertiaryContainer,
-                        )
-                    }
-                    is OneOnOneConnectionStatus.IncomingRequestPending -> {
-                        Spacer(modifier = Modifier.width(12.dp))
-                        Text(
-                            stringResource(MR.string.chat_connection_wants_to_connect),
-                            modifier = Modifier
-                                .background(
-                                    MaterialTheme.colorScheme.primaryContainer,
-                                    RoundedCornerShape(4.dp)
-                                )
-                                .padding(horizontal = 4.dp, vertical = 4.dp),
-                            style = MaterialTheme.typography.labelSmall,
-                            color = MaterialTheme.colorScheme.onPrimaryContainer,
-                        )
-                    }
-                    is OneOnOneConnectionStatus.NotConnected -> {
-                        Spacer(modifier = Modifier.width(12.dp))
-                        Text(
-                            stringResource(MR.string.chat_connection_not_connected),
-                            modifier = Modifier
-                                .background(
-                                    MaterialTheme.colorScheme.errorContainer,
-                                    RoundedCornerShape(4.dp)
-                                )
-                                .padding(horizontal = 4.dp, vertical = 4.dp),
-                            style = MaterialTheme.typography.labelSmall,
-                            color = MaterialTheme.colorScheme.onErrorContainer,
-                        )
-                    }
-                    else -> {}
-                }
-            }
 
-            if (showMenu) {
-                ConversationItemMenuPopup(
-                    dismissMenu = { showMenu = false},
-                    isPinned = enrichedData.conversation.isPinned,
-                    isArchived = enrichedData.conversation.conversationState == ConversationState.Archived,
-                    onMarkAsRead = onMarkAsReadClick,
-                    onTogglePin = onTogglePinClick,
-                    onArchive = onArchiveClick,
-                )
+                    Text(
+                        text = formatTimestamp(enrichedData.conversation.latestMessageTimestamp),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = if (enrichedData.conversation.unreadCount > 0) MaterialTheme.colorScheme.primary
+                        else MaterialTheme.colorScheme.onSurfaceVariant,
+                        fontWeight = if (enrichedData.conversation.unreadCount > 0) FontWeight.SemiBold else FontWeight.Normal
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(if (compact) 0.dp else 4.dp))
+
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.Start,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    // Strip richeditor's `<br>` empty-paragraph artifacts so a legacy `<br>` message
+                    // shows its real text in the list preview, not a stray break / blank line (#1104).
+                    val lastMessagePreview = remember(enrichedData.conversation.lastMessage) {
+                        enrichedData.conversation.lastMessage.stripComposerLineBreakArtifacts()
+                    }
+                    val contentLabel = messageContentLabel(
+                        textContent = lastMessagePreview,
+                        isDeleted = enrichedData.conversation.lastMessageIsDeleted,
+                        firstPayload = enrichedData.conversation.lastMessageFirstPayload,
+                        hasMultiplePayloads = enrichedData.conversation.lastMessageHasMultiplePayloads,
+                        messageContent = enrichedData.conversation.lastMessageContent,
+                    )
+
+                    // When there's no history for a 1:1 conversation with a pending connection
+                    // request, swap the default "No messages yet" fallback for a line that
+                    // actually tells the user what's happening.
+                    val pendingSubtitle: String? = if (
+                        contentLabel == null &&
+                        lastMessagePreview.isBlank()
+                    ) {
+                        when (enrichedData.oneOnOneConnectionStatus) {
+                            is OneOnOneConnectionStatus.OutgoingRequestPending ->
+                                stringResource(MR.string.chat_connection_invitation_sent)
+                            is OneOnOneConnectionStatus.IncomingRequestPending ->
+                                stringResource(MR.string.chat_connection_invitation_received)
+                            is OneOnOneConnectionStatus.NotConnected ->
+                                stringResource(MR.string.chat_connection_not_connected)
+                            else -> null
+                        }
+                    } else null
+
+                    val rawPreview = pendingSubtitle
+                        ?: contentLabel?.text
+                        ?: lastMessagePreview
+                    val groupSenderName: String? = remember(
+                        enrichedData.conversation.isGroupConversation,
+                        enrichedData.conversation.lastMessageSender,
+                        enrichedData.participants,
+                    ) {
+                        if (!enrichedData.conversation.isGroupConversation) null
+                        else enrichedData.participants
+                            .firstOrNull { it.odinId == enrichedData.conversation.lastMessageSender }
+                            ?.name?.takeIf { it.isNotBlank() }
+                            ?.substringBefore(' ')
+                    }
+                    val senderLabel: String? = when {
+                        pendingSubtitle != null -> null
+                        enrichedData.conversation.isWithSelf -> null
+                        enrichedData.conversation.lastMessageIsFromActiveUser -> stringResource(MR.string.you)
+                        else -> groupSenderName
+                    }
+                    // Render the sender prefix ("You:" / a group member's name) BEFORE the
+                    // content-type icon so it reads "You: <icon> Image", not "<icon> You: Image".
+                    val senderPrefix = if (senderLabel != null && rawPreview.isNotBlank()) {
+                        stringResource(MR.string.chat_preview_sender_label, senderLabel)
+                    } else {
+                        null
+                    }
+                    val iconRes = if (pendingSubtitle != null) null else contentLabel?.icon
+
+                    // A non-blank draft takes over the preview line ("Draft: …", tinted)
+                    // so the row advertises unsent text the way every messenger does.
+                    val draftRaw = enrichedData.conversation.draft
+                    val draftPreview = remember(draftRaw) {
+                        draftRaw?.stripComposerLineBreakArtifacts()?.takeIf { it.isNotBlank() }
+                    }
+                    val draftLabel = stringResource(
+                        MR.string.chat_preview_sender_label,
+                        stringResource(MR.string.chat_conversation_draft),
+                    )
+
+                    ConversationMessagePreview(
+                        text = draftPreview ?: rawPreview,
+                        prefix = if (draftPreview != null) draftLabel else senderPrefix,
+                        prefixColor = if (draftPreview != null) MaterialTheme.colorScheme.error
+                        else MaterialTheme.colorScheme.onSurfaceVariant,
+                        iconRes = if (draftPreview != null) null else iconRes,
+                        isDeleted = draftPreview == null && enrichedData.conversation.lastMessageIsDeleted,
+                        modifier = Modifier.weight(1f)
+                    )
+
+                    if (enrichedData.conversation.unreadCount > 0) {
+                        Spacer(modifier = Modifier.width(8.dp))
+
+                        Badge(
+                            containerColor = HomebaseTheme.extendedColors.bubbleSentSurface,
+                            contentColor = HomebaseTheme.extendedColors.bubbleSentOnSurface,
+                        ) {
+                            Text(
+                                modifier = Modifier.padding(4.dp),
+                                text = enrichedData.conversation.unreadCount.toString(),
+                                style = MaterialTheme.typography.labelSmall,
+                                fontWeight = FontWeight.Bold
+                            )
+                        }
+                    } else if (draftPreview == null && enrichedData.conversation.lastMessageIsFromActiveUser && enrichedData.conversation.lastMessageDeliveryStatus != null) {
+                        Spacer(modifier = Modifier.width(4.dp))
+                        DeliveryStatus(
+                            isPendingSend = enrichedData.conversation.lastMessageIsPendingSend,
+                            deliveryStatus = enrichedData.conversation.lastMessageDeliveryStatus,
+                            contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                    if (enrichedData.conversation.conversationState == ConversationState.Archived) {
+                        Spacer(modifier = Modifier.width(12.dp))
+                        Text(stringResource(MR.string.chat_archived),
+                            modifier = Modifier
+                                .background(MaterialTheme.colorScheme.secondaryContainer, RoundedCornerShape(4.dp))
+                                .padding(horizontal = 4.dp, vertical = 4.dp),
+                            style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSecondaryContainer
+                        )
+                    }
+                    if (enrichedData.conversation.conversationState == ConversationState.RejoinPending) {
+                        Spacer(modifier = Modifier.width(12.dp))
+                        Text(stringResource(MR.string.chat_group_rejoin_pending),
+                            modifier = Modifier
+                                .background(MaterialTheme.colorScheme.tertiaryContainer, RoundedCornerShape(4.dp))
+                                .padding(horizontal = 4.dp, vertical = 4.dp),
+                            style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onTertiaryContainer
+                        )
+                    }
+                    if (enrichedData.conversation.isLegacyGroup) {
+                        Spacer(modifier = Modifier.width(12.dp))
+                        Text(stringResource(MR.string.chat_group_legacy),
+                            modifier = Modifier
+                                .background(MaterialTheme.colorScheme.surfaceVariant, RoundedCornerShape(4.dp))
+                                .padding(horizontal = 4.dp, vertical = 4.dp),
+                            style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                    when (enrichedData.oneOnOneConnectionStatus) {
+                        is OneOnOneConnectionStatus.OutgoingRequestPending -> {
+                            Spacer(modifier = Modifier.width(12.dp))
+                            Text(
+                                stringResource(MR.string.chat_connection_invited),
+                                modifier = Modifier
+                                    .background(
+                                        MaterialTheme.colorScheme.tertiaryContainer,
+                                        RoundedCornerShape(4.dp)
+                                    )
+                                    .padding(horizontal = 4.dp, vertical = 4.dp),
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.onTertiaryContainer,
+                            )
+                        }
+                        is OneOnOneConnectionStatus.IncomingRequestPending -> {
+                            Spacer(modifier = Modifier.width(12.dp))
+                            Text(
+                                stringResource(MR.string.chat_connection_wants_to_connect),
+                                modifier = Modifier
+                                    .background(
+                                        MaterialTheme.colorScheme.primaryContainer,
+                                        RoundedCornerShape(4.dp)
+                                    )
+                                    .padding(horizontal = 4.dp, vertical = 4.dp),
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.onPrimaryContainer,
+                            )
+                        }
+                        is OneOnOneConnectionStatus.NotConnected -> {
+                            Spacer(modifier = Modifier.width(12.dp))
+                            Text(
+                                stringResource(MR.string.chat_connection_not_connected),
+                                modifier = Modifier
+                                    .background(
+                                        MaterialTheme.colorScheme.errorContainer,
+                                        RoundedCornerShape(4.dp)
+                                    )
+                                    .padding(horizontal = 4.dp, vertical = 4.dp),
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.onErrorContainer,
+                            )
+                        }
+                        else -> {}
+                    }
+                }
+
+                if (showMenu) {
+                    ConversationItemMenuPopup(
+                        dismissMenu = { showMenu = false},
+                        isPinned = enrichedData.conversation.isPinned,
+                        isArchived = isArchived,
+                        onMarkAsRead = onMarkAsReadClick,
+                        onTogglePin = onTogglePinClick,
+                        onArchive = onArchiveClick,
+                    )
+                }
             }
+        }
+    }
+}
+
+/**
+ * The strip uncovered behind a swiped conversation row. It spans only the exposed gap, so a
+ * row at rest is drawn exactly as before and no opaque row background is needed.
+ */
+@Composable
+private fun BoxScope.ConversationSwipeReveal(
+    state: SwipeRevealState,
+    atLeftEdge: Boolean,
+    icon: ImageVector,
+    label: String,
+    container: Color,
+    onContainer: Color,
+) {
+    val committed = state.isPastThreshold
+    val background by animateColorAsState(
+        targetValue = if (committed) container else MaterialTheme.colorScheme.surfaceContainerHighest,
+        animationSpec = tween(durationMillis = 150),
+    )
+    val tint by animateColorAsState(
+        targetValue = if (committed) onContainer else MaterialTheme.colorScheme.onSurfaceVariant,
+        animationSpec = tween(durationMillis = 150),
+    )
+    val pop by animateFloatAsState(
+        targetValue = if (committed) 1.15f else 1f,
+        animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy),
+    )
+    val revealWidth = with(LocalDensity.current) { state.offsetPx.absoluteValue.toDp() }
+
+    Box(modifier = Modifier.matchParentSize()) {
+        Box(
+            modifier = Modifier
+                .align(if (atLeftEdge) AbsoluteAlignment.CenterLeft else AbsoluteAlignment.CenterRight)
+                .fillMaxHeight()
+                .width(revealWidth)
+                .background(background),
+            contentAlignment = if (atLeftEdge) AbsoluteAlignment.CenterLeft
+            else AbsoluteAlignment.CenterRight,
+        ) {
+            Icon(
+                imageVector = icon,
+                contentDescription = label,
+                tint = tint,
+                modifier = Modifier
+                    .absolutePadding(
+                        left = if (atLeftEdge) 20.dp else 0.dp,
+                        right = if (atLeftEdge) 0.dp else 20.dp,
+                    )
+                    .scale((0.6f + 0.4f * state.progress) * pop)
+                    .size(24.dp),
+            )
         }
     }
 }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationListPane.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationListPane.kt
@@ -500,18 +500,22 @@ fun ConversationListPane(
                                     }
                                 }
                             ) { listItem ->
-                                ConversationLisContentItem(
-                                    listItem = listItem,
-                                    selectedConversationId = selectedConversationId,
-                                    iconOnlyMode = iconOnlyMode,
-                                    // Live search text drives the highlight in
-                                    // message-search rows; empty when not searching.
-                                    searchQuery = if (uiState.isSearchActive)
-                                        searchTextState.text.toString()
-                                    else "",
-                                    onUiAction = onUiAction,
-                                    onConversationSelected = onConversationSelected,
-                                )
+                                Box(modifier = Modifier.animateItem()) {
+                                    ConversationLisContentItem(
+                                        listItem = listItem,
+                                        selectedConversationId = selectedConversationId,
+                                        iconOnlyMode = iconOnlyMode,
+                                        // Search results are a tap target, not a swipe target.
+                                        allowSwipeActions = !uiState.isSearchActive,
+                                        // Live search text drives the highlight in
+                                        // message-search rows; empty when not searching.
+                                        searchQuery = if (uiState.isSearchActive)
+                                            searchTextState.text.toString()
+                                        else "",
+                                        onUiAction = onUiAction,
+                                        onConversationSelected = onConversationSelected,
+                                    )
+                                }
                             }
                         }
                     }
@@ -577,6 +581,7 @@ fun ConversationLisContentItem(
     searchQuery: String,
     onUiAction: (ConversationListUiAction) -> Unit,
     onConversationSelected: (conversationId: Uuid) -> Unit,
+    allowSwipeActions: Boolean = true,
 ) {
     when (listItem) {
         is ConversationListContentModel.Header -> {
@@ -642,6 +647,7 @@ fun ConversationLisContentItem(
                     },
 
                     isSelected = listItem.conversation.conversation.id == selectedConversationId,
+                    allowSwipeActions = allowSwipeActions,
                 )
             }
         }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/SwipeRevealBox.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/SwipeRevealBox.kt
@@ -1,0 +1,253 @@
+package id.homebase.chat.widget
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.FastOutLinearInEasing
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.absoluteOffset
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.input.pointer.positionChange
+import androidx.compose.ui.input.pointer.util.VelocityTracker
+import androidx.compose.ui.input.pointer.util.addPointerInputChange
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+import id.homebase.core.haptics.HapticEvent
+import id.homebase.core.haptics.rememberHaptics
+import id.homebase.core.util.isMobile
+import kotlinx.coroutines.delay
+import kotlin.math.absoluteValue
+import kotlin.math.roundToInt
+import kotlin.math.sqrt
+
+private const val SLIDE_OUT_MS = 180
+
+/** How long a slid-out row waits for the list to drop it before deciding the action didn't. */
+private const val SLIDE_OUT_RECOVERY_MS = 700L
+
+@Immutable
+sealed interface SwipeDistance {
+    data class Fixed(val distance: Dp) : SwipeDistance
+    data class Fraction(val fraction: Float) : SwipeDistance
+}
+
+private fun SwipeDistance.toPx(widthPx: Int, density: Density): Float = when (this) {
+    is SwipeDistance.Fixed -> with(density) { distance.toPx() }
+    is SwipeDistance.Fraction -> widthPx * fraction
+}
+
+@Immutable
+data class SwipeRevealState(
+    /** Physical: positive means the row moved right on screen, under RTL too. */
+    val offsetPx: Float,
+    val thresholdPx: Float,
+) {
+    val progress: Float
+        get() = if (thresholdPx <= 0f) 0f else (offsetPx.absoluteValue / thresholdPx).coerceIn(0f, 1f)
+
+    val isPastThreshold: Boolean
+        get() = thresholdPx > 0f && offsetPx.absoluteValue >= thresholdPx
+}
+
+/**
+ * Horizontal swipe that reveals an action behind the row and fires it on release. It never
+ * latches open: the row either springs back, or — where the action removes it — slides out.
+ *
+ * The gesture stays in physical screen space, RTL included: [onSwipeRight] / [onSwipeLeft]
+ * and [SwipeRevealState.offsetPx] are pointer directions, not layout-relative ones, so a
+ * caller that wants the actions to mirror under RTL swaps them itself.
+ */
+@Composable
+fun SwipeRevealBox(
+    onSwipeRight: (() -> Unit)?,
+    onSwipeLeft: (() -> Unit)?,
+    commitThreshold: SwipeDistance,
+    maxOffset: SwipeDistance,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = isMobile(),
+    /** Null disables the flick shortcut, leaving distance as the only way to commit. */
+    escapeVelocityDpPerSecond: Float? = null,
+    /** Set where a committed swipe removes the row: it then slides out instead of springing
+     *  back, and returns only if the row is somehow still here afterwards. */
+    slideOutOnSwipeRight: Boolean = false,
+    slideOutOnSwipeLeft: Boolean = false,
+    reveal: @Composable BoxScope.(SwipeRevealState) -> Unit,
+    content: @Composable () -> Unit,
+) {
+    if (!enabled || (onSwipeRight == null && onSwipeLeft == null)) {
+        Box(modifier) { content() }
+        return
+    }
+
+    val density = LocalDensity.current
+    var widthPx by remember { mutableIntStateOf(0) }
+    val thresholdPx = commitThreshold.toPx(widthPx, density)
+    val maxOffsetPx = maxOffset.toPx(widthPx, density)
+    val escapeVelocityPx = escapeVelocityDpPerSecond?.let { with(density) { it.dp.toPx() } }
+
+    // Read live inside the gesture instead of keying pointerInput on them: the gesture
+    // captures its first composition, when the row is still unmeasured, and re-keying on
+    // the lambdas (a new identity on every recomposition of the row) would cancel an
+    // in-flight swipe every time a new message landed in that conversation.
+    val currentOnSwipeRight by rememberUpdatedState(onSwipeRight)
+    val currentOnSwipeLeft by rememberUpdatedState(onSwipeLeft)
+    val currentThresholdPx by rememberUpdatedState(thresholdPx)
+    val currentMaxOffsetPx by rememberUpdatedState(maxOffsetPx)
+    val currentEscapeVelocityPx by rememberUpdatedState(escapeVelocityPx)
+    val currentSlideOutRight by rememberUpdatedState(slideOutOnSwipeRight)
+    val currentSlideOutLeft by rememberUpdatedState(slideOutOnSwipeLeft)
+
+    // Plain float state during the drag — no coroutine per pointer event. The release
+    // animation writes back into the same value so the row never jumps between the two.
+    var offsetPx by remember { mutableFloatStateOf(0f) }
+    var isDragging by remember { mutableStateOf(false) }
+    var slideOutDirection by remember { mutableIntStateOf(0) }
+    val settle = remember { Animatable(0f) }
+    val haptics = rememberHaptics()
+    var hapticFired by remember { mutableStateOf(false) }
+
+    LaunchedEffect(isDragging, slideOutDirection) {
+        if (isDragging) return@LaunchedEffect
+        settle.snapTo(offsetPx)
+        if (slideOutDirection != 0 && widthPx > 0) {
+            settle.animateTo(
+                targetValue = slideOutDirection * widthPx.toFloat(),
+                animationSpec = tween(SLIDE_OUT_MS, easing = FastOutLinearInEasing),
+            ) { offsetPx = value }
+            delay(SLIDE_OUT_RECOVERY_MS)
+            slideOutDirection = 0
+        } else {
+            settle.animateTo(0f, spring()) { offsetPx = value }
+        }
+    }
+
+    Box(modifier = modifier.onSizeChanged { widthPx = it.width }) {
+        if (offsetPx != 0f) {
+            reveal(SwipeRevealState(offsetPx = offsetPx, thresholdPx = thresholdPx))
+        }
+
+        Box(
+            modifier = Modifier
+                .absoluteOffset { IntOffset(offsetPx.roundToInt(), 0) }
+                .pointerInput(Unit) {
+                    val slop = viewConfiguration.touchSlop
+                    awaitEachGesture {
+                        awaitFirstDown(requireUnconsumed = false)
+                        val velocityTracker = VelocityTracker()
+
+                        var totalX = 0f
+                        var totalY = 0f
+                        var directionDecided = false
+                        var isHorizontal = false
+
+                        try {
+                            while (true) {
+                                val event = awaitPointerEvent()
+                                val change = event.changes.firstOrNull() ?: break
+                                if (!change.pressed) break
+
+                                val delta = change.positionChange()
+
+                                if (!directionDecided) {
+                                    totalX += delta.x
+                                    totalY += delta.y
+                                    val distance = sqrt(totalX * totalX + totalY * totalY)
+                                    if (distance > slop) {
+                                        directionDecided = true
+                                        // Commit to horizontal only when the drag is clearly
+                                        // sideways, so the LazyColumn keeps vertical scrolling.
+                                        isHorizontal =
+                                            totalX.absoluteValue > totalY.absoluteValue * 1.5f
+                                        if (!isHorizontal) break
+                                        isDragging = true
+                                        hapticFired = false
+                                        slideOutDirection = 0
+                                        offsetPx = 0f
+                                        change.consume()
+                                    }
+                                    continue
+                                }
+
+                                change.consume()
+                                velocityTracker.addPointerInputChange(change)
+                                var newValue = offsetPx + delta.x
+                                if (currentOnSwipeRight == null) newValue = newValue.coerceAtMost(0f)
+                                if (currentOnSwipeLeft == null) newValue = newValue.coerceAtLeast(0f)
+                                offsetPx = newValue.coerceIn(-currentMaxOffsetPx, currentMaxOffsetPx)
+
+                                if (!hapticFired && offsetPx.absoluteValue >= currentThresholdPx) {
+                                    hapticFired = true
+                                    haptics.perform(HapticEvent.LongPress)
+                                } else if (hapticFired && offsetPx.absoluteValue < currentThresholdPx) {
+                                    hapticFired = false
+                                }
+                            }
+
+                            if (isHorizontal) {
+                                val commit = shouldCommitSwipe(
+                                    offsetPx = offsetPx,
+                                    thresholdPx = currentThresholdPx,
+                                    velocityPxPerSecond = velocityTracker.calculateVelocity().x,
+                                    escapeVelocityPxPerSecond = currentEscapeVelocityPx,
+                                )
+                                // Act on release rather than after the spring-back, so the
+                                // action never trails the gesture by an animation.
+                                if (commit) {
+                                    val toRight = offsetPx > 0f
+                                    if (toRight) currentOnSwipeRight?.invoke()
+                                    else currentOnSwipeLeft?.invoke()
+                                    val slidesOut =
+                                        if (toRight) currentSlideOutRight else currentSlideOutLeft
+                                    if (slidesOut) slideOutDirection = if (toRight) 1 else -1
+                                }
+                            }
+                        } finally {
+                            // awaitEachGesture swallows a gesture-level cancellation and
+                            // restarts, so without this the row stays held open: the
+                            // spring-back only runs on an isDragging edge.
+                            if (isHorizontal) isDragging = false
+                        }
+                    }
+                }
+        ) {
+            content()
+        }
+    }
+}
+
+/**
+ * Whether a released swipe fires its action. Distance is the primary path; the flick
+ * shortcut deliberately needs a fast, same-direction gesture that already travelled half
+ * the commit distance, so a stray twitch can't trigger an action.
+ */
+internal fun shouldCommitSwipe(
+    offsetPx: Float,
+    thresholdPx: Float,
+    velocityPxPerSecond: Float,
+    escapeVelocityPxPerSecond: Float?,
+): Boolean {
+    if (thresholdPx <= 0f || offsetPx == 0f) return false
+    if (offsetPx.absoluteValue >= thresholdPx) return true
+    if (escapeVelocityPxPerSecond == null) return false
+    return velocityPxPerSecond.absoluteValue >= escapeVelocityPxPerSecond &&
+        (velocityPxPerSecond > 0f) == (offsetPx > 0f) &&
+        offsetPx.absoluteValue >= thresholdPx / 2f
+}

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/SwipeableMessageWrapper.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/SwipeableMessageWrapper.kt
@@ -1,13 +1,8 @@
 package id.homebase.chat.widget
 
-import androidx.compose.animation.core.Animatable
-import androidx.compose.animation.core.spring
 import androidx.compose.foundation.background
-import androidx.compose.foundation.gestures.awaitEachGesture
-import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
@@ -17,30 +12,16 @@ import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableFloatStateOf
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
+import androidx.compose.ui.AbsoluteAlignment
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.scale
-import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.input.pointer.positionChange
-import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
-import id.homebase.core.haptics.HapticEvent
-import id.homebase.core.haptics.rememberHaptics
 import id.homebase.core.util.isMobile
 import id.homebase.resources.MR
 import id.homebase.resources.chat_message_reply
 import id.homebase.resources.info
 import org.jetbrains.compose.resources.stringResource
-import kotlin.math.absoluteValue
-import kotlin.math.roundToInt
-import kotlin.math.sqrt
 
 @Composable
 fun SwipeableMessageWrapper(
@@ -54,145 +35,40 @@ fun SwipeableMessageWrapper(
         return
     }
 
-    val density = LocalDensity.current
-    val thresholdPx = with(density) { 56.dp.toPx() }
-    val maxOffsetPx = with(density) { 96.dp.toPx() }
-    // Use plain float state during drag (no coroutines needed), Animatable only for spring-back
-    var dragOffset by remember { mutableFloatStateOf(0f) }
-    var isDragging by remember { mutableStateOf(false) }
-    val animatable = remember { Animatable(0f) }
-    val haptics = rememberHaptics()
-    var hapticFired by remember { mutableStateOf(false) }
-
-    // The displayed offset: drag value while dragging, animated value while springing back
-    val displayOffset = if (isDragging) dragOffset else animatable.value
-
-    // Spring back to 0 when drag ends
-    LaunchedEffect(isDragging) {
-        if (!isDragging) {
-            animatable.snapTo(dragOffset)
-            animatable.animateTo(0f, spring())
-        }
-    }
-
-    Box(
+    SwipeRevealBox(
+        onSwipeRight = onSwipeRight,
+        onSwipeLeft = onSwipeLeft,
         modifier = Modifier.fillMaxWidth(),
-        contentAlignment = Alignment.CenterStart,
-    ) {
-        // Reply icon (left side, revealed on swipe right)
-        if (onSwipeRight != null && displayOffset > 0f) {
-            val progress = (displayOffset / thresholdPx).coerceIn(0f, 1f)
-            Box(
-                modifier = Modifier
-                    .padding(start = 12.dp)
-                    .size(32.dp)
-                    .scale(0.5f + 0.5f * progress)
-                    .background(
-                        MaterialTheme.colorScheme.surfaceContainerHighest,
-                        CircleShape
-                    ),
-                contentAlignment = Alignment.Center,
-            ) {
-                Icon(
-                    imageVector = Icons.AutoMirrored.Filled.Reply,
-                    contentDescription = stringResource(MR.string.chat_message_reply),
-                    modifier = Modifier.size(18.dp),
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
-        }
-
-        // Info icon (right side, revealed on swipe left)
-        if (onSwipeLeft != null && displayOffset < 0f) {
-            val progress = (displayOffset.absoluteValue / thresholdPx).coerceIn(0f, 1f)
-            Box(
-                modifier = Modifier
-                    .align(Alignment.CenterEnd)
-                    .padding(end = 12.dp)
-                    .size(32.dp)
-                    .scale(0.5f + 0.5f * progress)
-                    .background(
-                        MaterialTheme.colorScheme.surfaceContainerHighest,
-                        CircleShape
-                    ),
-                contentAlignment = Alignment.Center,
-            ) {
-                Icon(
-                    imageVector = Icons.Outlined.Info,
-                    contentDescription = stringResource(MR.string.info),
-                    modifier = Modifier.size(18.dp),
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
-        }
-
-        // Message content
-        Box(
-            modifier = Modifier
-                .offset { IntOffset(displayOffset.roundToInt(), 0) }
-                .pointerInput(onSwipeRight, onSwipeLeft) {
-                    val slop = viewConfiguration.touchSlop
-                    awaitEachGesture {
-                        awaitFirstDown(requireUnconsumed = false)
-
-                        var totalX = 0f
-                        var totalY = 0f
-                        var directionDecided = false
-                        var isHorizontal = false
-
-                        while (true) {
-                            val event = awaitPointerEvent()
-                            val change = event.changes.firstOrNull() ?: break
-                            if (!change.pressed) break
-
-                            val delta = change.positionChange()
-
-                            if (!directionDecided) {
-                                totalX += delta.x
-                                totalY += delta.y
-                                val distance = sqrt(totalX * totalX + totalY * totalY)
-                                if (distance > slop) {
-                                    directionDecided = true
-                                    isHorizontal =
-                                        totalX.absoluteValue > totalY.absoluteValue * 1.5f
-                                    if (!isHorizontal) break
-                                    isDragging = true
-                                    hapticFired = false
-                                    dragOffset = 0f
-                                    change.consume()
-                                }
-                                continue
-                            }
-
-                            change.consume()
-                            var newValue = dragOffset + delta.x
-                            // Clamp: only allow right if onSwipeRight exists, left if onSwipeLeft exists
-                            if (onSwipeRight == null) newValue = newValue.coerceAtMost(0f)
-                            if (onSwipeLeft == null) newValue = newValue.coerceAtLeast(0f)
-                            newValue = newValue.coerceIn(-maxOffsetPx, maxOffsetPx)
-                            dragOffset = newValue
-
-                            // Fire haptic at threshold
-                            if (!hapticFired && newValue.absoluteValue >= thresholdPx) {
-                                hapticFired = true
-                                haptics.perform(HapticEvent.LongPress)
-                            } else if (hapticFired && newValue.absoluteValue < thresholdPx) {
-                                hapticFired = false
-                            }
-                        }
-
-                        if (isHorizontal) {
-                            if (dragOffset > thresholdPx && onSwipeRight != null) {
-                                onSwipeRight()
-                            } else if (dragOffset < -thresholdPx && onSwipeLeft != null) {
-                                onSwipeLeft()
-                            }
-                            isDragging = false
-                        }
-                    }
+        commitThreshold = SwipeDistance.Fixed(56.dp),
+        maxOffset = SwipeDistance.Fixed(96.dp),
+        reveal = { state ->
+            val revealingReply = state.offsetPx > 0f
+            if (if (revealingReply) onSwipeRight != null else onSwipeLeft != null) {
+                Box(
+                    modifier = Modifier
+                        .align(if (revealingReply) AbsoluteAlignment.CenterLeft
+                        else AbsoluteAlignment.CenterRight)
+                        .padding(horizontal = 12.dp)
+                        .size(32.dp)
+                        .scale(0.5f + 0.5f * state.progress)
+                        .background(
+                            MaterialTheme.colorScheme.surfaceContainerHighest,
+                            CircleShape,
+                        ),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Icon(
+                        imageVector = if (revealingReply) Icons.AutoMirrored.Filled.Reply
+                        else Icons.Outlined.Info,
+                        contentDescription = stringResource(
+                            if (revealingReply) MR.string.chat_message_reply else MR.string.info
+                        ),
+                        modifier = Modifier.size(18.dp),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
                 }
-        ) {
-            content()
-        }
-    }
+            }
+        },
+        content = content,
+    )
 }

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/conversationlist/ConversationListEventsTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/conversationlist/ConversationListEventsTest.kt
@@ -1,0 +1,53 @@
+package id.homebase.chat.conversationlist
+
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Regression guard for the single-slot `uiState.uiEvent` this replaced.
+ *
+ * The old mechanism was one nullable field written by `sendEvent` and cleared by
+ * `eventConsumed`, so a second send before the screen consumed the first simply
+ * overwrote it. Swiping several rows to archive in quick succession therefore showed
+ * only the last undo snackbar, and the earlier archives became unrecoverable from the UI.
+ */
+class ConversationListEventsTest {
+
+    @Test
+    fun rapidSuccessiveEventsAreAllDelivered() = runTest {
+        val events = ConversationListEvents()
+        val sent = (1..5).map { ConversationListUiEvent.NavigateToContactInfo("peer$it") }
+
+        sent.forEach(events::send)
+
+        assertEquals(sent, events.events.take(sent.size).toList())
+    }
+
+    @Test
+    fun eventsSentBeforeACollectorAttachesSurvive() = runTest {
+        val events = ConversationListEvents()
+        events.send(ConversationListUiEvent.NavigateBack)
+
+        assertEquals(
+            listOf(ConversationListUiEvent.NavigateBack),
+            events.events.take(1).toList(),
+        )
+    }
+
+    @Test
+    fun collectingTwiceDoesNotReplayAlreadyHandledEvents() = runTest {
+        val events = ConversationListEvents()
+        events.send(ConversationListUiEvent.NavigateToGroupSettings("first"))
+        assertEquals(1, events.events.take(1).toList().size)
+
+        events.send(ConversationListUiEvent.NavigateToGroupSettings("second"))
+
+        assertEquals(
+            listOf(ConversationListUiEvent.NavigateToGroupSettings("second")),
+            events.events.take(1).toList(),
+        )
+    }
+}

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/conversationlist/UndoSnackbarDurationTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/conversationlist/UndoSnackbarDurationTest.kt
@@ -1,0 +1,50 @@
+package id.homebase.chat.conversationlist
+
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.runComposeUiTest
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+/**
+ * The undo snackbar carries an action label, and `showSnackbar` silently upgrades those to
+ * `Indefinite`: build 1.3.1427 pinned it over the FAB forever and, because `showSnackbar`
+ * serialises on a mutex, stalled every later snackbar on the screen behind it.
+ */
+@OptIn(ExperimentalTestApi::class)
+class UndoSnackbarDurationTest {
+
+    @Test
+    fun anUndoSnackbarDismissesItself() = runComposeUiTest {
+        val host = SnackbarHostState()
+        setContent {
+            LaunchedEffect(Unit) { host.showTimedSnackbar("Conversation archived", "Undo") }
+            SnackbarHost(host)
+        }
+        waitForIdle()
+        assertNotNull(host.currentSnackbarData, "snackbar never showed")
+
+        mainClock.advanceTimeBy(10_000)
+        waitForIdle()
+        assertNull(host.currentSnackbarData, "snackbar was still up 10s later")
+    }
+
+    @Test
+    fun theMaterialDefaultWouldNeverDismissIt() = runComposeUiTest {
+        val host = SnackbarHostState()
+        setContent {
+            LaunchedEffect(Unit) {
+                host.showSnackbar(message = "Conversation archived", actionLabel = "Undo")
+            }
+            SnackbarHost(host)
+        }
+        waitForIdle()
+
+        mainClock.advanceTimeBy(60_000)
+        waitForIdle()
+        assertNotNull(host.currentSnackbarData)
+    }
+}

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/widget/SwipeCommitTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/widget/SwipeCommitTest.kt
@@ -1,0 +1,62 @@
+package id.homebase.chat.widget
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The release decision behind the conversation-list swipe. Distance is the primary path;
+ * the flick shortcut is deliberately hard to hit so an accidental swipe can't archive a
+ * conversation (Signal tunes theirs the same way).
+ */
+class SwipeCommitTest {
+
+    private val threshold = 120f
+    private val escape = 1000f
+
+    @Test
+    fun pastThresholdCommits() {
+        assertTrue(shouldCommitSwipe(threshold, threshold, 0f, escape))
+        assertTrue(shouldCommitSwipe(-threshold - 1f, threshold, 0f, escape))
+    }
+
+    @Test
+    fun shortSlowDragSpringsBackWithoutCommitting() {
+        assertFalse(shouldCommitSwipe(30f, threshold, 50f, escape))
+    }
+
+    @Test
+    fun fastFlickPastHalfwayCommitsShortOfTheThreshold() {
+        assertTrue(shouldCommitSwipe(70f, threshold, 1500f, escape))
+        assertTrue(shouldCommitSwipe(-70f, threshold, -1500f, escape))
+    }
+
+    @Test
+    fun fastFlickThatBarelyMovedDoesNotCommit() {
+        assertFalse(shouldCommitSwipe(20f, threshold, 4000f, escape))
+    }
+
+    @Test
+    fun flingBackTowardsRestDoesNotCommit() {
+        // Dragged right, then flicked back left on release — the user changed their mind.
+        assertFalse(shouldCommitSwipe(70f, threshold, -2000f, escape))
+    }
+
+    @Test
+    fun withoutAnEscapeVelocityOnlyDistanceCommits() {
+        assertFalse(shouldCommitSwipe(70f, threshold, 9000f, escapeVelocityPxPerSecond = null))
+        assertTrue(shouldCommitSwipe(130f, threshold, 0f, escapeVelocityPxPerSecond = null))
+    }
+
+    @Test
+    fun anUnmeasuredRowNeverCommits() {
+        // A fraction-of-width threshold is 0 until the row has been measured; treating that
+        // as "everything is past the threshold" would archive on the first stray pixel.
+        assertFalse(shouldCommitSwipe(500f, thresholdPx = 0f, velocityPxPerSecond = 0f, escapeVelocityPxPerSecond = escape))
+    }
+
+    @Test
+    fun aStationaryPointerNeverCommits() {
+        assertFalse(shouldCommitSwipe(0f, threshold, 5000f, escape))
+    }
+}

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/widget/SwipeRevealBoxGestureTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/widget/SwipeRevealBoxGestureTest.kt
@@ -1,0 +1,158 @@
+package id.homebase.chat.widget
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.getUnclippedBoundsInRoot
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import com.russhwolf.settings.PreferencesSettings
+import id.homebase.core.settings.UserPreferences
+import org.koin.compose.KoinIsolatedContext
+import org.koin.dsl.koinApplication
+import org.koin.dsl.module
+import java.util.prefs.Preferences
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * The box never latches open: whatever the release did, the row has to come back to rest,
+ * otherwise the conversation stays permanently shifted with its action reveal showing.
+ */
+@OptIn(ExperimentalTestApi::class)
+class SwipeRevealBoxGestureTest {
+
+    private val rowTag = "swipe-row"
+    private val revealTag = "swipe-reveal"
+
+    private val koin = koinApplication {
+        modules(
+            module {
+                single {
+                    UserPreferences(
+                        PreferencesSettings(Preferences.userRoot().node("/id/homebase/test"))
+                    )
+                }
+            }
+        )
+    }
+
+    @Composable
+    private fun Harness(onSwipeRight: () -> Unit, slideOut: Boolean = false) {
+        KoinIsolatedContext(koin) {
+            MaterialTheme {
+                SwipeRevealBox(
+                    onSwipeRight = onSwipeRight,
+                    onSwipeLeft = null,
+                    commitThreshold = SwipeDistance.Fixed(20.dp),
+                    maxOffset = SwipeDistance.Fixed(40.dp),
+                    enabled = true,
+                    slideOutOnSwipeRight = slideOut,
+                    modifier = Modifier.fillMaxWidth(),
+                    reveal = { Box(Modifier.testTag(revealTag).size(24.dp)) },
+                ) {
+                    Box(Modifier.testTag(rowTag).fillMaxWidth().height(64.dp))
+                }
+            }
+        }
+    }
+
+    @Test
+    fun aDragPastTheThresholdFiresOnReleaseAndSpringsBack() = runComposeUiTest {
+        var fired = 0
+        setContent { Harness(onSwipeRight = { fired++ }) }
+        waitForIdle()
+        onNodeWithTag(revealTag).assertDoesNotExist()
+
+        onNodeWithTag(rowTag).performTouchInput { down(centerLeft + Offset(4f, 0f)) }
+        onNodeWithTag(rowTag).performTouchInput { moveBy(Offset(40f, 0f)) }
+        onNodeWithTag(rowTag).performTouchInput { moveBy(Offset(80f, 0f)) }
+        waitForIdle()
+        onNodeWithTag(revealTag).assertExists()
+        assertEquals(0, fired, "the action must wait for the release")
+
+        onNodeWithTag(rowTag).performTouchInput { up() }
+        waitForIdle()
+        mainClock.advanceTimeBy(2_000)
+        waitForIdle()
+
+        assertEquals(1, fired)
+        onNodeWithTag(revealTag).assertDoesNotExist()
+    }
+
+    @Test
+    fun aShortDragSpringsBackWithoutFiring() = runComposeUiTest {
+        var fired = 0
+        setContent { Harness(onSwipeRight = { fired++ }) }
+        waitForIdle()
+
+        onNodeWithTag(rowTag).performTouchInput { down(centerLeft + Offset(4f, 0f)) }
+        onNodeWithTag(rowTag).performTouchInput { moveBy(Offset(40f, 0f)) }
+        onNodeWithTag(rowTag).performTouchInput { moveBy(Offset(8f, 0f)) }
+        onNodeWithTag(rowTag).performTouchInput { up() }
+        waitForIdle()
+        mainClock.advanceTimeBy(2_000)
+        waitForIdle()
+
+        assertEquals(0, fired)
+        onNodeWithTag(revealTag).assertDoesNotExist()
+    }
+
+    @Test
+    fun aCommittedSwipeThatRemovesTheRowSlidesOutInsteadOfSnappingBack() = runComposeUiTest {
+        setContent { Harness(onSwipeRight = {}, slideOut = true) }
+        waitForIdle()
+
+        onNodeWithTag(rowTag).performTouchInput { down(centerLeft + Offset(4f, 0f)) }
+        onNodeWithTag(rowTag).performTouchInput { moveBy(Offset(40f, 0f)) }
+        onNodeWithTag(rowTag).performTouchInput { moveBy(Offset(80f, 0f)) }
+        onNodeWithTag(rowTag).performTouchInput { up() }
+        waitForIdle()
+        mainClock.advanceTimeBy(400)
+        waitForIdle()
+
+        // Still held open: the list is expected to drop the row while it is off-screen.
+        onNodeWithTag(revealTag).assertExists()
+
+        // Nothing removed it, so it comes back rather than staying stuck aside.
+        mainClock.advanceTimeBy(2_000)
+        waitForIdle()
+        onNodeWithTag(revealTag).assertDoesNotExist()
+    }
+
+    @Test
+    fun theRowFollowsTheFingerUnderRtl() = runComposeUiTest {
+        setContent {
+            CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Rtl) {
+                Harness(onSwipeRight = {})
+            }
+        }
+        waitForIdle()
+        val atRest = onNodeWithTag(rowTag).getUnclippedBoundsInRoot().left
+
+        onNodeWithTag(rowTag).performTouchInput { down(centerLeft + Offset(4f, 0f)) }
+        onNodeWithTag(rowTag).performTouchInput { moveBy(Offset(40f, 0f)) }
+        onNodeWithTag(rowTag).performTouchInput { moveBy(Offset(40f, 0f)) }
+        waitForIdle()
+
+        // Modifier.offset is RTL-aware and would mirror this into a leftward slide, so the
+        // row would run away from the finger and uncover the wrong edge.
+        assertTrue(
+            onNodeWithTag(rowTag).getUnclippedBoundsInRoot().left > atRest,
+            "a rightward drag must move the row right, RTL included",
+        )
+    }
+}

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -91,6 +91,7 @@
     <string name="show_more">Show more</string>
     <string name="chat_message_read_more">Read more</string>
     <string name="action_cannot_be_undone">This action can't be undone.</string>
+    <string name="action_undo">Undo</string>
     <string name="slide_to_cancel">&lt; Slide to cancel</string>
     <string name="someone">Someone</string>
     <string name="leave">Leave</string>
@@ -677,6 +678,8 @@
     <string name="chat_unarchive">Restore</string>
     <string name="chat_archived_chats">Archived conversations</string>
     <string name="chat_archived_chats_empty">Archived conversations will be shown here</string>
+    <string name="chat_conversation_archived_confirmation">Conversation archived</string>
+    <string name="chat_conversation_restored_confirmation">Conversation restored</string>
     <string name="chat_clear">Clear</string>
     <string name="chat_options">Conversation options</string>
     <string name="chat_no_messages">No messages yet</string>


### PR DESCRIPTION
Swipe a conversation-list row one way to **archive** it (with an Undo snackbar), the other way to **mark it as read**.

Delete is deliberately **not** on the swipe. It is irreversible, and it keeps its existing two-variant confirm dialog. Signal reached the same conclusion for the same reason.

Fixes #1192

## Prerequisite refactor: one-time events off UiState

`ConversationListUiEvent` was a single nullable slot on `ConversationListUiState`, documented in-repo as lossy — a second event overwrote the first before the UI consumed it. That is fatal here, because two quick swipes must produce two undo snackbars, each undoing its own conversation.

It is now a `Channel(BUFFERED)` in a new `ConversationListEvents`, so every event is delivered. `ShowInfoMessage` gained an action, carried as a comparable `ConversationListUiAction` **value, not a lambda** — so the event stays equatable and testable.

This also clears a documented `CLAUDE.md` architecture violation: one-time events (navigation, snackbar) belong in a flow, not in UiState.

## Gesture core extracted

The drag/threshold/spring-back machinery moved out of `SwipeableMessageWrapper` into a reusable `SwipeRevealBox`, parameterised on commit distance, velocity escape and reveal content.

`SwipeableMessageWrapper` (message swipe-to-reply) now sits on top of it and was verified behaviourally identical: same 56dp commit threshold, same 96dp clamp, same chip visuals, same haptic re-arm, and still no velocity escape.

## Scope and gating

- Applied to `Conversation` rows only. Headers, message-search rows, the trailing `item {}` blocks and the filter chips are inert by construction, and swipe is additionally gated off while a search is active.
- Gated on `isMobile()`. Desktop and Web keep the long-press context menu.
- Threshold is 0.4 of row width with a 1000 dp/s flick escape — Signal's tuning, chosen to stop accidental archives.
- Haptic is `HapticEvent.LongPress`, the only constant that actually fires on the AOSP test device.
- Custom accessibility actions (Archive/Restore, Mark as read) are exposed on the row. Signal has none, so this is deliberately better than the reference implementation.
- Row slides out on commit, and `animateItem()` closes the gap in the list.

## Two real bugs fixed during the work

1. **`pointerInput` was keyed on the callbacks.** Any recomposition mid-drag restarted the gesture detector and left the row latched open permanently.
2. **The spring-back read the animatable on the frame `isDragging` flipped**, flashing the row to offset 0 before animating.

## Two review findings fixed

1. **The undo snackbar never dismissed.** M3 silently upgrades duration to `Indefinite` when `actionLabel` is non-null, so the snackbar sat there occluding the FAB and holding the snackbar mutex against every later snackbar. Now `Short`, via a `showTimedSnackbar` helper.
2. **RTL was inverted.** `Modifier.offset` is RTL-aware while `delta.x` is raw screen space, so under RTL the row moved opposite the finger and the reveal rendered underneath it. Now `absoluteOffset` + `AbsoluteAlignment` + `absolutePadding`.

## Pin interaction

Archive and unarchive are independent tag add/remove operations and do not disturb pin state, so undo is a clean one-liner. Signal's `PINNED_ORDER` bug has no analogue here. Verified on device: tags went 2 to 3 to 2, and the row returned under **Pinned**.

## Verification

Device-verified on a physical Redmi Note 5 Pro:

- commit and spring-back
- direction lock — a diagonal drag scrolls the list and fires nothing
- threshold colour and icon flip
- snackbar auto-dismiss, with the FAB returning
- a second archive getting its own snackbar
- Undo restoring the conversation, with no follow-up snackbar
- swipe-restore on the archived pane

Tests: `homebase-chat` / `homebase-common` / `homebase-auth` / `homebase-api` `jvmTest` — 2982 tests, 0 failures.
Compiles on JVM, Android, iOS (`iosSimulatorArm64`) and wasmJs.

## Known gaps, stated honestly

- **RTL is unit-tested but not device-verified.** `debug.force_rtl` has no effect on this AOSP ROM, and the app ships only `en` and `da`.
- **Accessibility custom actions are unverified without TalkBack.** They are wired per Compose's standard `customActions` API, but nobody has heard them announced.
- **Mark-as-read commit is unexercised** — the test account has zero unread conversations.
- **Snackbars queue rather than coalesce.** Three fast archives give three snackbars, not one "3 archived". Worth a follow-up.

## Note on `tertiaryContainer`

The theme never defines `tertiary`, so `tertiaryContainer` falls back to Material's baseline purple. The swipe reveal uses `primary` / `secondary` for that reason. The pre-existing `tertiaryContainer` chips elsewhere in `ConversationItem` are untouched here and are worth a separate issue.
