### PR TITLE
Stop a server 403 from killing the app

### DIFF
--- a/androidApp/src/main/kotlin/id/homebase/feed/crash/GlobalCrashHandler.kt
+++ b/androidApp/src/main/kotlin/id/homebase/feed/crash/GlobalCrashHandler.kt
@@ -9,6 +9,7 @@ import co.touchlab.kermit.Logger
 import com.google.firebase.Firebase
 import com.google.firebase.crashlytics.crashlytics
 import id.homebase.api.client.isMlKitTeardownFailure
+import id.homebase.api.client.isRecoverablePermissionFailure
 import id.homebase.api.client.isRecoverableServerConflict
 import id.homebase.api.client.isTransientNetworkFailure
 import id.homebase.core.crash.CrashMetadata
@@ -69,6 +70,8 @@ object GlobalCrashHandler {
                             "ML Kit/MediaPipe failure (background removal degrades to no cutout)"
                         throwable.isRecoverableServerConflict() ->
                             "Recoverable server conflict (stale versionTag; write dropped, drive-sync reconciles)"
+                        throwable.isRecoverablePermissionFailure() ->
+                            "Permission denied by the server (403; the grant was revoked or narrowed)"
                         else -> "Transient network failure"
                     }
                     "$kind on '${thread.name}'; contained, not crashing: ${throwable.message}"
@@ -117,7 +120,9 @@ object GlobalCrashHandler {
      *    failure**, including a TLS-inspecting VPN/proxy/AV presenting an untrusted cert; and
      *  - an ML Kit / MediaPipe teardown (best-effort background removal on native threads); and
      *  - a recoverable optimistic-concurrency conflict (a 400 VersionTagMismatch — the write was
-     *    dropped because the file's versionTag advanced; drive-sync reconciles). See #1008.
+     *    dropped because the file's versionTag advanced; drive-sync reconciles). See #1008; and
+     *  - a permission denial (a 403 — the app token's grant was revoked or narrowed server-side;
+     *    the extend-permissions flow is how the user restores it).
      *
      * These routinely leak from a coroutine launched on a scope without its own
      * CoroutineExceptionHandler (e.g. a bare `viewModelScope.launch`). Killing the process for
@@ -127,7 +132,8 @@ object GlobalCrashHandler {
     internal fun isContainableNonFatal(throwable: Throwable): Boolean =
         throwable.isTransientNetworkFailure() ||
             throwable.isMlKitTeardownFailure() ||
-            throwable.isRecoverableServerConflict()
+            throwable.isRecoverableServerConflict() ||
+            throwable.isRecoverablePermissionFailure()
 
     /**
      * Whether to launch the [CrashActivity] recovery screen for this crash. Pure so it

--- a/androidApp/src/test/kotlin/id/homebase/feed/crash/GlobalCrashHandlerContainmentTest.kt
+++ b/androidApp/src/test/kotlin/id/homebase/feed/crash/GlobalCrashHandlerContainmentTest.kt
@@ -1,9 +1,11 @@
 package id.homebase.feed.crash
 
 import id.homebase.api.client.ClientException
+import id.homebase.api.client.ForbiddenException
 import id.homebase.api.client.NetworkException
 import id.homebase.api.client.OdinClientErrorCode
 import id.homebase.api.client.ProblemDetails
+import id.homebase.api.client.UnauthorizedException
 import java.io.IOException
 import javax.net.ssl.SSLHandshakeException
 import kotlin.test.assertFalse
@@ -68,5 +70,26 @@ class GlobalCrashHandlerContainmentTest {
     fun otherClientError_isNotContained_soItStillCrashes() {
         // A non-conflict 400 (a real bad-request bug) must still terminate + report.
         assertFalse(GlobalCrashHandler.isContainableNonFatal(clientException(OdinClientErrorCode.UnhandledScenario)))
+    }
+
+    @Test
+    fun permissionDenied_isContained() {
+        // The desktop crash loop: an add-on activation writes the drive registry on the Chat
+        // drive, the app token's grant has been revoked server-side, and the 403 leaves a bare
+        // viewModelScope.launch. A revoked grant must never kill the app.
+        val forbidden = ForbiddenException(
+            ProblemDetails(
+                status = 403,
+                title = "No access permitted to drive 9ff813af-f2d6-1e2f-9b9d-b189e72d1a11",
+            ),
+        )
+        assertTrue(GlobalCrashHandler.isContainableNonFatal(forbidden))
+        assertTrue(GlobalCrashHandler.isContainableNonFatal(RuntimeException("wrapped", forbidden)))
+    }
+
+    @Test
+    fun unauthorized_isNotContained_soItStillCrashes() {
+        // A 401 is an auth-state problem for the auth layer to act on, not one to run through.
+        assertFalse(GlobalCrashHandler.isContainableNonFatal(UnauthorizedException()))
     }
 }

--- a/desktopApp/src/jvmMain/kotlin/id/homebase/app/Main.kt
+++ b/desktopApp/src/jvmMain/kotlin/id/homebase/app/Main.kt
@@ -37,6 +37,7 @@ import id.homebase.core.App
 import id.homebase.core.auth.AuthConnectionCoordinator
 import id.homebase.core.di.allModules
 import id.homebase.core.diagnostics.MainThreadWatchdog
+import id.homebase.api.client.isRecoverablePermissionFailure
 import id.homebase.api.client.isRecoverableServerConflict
 import id.homebase.api.client.isTransientNetworkFailure
 import id.homebase.app.crash.CrashRecoveryDialog
@@ -362,17 +363,32 @@ private val MAC_TITLE_BAR_HEIGHT = 28.dp
 private fun menuShortcut(key: Key) =
     KeyShortcut(key, ctrl = !isMacOs, meta = isMacOs)
 
+/**
+ * A failure the desktop app records and keeps running for, instead of dying: a transient network
+ * blip (PR #737), a recoverable optimistic-concurrency conflict (400 VersionTagMismatch, #1008),
+ * or a permission denial (403 — the app token's grant was revoked or narrowed server-side).
+ *
+ * All three are server answers, not client defects, and all three routinely leak from a coroutine
+ * launched on a scope with no CoroutineExceptionHandler of its own (a bare `viewModelScope.launch`
+ * — how every add-on activates its drive). Anything else still terminates and reports. Pure so it
+ * is unit-testable; mirrors Android's `GlobalCrashHandler.isContainableNonFatal`.
+ */
+internal fun isContainableNonFatal(throwable: Throwable): Boolean =
+    throwable.isTransientNetworkFailure() ||
+        throwable.isRecoverableServerConflict() ||
+        throwable.isRecoverablePermissionFailure()
+
 private fun setupCrashHandler() {
     Thread.setDefaultUncaughtExceptionHandler { thread, throwable ->
-        // Preserve PR #737: don't crash on a transient network blip. Also contain a
-        // recoverable optimistic-concurrency conflict (400 VersionTagMismatch, #1008).
-        if (throwable.isTransientNetworkFailure() || throwable.isRecoverableServerConflict()) {
+        if (isContainableNonFatal(throwable)) {
             crashlyticsRecordException(throwable)
             Logger.w(tag = "CrashHandler") {
-                val kind = if (throwable.isRecoverableServerConflict()) {
-                    "Recoverable server conflict (stale versionTag; write dropped, drive-sync reconciles)"
-                } else {
-                    "Transient network failure"
+                val kind = when {
+                    throwable.isRecoverableServerConflict() ->
+                        "Recoverable server conflict (stale versionTag; write dropped, drive-sync reconciles)"
+                    throwable.isRecoverablePermissionFailure() ->
+                        "Permission denied by the server (403; the grant was revoked or narrowed)"
+                    else -> "Transient network failure"
                 }
                 "$kind leaked to '${thread.name}' (no local handler); " +
                     "app not crashing: ${throwable.message}\n" +

--- a/desktopApp/src/jvmTest/kotlin/id/homebase/app/DesktopCrashHandlerContainmentTest.kt
+++ b/desktopApp/src/jvmTest/kotlin/id/homebase/app/DesktopCrashHandlerContainmentTest.kt
@@ -1,0 +1,75 @@
+package id.homebase.app
+
+import id.homebase.api.client.ClientException
+import id.homebase.api.client.ForbiddenException
+import id.homebase.api.client.NetworkException
+import id.homebase.api.client.OdinClientErrorCode
+import id.homebase.api.client.ProblemDetails
+import id.homebase.api.client.UnauthorizedException
+import java.io.IOException
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Guards [isContainableNonFatal] — the decision the desktop uncaught-exception handler makes
+ * before it shows the crash-recovery dialog and terminates. The Android twin is
+ * `GlobalCrashHandlerContainmentTest`.
+ *
+ * The 403 case is the desktop crash loop: with the app token's drive grants revoked
+ * server-side, an add-on activation writes the drive-registry file on the Chat drive, the
+ * server answers 403, and the exception leaves a bare `viewModelScope.launch` — which on
+ * desktop is `Dispatchers.Main.immediate`, i.e. the AWT EDT — with no handler. Four process
+ * deaths in 72 seconds.
+ */
+class DesktopCrashHandlerContainmentTest {
+
+    private val forbidden = ForbiddenException(
+        ProblemDetails(
+            status = 403,
+            title = "No access permitted to drive 9ff813af-f2d6-1e2f-9b9d-b189e72d1a11",
+        ),
+    )
+
+    @Test
+    fun permissionDeniedIsContained() {
+        assertTrue(isContainableNonFatal(forbidden))
+    }
+
+    @Test
+    fun permissionDeniedNestedInACauseChainIsContained() {
+        assertTrue(isContainableNonFatal(RuntimeException("upload failed", forbidden)))
+    }
+
+    @Test
+    fun transientNetworkFailureIsStillContained() {
+        assertTrue(isContainableNonFatal(NetworkException(IOException("socket closed"))))
+    }
+
+    @Test
+    fun versionTagMismatchIsStillContained() {
+        assertTrue(
+            isContainableNonFatal(
+                ClientException(
+                    status = 400,
+                    errorCode = OdinClientErrorCode.VersionTagMismatch,
+                    message = "stale versionTag",
+                    correlationId = null,
+                    problem = ProblemDetails(status = 400, title = "stale versionTag"),
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun unauthorizedStillCrashes() {
+        // A dead token is for the auth layer to act on, not something to keep running through.
+        assertFalse(isContainableNonFatal(UnauthorizedException()))
+    }
+
+    @Test
+    fun programmingErrorsStillCrash() {
+        assertFalse(isContainableNonFatal(IllegalStateException("No active credentials set")))
+        assertFalse(isContainableNonFatal(NullPointerException()))
+    }
+}

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/ForbiddenException.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/ForbiddenException.kt
@@ -3,3 +3,28 @@ package id.homebase.api.client
 class ForbiddenException(
     problem: ProblemDetails? = null
 ) : OdinApiException(403, problem?.title ?: "Forbidden", problem = problem)
+
+/**
+ * True when [this] (or anything in its cause chain) is a server **permission denial** — a 403.
+ * The server answered, and its answer is "this app token has no grant for that": a drive grant
+ * revoked or narrowed in the owner console, an app re-authorized against a smaller set, a
+ * circle/connection check that no longer passes. That is a state of the account, recoverable by
+ * the user through the extend-permissions flow — not a defect in the client, and never a reason
+ * to kill the process.
+ *
+ * Used by the platform uncaught-exception handlers exactly like [isTransientNetworkFailure] and
+ * [isRecoverableServerConflict], for a 403 that leaks from a write on a scope with no
+ * CoroutineExceptionHandler of its own (a bare `viewModelScope.launch`). Deliberately narrow:
+ * 403 only. A 401 stays fatal — an invalid token is an auth-state problem the auth layer has to
+ * act on, not something to keep running through. Walks the cause chain defensively (guards
+ * against a cyclic chain).
+ */
+fun Throwable.isRecoverablePermissionFailure(): Boolean {
+    val seen = HashSet<Throwable>()
+    var cur: Throwable? = this
+    while (cur != null && seen.add(cur)) {
+        if (cur is ForbiddenException) return true
+        cur = cur.cause
+    }
+    return false
+}

--- a/homebase-api/src/jvmTest/kotlin/id/homebase/api/client/ForbiddenExceptionTest.kt
+++ b/homebase-api/src/jvmTest/kotlin/id/homebase/api/client/ForbiddenExceptionTest.kt
@@ -1,0 +1,74 @@
+package id.homebase.api.client
+
+import kotlinx.io.IOException
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Tests for the [isRecoverablePermissionFailure] predicate the platform uncaught-exception
+ * handlers use to keep a server 403 from killing the process.
+ *
+ * The observed crash: with the app token's drive grants revoked server-side, an add-on
+ * activation writes the drive-registry file on the Chat drive, the server answers 403, and the
+ * exception leaves a bare `viewModelScope.launch` with no CoroutineExceptionHandler — straight
+ * to `Thread.setDefaultUncaughtExceptionHandler` and process death, four times in 72 seconds.
+ *
+ * The predicate must be precise: a 403 classifies true (recorded, app survives), every other
+ * failure — a 401, a programming error — classifies false and stays fatal.
+ */
+class ForbiddenExceptionTest {
+
+    private fun forbidden(title: String) = ForbiddenException(
+        ProblemDetails(status = 403, title = title),
+    )
+
+    @Test
+    fun `a 403 classifies as a recoverable permission failure`() {
+        assertTrue(
+            forbidden("No access permitted to drive 9ff813af-f2d6-1e2f-9b9d-b189e72d1a11")
+                .isRecoverablePermissionFailure(),
+        )
+    }
+
+    @Test
+    fun `a 403 nested in a cause chain classifies`() {
+        // The image loader wraps the real cause in a RuntimeException before rethrowing.
+        val wrapped = RuntimeException("thumbnail load failed", forbidden("Does not have permission"))
+        assertTrue(wrapped.isRecoverablePermissionFailure())
+    }
+
+    @Test
+    fun `a cyclic cause chain terminates`() {
+        val outer = RuntimeException("outer")
+        val inner = RuntimeException("inner", outer)
+        outer.initCause(inner)
+        assertFalse(outer.isRecoverablePermissionFailure())
+    }
+
+    @Test
+    fun `a 401 stays fatal`() {
+        // An invalid token is an auth-state problem the auth layer has to act on
+        // (DeadTokenLogout), not something to keep running through.
+        assertFalse(UnauthorizedException().isRecoverablePermissionFailure())
+    }
+
+    @Test
+    fun `programming errors stay fatal`() {
+        assertFalse(IllegalStateException("No active credentials set").isRecoverablePermissionFailure())
+        assertFalse(NullPointerException().isRecoverablePermissionFailure())
+        assertFalse(IllegalArgumentException("bad").isRecoverablePermissionFailure())
+    }
+
+    @Test
+    fun `a transport failure is not misclassified as a permission failure`() {
+        assertFalse(NetworkException(IOException("socket closed")).isRecoverablePermissionFailure())
+    }
+
+    @Test
+    fun `a permission failure is not misclassified as transport or conflict`() {
+        val ex = forbidden("No access permitted to drive")
+        assertFalse(ex.isTransientNetworkFailure())
+        assertFalse(ex.isRecoverableServerConflict())
+    }
+}

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/image/HomebaseImageLoader.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/image/HomebaseImageLoader.kt
@@ -1,6 +1,7 @@
 package id.homebase.core.image
 
 import co.touchlab.kermit.Logger
+import id.homebase.api.client.ForbiddenException
 import id.homebase.api.client.NotFoundException
 import id.homebase.api.client.PayloadTooLargeException
 import id.homebase.api.client.RetryConfig
@@ -71,13 +72,18 @@ class HomebaseImageLoader(
 
         // Default retry configuration for image loading.
         // retryOn unwraps the RuntimeException wrapper produced below so the real
-        // cause (e.g. NotFoundException) still short-circuits retries.
+        // cause (e.g. NotFoundException) still short-circuits retries. A 403 is a
+        // standing answer, not a blip: retrying it four times with backoff only
+        // multiplies the log noise.
         val DEFAULT_RETRY_CONFIG = RetryConfig(
             maxRetries = 3,
             initialDelayMs = 500L,
             maxDelayMs = 5000L,
             backoffMultiplier = 2.0,
-            retryOn = { e -> (e.cause ?: e) !is NotFoundException }
+            retryOn = { e ->
+                val cause = e.cause ?: e
+                cause !is NotFoundException && cause !is ForbiddenException
+            }
         )
     }
 

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/sync/DriveRegistry.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/sync/DriveRegistry.kt
@@ -16,6 +16,7 @@ import id.homebase.api.client.drives.upload.UploadFileMetadata
 import id.homebase.api.client.drives.upload.UploadFileRequest
 import id.homebase.api.client.eventbus.BackendEvent
 import id.homebase.api.client.eventbus.EventBus
+import id.homebase.api.client.isRecoverablePermissionFailure
 import id.homebase.api.client.isTransientNetworkFailure
 import id.homebase.api.crypto.ByteArrayUtil
 import id.homebase.api.serialization.OdinSystemSerializer
@@ -287,17 +288,33 @@ class DriveRegistry(
         }
     }
 
-    // Transport failure only: the drive stays out of the cross-device list until a later
-    // activation re-registers it. Every other failure still propagates.
+    /**
+     * Register [drive] without letting the registry write decide whether the activation
+     * happens. Two failures are contained, both of which mean "the server would not take the
+     * write", never "the client is broken":
+     *
+     *  - a transport failure (offline, timeout, dropped socket), and
+     *  - a 403 on the Chat drive that holds the registry file — the app token's write grant was
+     *    revoked or narrowed in the owner console.
+     *
+     * In both cases the drive stays out of the cross-device list until a later activation
+     * re-registers it, and [AuthConnectionCoordinator.mountDrive] carries on to mount it
+     * locally — which is the caller's actual goal and works off a read grant this write does not
+     * gate. Rethrowing the 403 instead both aborted the local mount and, because every add-on
+     * activates from a `viewModelScope.launch` with no CoroutineExceptionHandler, killed the
+     * process. Every other failure still propagates.
+     */
     suspend fun addDriveBestEffort(drive: LabeledDrive) {
         try {
             addDrive(drive)
         } catch (e: CancellationException) {
             throw e
         } catch (e: Throwable) {
-            if (!e.isTransientNetworkFailure()) throw e
+            val transport = e.isTransientNetworkFailure()
+            if (!transport && !e.isRecoverablePermissionFailure()) throw e
             Logger.w(tag = TAG, throwable = e) {
-                "addDrive(${drive.label}) hit a transport failure — not registered this session"
+                val reason = if (transport) "a transport failure" else "a 403 on the Chat drive"
+                "addDrive(${drive.label}) hit $reason — not registered this session"
             }
         }
     }

--- a/homebase-common/src/jvmTest/kotlin/id/homebase/core/sync/DriveRegistryTest.kt
+++ b/homebase-common/src/jvmTest/kotlin/id/homebase/core/sync/DriveRegistryTest.kt
@@ -1,9 +1,11 @@
 package id.homebase.core.sync
 
 import id.homebase.api.client.ClientException
+import id.homebase.api.client.ForbiddenException
 import id.homebase.api.client.NetworkException
 import id.homebase.api.client.OdinClientErrorCode
 import id.homebase.api.client.ProblemDetails
+import id.homebase.api.client.UnauthorizedException
 import id.homebase.api.client.auth.ApiCredentials
 import id.homebase.api.client.auth.CredentialsManager
 import id.homebase.api.client.drives.HomebaseFile
@@ -20,7 +22,10 @@ import id.homebase.api.sync.database.DatabaseManager
 import id.homebase.api.sync.database.MainIndexMetaHelpers
 import id.homebase.core.config.LabeledDrive
 import id.homebase.core.config.feedLabeledDrive
+import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestScope
@@ -285,6 +290,88 @@ class DriveRegistryTest {
         val registry = buildRegistry(db, recorder = recorder)
 
         assertFailsWith<ClientException> {
+            registry.addDriveBestEffort(feedLabeledDrive)
+        }
+        db.close()
+    }
+
+    // ---------- addDriveBestEffort: the 403 crash loop ----------
+    //
+    // With the app token's drive grants revoked server-side, `updateRegistry` finds no registry
+    // file (the by-uid header GET answers 404), tries to CREATE one on the Chat drive, and the
+    // server answers 403. Because `addDriveBestEffort` only contained *transport* failures, the
+    // 403 propagated out of `AuthConnectionCoordinator.mountDrive` — whose own contract says
+    // "Must not throw: callers activate add-ons from a viewModelScope with no handler" — and
+    // straight into the platform uncaught handler. Four process deaths in 72 seconds.
+
+    @Test
+    fun addDriveBestEffortSwallowsPermissionDenied() = runTest {
+        val db = createTestDatabaseManager()
+        val recorder = WriteRecorder(
+            uploadThrowsOnCall = { forbiddenOnChatDrive() },
+        )
+        val registry = buildRegistry(db, recorder = recorder)
+
+        // Must return normally. Throwing here is the crash.
+        registry.addDriveBestEffort(feedLabeledDrive)
+
+        assertEquals(1, recorder.uploads.size, "the write was attempted, and denied")
+        db.close()
+    }
+
+    /**
+     * The production shape, modelled on `NoteToSelfBootstrapCrashTest`: an add-on activates from
+     * a `viewModelScope`-shaped scope (SupervisorJob, no CoroutineExceptionHandler) with no local
+     * try/catch. The handler here stands in for the uncaught path so the test can observe an
+     * escape without killing the test JVM; on the real scope there is none, so an escape lands on
+     * `Thread.setDefaultUncaughtExceptionHandler` and the process dies.
+     */
+    @Test
+    fun permissionDeniedDoesNotEscapeAViewModelScopedActivation() = runTest {
+        val db = createTestDatabaseManager()
+        val registry = buildRegistry(
+            db,
+            recorder = WriteRecorder(uploadThrowsOnCall = { forbiddenOnChatDrive() }),
+        )
+
+        var escaped: Throwable? = null
+        val viewModelLikeScope = CoroutineScope(
+            SupervisorJob() + Dispatchers.Unconfined + CoroutineExceptionHandler { _, e -> escaped = e },
+        )
+
+        // What AuthConnectionCoordinator.mountDrive does first, launched the way every add-on
+        // ViewModel launches it.
+        viewModelLikeScope.launch { registry.addDriveBestEffort(feedLabeledDrive) }.join()
+
+        assertNull(escaped, "a 403 on the registry write must not reach the uncaught path; was: $escaped")
+        db.close()
+    }
+
+    @Test
+    fun addDriveBestEffortPropagatesUnauthorized() = runTest {
+        // 401 is not a permission denial to shrug off — the auth layer has to act on a dead
+        // token. Guards the containment from widening past 403.
+        val db = createTestDatabaseManager()
+        val registry = buildRegistry(
+            db,
+            recorder = WriteRecorder(uploadThrowsOnCall = { UnauthorizedException() }),
+        )
+
+        assertFailsWith<UnauthorizedException> {
+            registry.addDriveBestEffort(feedLabeledDrive)
+        }
+        db.close()
+    }
+
+    @Test
+    fun addDriveBestEffortPropagatesProgrammingErrors() = runTest {
+        val db = createTestDatabaseManager()
+        val registry = buildRegistry(
+            db,
+            recorder = WriteRecorder(uploadThrowsOnCall = { IllegalStateException("bug") }),
+        )
+
+        assertFailsWith<IllegalStateException> {
             registry.addDriveBestEffort(feedLabeledDrive)
         }
         db.close()
@@ -821,6 +908,8 @@ class DriveRegistryTest {
         // Returning null (or omitting) → success (the request is captured).
         val uploadErrorOnCall: (() -> OdinClientErrorCode?)? = null,
         val updateErrorOnCall: (() -> OdinClientErrorCode?)? = null,
+        // For failures that are not ClientExceptions (a 403, say).
+        val uploadThrowsOnCall: (() -> Throwable?)? = null,
     ) {
         val uploads = mutableListOf<UploadFileRequest>()
         val updates = mutableListOf<UpdateFileByUniqueIdRequest>()
@@ -855,6 +944,7 @@ class DriveRegistryTest {
             uploadFile = { request ->
                 // Record the attempt regardless of outcome so retries are observable.
                 recorder.uploads += request
+                recorder.uploadThrowsOnCall?.invoke()?.let { throw it }
                 val err = recorder.uploadErrorOnCall?.invoke()
                 if (err != null) throw buildClientException(err)
             },
@@ -867,6 +957,13 @@ class DriveRegistryTest {
             scope = backgroundScope,
         )
     }
+
+    private fun forbiddenOnChatDrive(): ForbiddenException = ForbiddenException(
+        ProblemDetails(
+            status = 403,
+            title = "No access permitted to drive ${SystemDriveConstants.chatDrive.alias}",
+        ),
+    )
 
     private fun buildClientException(code: OdinClientErrorCode): ClientException =
         ClientException(

--- a/homebase-common/src/nativeMain/kotlin/id/homebase/core/logging/IOSCrashHandler.kt
+++ b/homebase-common/src/nativeMain/kotlin/id/homebase/core/logging/IOSCrashHandler.kt
@@ -1,6 +1,7 @@
 package id.homebase.core.logging
 
 import co.touchlab.kermit.Logger
+import id.homebase.api.client.isRecoverablePermissionFailure
 import id.homebase.api.client.isRecoverableServerConflict
 import id.homebase.api.client.isTransientNetworkFailure
 import id.homebase.core.crash.CrashReporting
@@ -103,15 +104,20 @@ fun setupIOSCrashHandler() {
         // NOT abort the app. Record it as a non-fatal (full stack + breadcrumb) so
         // it stays debuggable, then return WITHOUT terminating. Any non-network
         // throwable falls through and still crashes normally below.
-        if (throwable.isTransientNetworkFailure() || throwable.isRecoverableServerConflict()) {
+        if (throwable.isTransientNetworkFailure() ||
+            throwable.isRecoverableServerConflict() ||
+            throwable.isRecoverablePermissionFailure()
+        ) {
             try {
                 crashlyticsRecordException(throwable)
                 crashlyticsLogFatalBreadcrumb(throwable)
                 Logger.w(tag = TAG) {
-                    val kind = if (throwable.isRecoverableServerConflict()) {
-                        "Recoverable server conflict (stale versionTag; write dropped, drive-sync reconciles)"
-                    } else {
-                        "Transient network failure"
+                    val kind = when {
+                        throwable.isRecoverableServerConflict() ->
+                            "Recoverable server conflict (stale versionTag; write dropped, drive-sync reconciles)"
+                        throwable.isRecoverablePermissionFailure() ->
+                            "Permission denied by the server (403; the grant was revoked or narrowed)"
+                        else -> "Transient network failure"
                     }
                     "$kind (no local handler); app not crashing: ${throwable.message}"
                 }


### PR DESCRIPTION
## What was happening

A revoked drive grant was killing the desktop app in a loop — four process deaths in 72 seconds (10:24:13, 10:24:36, 10:25:09, 10:25:25), each on a byte-identical stack:

```
id.homebase.api.client.ForbiddenException: Forbidden: No access permitted to drive 9ff813af-… (Chat)
    at id.homebase.api.client.OdinApiProviderBase.throwForFailure(OdinApiProviderBase.kt:551)
    at …DriveUploadProvider.handleErrorResponse(DriveUploadProvider.kt:558)
    at …DriveUploadProvider.pureUpload(DriveUploadProvider.kt:443)
    …
    at java.desktop/java.awt.EventDispatchThread.run(EventDispatchThread.java:90)
    Suppressed: DiagnosticCoroutineContextException: [StandaloneCoroutine{Cancelling}, Dispatchers.Main.immediate]
```

The chain:

1. The app token's read grants for Vault / Moments / Location / Feed are gone server-side. `AuthCC` prunes those four drives from the live session (`read grant revoked — pruning drive …`), so their `isActivated` reads false.
2. An add-on's auto-activate collector sees "permission granted, drive not activated" and calls `OptionalDriveActivation.activate(...)` → `AuthConnectionCoordinator.mountDrive(...)`.
3. `mountDrive` persists to the cross-device registry first: `driveRegistry.addDriveBestEffort(drive)` → `updateRegistry`. The registry file's header `GET` answers 404, so the client believes no registry file exists and tries to **create** one on the Chat drive. The server answers **403**.
4. `addDriveBestEffort` only contained `isTransientNetworkFailure()`. A 403 is not transient, so it rethrew — out of `mountDrive`, whose own doc comment already reads *"Must not throw: callers activate add-ons from a viewModelScope with no handler"* — into a bare `viewModelScope.launch`. On desktop that scope is `Dispatchers.Main.immediate`, i.e. the AWT EDT, so it reached `Thread.setDefaultUncaughtExceptionHandler` and the app died.

`StickerService.activate()` already catches, which is why the first registry write of each run is logged (`Failed to activate Stickers drive`) and survived; a second, unguarded activation ~300 ms later is the one that killed the process.

## The fix

Two layers, both extending mechanisms this repo already has.

**1. Honour the contract that already exists.** `DriveRegistry.addDriveBestEffort` now contains a 403 as well as a transport failure. Both mean "the server would not take this write", never "the client is broken". The drive stays out of the cross-device list until a later activation re-registers it — the same trade-off the transport case already accepts — and `mountDrive` carries on to mount the drive **locally**, which is what the caller actually wanted and which the failed cross-device write does not gate. Before, the 403 aborted the mount as well as killing the app.

**2. Close the class at the last line of defence.** The three platform uncaught handlers (desktop `Main.kt`, `GlobalCrashHandler`, `IOSCrashHandler`) already contain a transient network failure (#737) and a recoverable optimistic-concurrency conflict (#1008) instead of terminating, precisely because those "routinely leak from a coroutine launched on a scope without its own CoroutineExceptionHandler (e.g. a bare `viewModelScope.launch`)". A 403 belongs in the same category and was simply never added. New `Throwable.isRecoverablePermissionFailure()` sits beside `isTransientNetworkFailure()` and `isRecoverableServerConflict()`, and all three handlers consult it.

The line is drawn deliberately: a **403** is a server answer about the state of the account, recoverable by the user through the extend-permissions flow. A `NullPointerException`, an `IllegalStateException`, a non-conflict 400 — still fatal, still get the crash-recovery screen. **401 stays fatal too**: a dead token is for the auth layer to act on, not something to keep running through.

Desktop's containment decision is extracted to a pure `isContainableNonFatal(throwable)`, mirroring Android's, so the real function the handler calls is unit-testable.

**3. One-liner while in the area:** the image loader retried a `ForbiddenException` four times with backoff. A 403 is a standing answer, not a blip — it is now non-retriable alongside `NotFoundException`.

## What this does NOT cover

- The handler is a net, not error handling. `VaultViewModel.handleActivation` goes on to `createDefaultSections()` → an upload to the Vault drive; a 403 there still escapes its unguarded launch. The app now survives it (logged + recorded as a non-fatal) but that VM's collector is dead for the session and the user gets no message. Same for the other add-on activations. Individually guarding those call sites is a separate, per-feature job.
- It does not fix *why* there is a 403 — see below.
- Containment is per-throwable, not per-scope: a coroutine that takes a 403 is still cancelled, so whatever it was doing does not finish.

## Why there is a 403 (not fixed here — needs its own issue)

Reproduced live against a copy of the affected data directory, on current `main`:

- `AuthCC: readable drive grants resolved (count=17)` and Vault / Moments / Location / Feed are genuinely not among them, so all four are pruned, while `DriveRegistry.reconcileWithServer: server has 7 drive(s)` — the identity's registry lists drives the app token cannot read.
- `GET /api/v2/connections/circles/with-members` answers `403 Does not have permission` on every run.
- In the crashing runs the Chat-drive registry header `GET` answered 404 and the Chat-drive `POST /files` answered `403 No access permitted to drive`, while `query-batch-collection` on the same drive succeeded. The Contacts drive behaved the same way (`403 No access permitted to drive 2612429d-…` on payload `GET`s from `ContactOverrideStore`).

So a freshly re-authorized app token is missing grants it should have — including, intermittently, write access to its **own Chat drive**. That is a server/authorization-state defect, not a client one, and it deserves a separate issue rather than being patched inside this PR.

Worth a look in that issue: `ExtendPermissionViewModel` flip-flops between `Missing permissions detected: drives=1` and `All permissions are granted` dozens of times in a couple of seconds, firing a burst of `GET /api/v2/auth/context` — that flapping is what re-arms the auto-activate collectors, and it reproduces even when the app is otherwise healthy.

## Tests

- `ForbiddenExceptionTest` (homebase-api) — the predicate: a 403 direct and nested in a cause chain classifies; a cyclic chain terminates; 401, `IllegalStateException`, `NullPointerException` and a transport failure do not.
- `DriveRegistryTest` — `addDriveBestEffortSwallowsPermissionDenied`, plus `permissionDeniedDoesNotEscapeAViewModelScopedActivation`, which reproduces the production shape (SupervisorJob + no `CoroutineExceptionHandler` + no local try/catch, modelled on `NoteToSelfBootstrapCrashTest`) and asserts nothing reaches the uncaught path. Both fail on `main` and pass here. `addDriveBestEffortPropagatesUnauthorized` / `…ProgrammingErrors` pin the containment from widening.
- `DesktopCrashHandlerContainmentTest` (new) and `GlobalCrashHandlerContainmentTest` (extended) — the containment decision on both platforms, including that 401 and programming errors still crash.

Compiled: `:homebase-api:` and `:homebase-common:` on `compileKotlinJvm`, `compileAndroidMain`, `compileKotlinWasmJs`, `compileKotlinIosSimulatorArm64`; `:androidApp:compileDebugKotlin`; `:desktopApp:compileKotlinJvm`. Suites green: `homebase-api:jvmTest`, `homebase-common:jvmTest`, `homebase-chat:jvmTest`, `homebase-core:jvmTest`, `desktopApp:jvmTest`, `androidApp:testDebugUnitTest`, and `./gradlew lint`.

The desktop app was also run end-to-end against a copy of the affected data directory: it starts, prunes the four ungranted drives, and stays up.
