### PR TITLE
Open the desktop database in SQLCipher raw-key mode

### DIFF
--- a/homebase-api/src/jvmMain/kotlin/id/homebase/api/sync/database/DatabaseDriverFactory.jvm.kt
+++ b/homebase-api/src/jvmMain/kotlin/id/homebase/api/sync/database/DatabaseDriverFactory.jvm.kt
@@ -4,7 +4,6 @@ import app.cash.sqldelight.db.SqlDriver
 import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
 import id.homebase.api.file.JvmFileSystemUtil
 import java.io.File
-import java.util.Properties
 
 actual class DatabaseDriverFactory {
     actual fun createDriver(passphrase: String?): SqlDriver {
@@ -14,10 +13,7 @@ actual class DatabaseDriverFactory {
         val jdbcUrl = if (passphrase.isNullOrEmpty()) {
             "jdbc:sqlite:$dbFileName"
         } else {
-            val encodedPassword = java.net.URLEncoder.encode(
-                passphrase, java.nio.charset.StandardCharsets.UTF_8.name()
-            )
-            "jdbc:sqlite:file:$dbFileName?cipher=sqlcipher&legacy=4&key=$encodedPassword"
+            SqlCipherKeyMode.jdbcUrl(dbFile, passphrase)
         }
 
         // Apply the shared SQLITE_TUNING_PRAGMAS as JDBC connection properties — the
@@ -25,11 +21,7 @@ actual class DatabaseDriverFactory {
         // writes use different connections; see DatabaseManager). These are the same
         // key/value pairs SQLiteConfig.toProperties() would emit, just sourced from the
         // one cross-platform definition so desktop/Android/iOS can't drift.
-        val props = Properties().apply {
-            SQLITE_TUNING_PRAGMAS.forEach { (key, value) -> setProperty(key, value) }
-        }
-
-        return JdbcSqliteDriver(jdbcUrl, props)
+        return JdbcSqliteDriver(jdbcUrl, tuningProperties())
     }
 
     actual fun dbFilePath(): String = resolveDbFile().absolutePath

--- a/homebase-api/src/jvmMain/kotlin/id/homebase/api/sync/database/SqlCipherKeyMode.jvm.kt
+++ b/homebase-api/src/jvmMain/kotlin/id/homebase/api/sync/database/SqlCipherKeyMode.jvm.kt
@@ -1,0 +1,138 @@
+package id.homebase.api.sync.database
+
+import co.touchlab.kermit.Logger
+import id.homebase.api.storage.SecureStorage
+import java.io.File
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+import java.security.SecureRandom
+import java.sql.DriverManager
+import java.util.Properties
+import javax.crypto.SecretKeyFactory
+import javax.crypto.spec.PBEKeySpec
+
+internal interface RawKeyStore {
+    fun get(): String?
+    fun put(hex: String)
+    fun remove()
+}
+
+private object SecureStorageRawKeyStore : RawKeyStore {
+    private const val KEY_DB_RAW_KEY = "odin_db_raw_key"
+
+    override fun get(): String? = SecureStorage.get(KEY_DB_RAW_KEY)
+    override fun put(hex: String) = SecureStorage.put(KEY_DB_RAW_KEY, hex)
+    override fun remove() = SecureStorage.remove(KEY_DB_RAW_KEY)
+}
+
+/**
+ * Builds the SQLCipher JDBC URL for the desktop database, preferring **raw-key** mode
+ * (`key=x'<64 hex>'`) over passphrase mode (`key=<text>`).
+ *
+ * The distinction is the whole point: with a passphrase SQLCipher runs
+ * PBKDF2-HMAC-SHA512 × 256,000 on *every* connection open, and SQLDelight's
+ * [app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver] closes its connection
+ * whenever no transaction is active — so a cold start pays that KDF ~30 times
+ * (measured: 165 ms each, ~4 s of a desktop launch). A raw key is the KDF's *output*,
+ * so handing it over directly skips the derivation and opens in ~1 ms.
+ *
+ * The 32-byte key is derived once from the existing passphrase and the file's own
+ * 16-byte header salt, then cached. Same key, same ciphertext — the database file is
+ * never rewritten and the change is reversible by deleting the cached key.
+ */
+internal object SqlCipherKeyMode {
+    private const val SALT_BYTES = 16
+    private const val RAW_KEY_BYTES = 32
+    private const val RAW_KEY_HEX_LENGTH = RAW_KEY_BYTES * 2
+
+    // Must match the `legacy=4` (SQLCipher v4) profile the URL asks for, or the derived
+    // key won't be the one the file was encrypted with.
+    private const val KDF_ITERATIONS = 256_000
+
+    private val logger = Logger.withTag("SqlCipherKeyMode")
+
+    fun jdbcUrl(dbFile: File, passphrase: String): String =
+        jdbcUrl(dbFile, passphrase, SecureStorageRawKeyStore)
+
+    internal fun jdbcUrl(dbFile: File, passphrase: String, store: RawKeyStore): String {
+        val cached = store.get()?.takeIf(::isRawKeyHex)
+
+        if (!dbFile.isFile || dbFile.length() < SALT_BYTES) {
+            // Store before the driver creates the file, so a crash in between leaves the
+            // key that the next run will open it with.
+            val hex = cached ?: newRawKeyHex().also { store.put(it) }
+            return rawKeyUrl(dbFile, hex)
+        }
+
+        if (cached != null && opens(rawKeyUrl(dbFile, cached))) return rawKeyUrl(dbFile, cached)
+
+        val derived = deriveRawKeyHex(passphrase, readSalt(dbFile))
+        if (opens(rawKeyUrl(dbFile, derived))) {
+            store.put(derived)
+            logger.i { "Database migrated to SQLCipher raw-key mode" }
+            return rawKeyUrl(dbFile, derived)
+        }
+
+        // Neither key decrypts the file. Hand back the passphrase URL so a genuinely
+        // broken database fails exactly where it used to, in DatabaseManager's recovery.
+        logger.w { "Raw-key open failed; falling back to passphrase mode" }
+        store.remove()
+        return passphraseUrl(dbFile, passphrase)
+    }
+
+    internal fun rawKeyUrl(dbFile: File, rawKeyHex: String): String =
+        cipherUrl(dbFile, "x'$rawKeyHex'")
+
+    internal fun passphraseUrl(dbFile: File, passphrase: String): String =
+        cipherUrl(dbFile, passphrase)
+
+    private fun cipherUrl(dbFile: File, key: String): String {
+        val encoded = URLEncoder.encode(key, StandardCharsets.UTF_8.name())
+        return "jdbc:sqlite:file:${dbFile.absolutePath}?cipher=sqlcipher&legacy=4&key=$encoded"
+    }
+
+    internal fun deriveRawKeyHex(passphrase: String, salt: ByteArray): String {
+        val spec = PBEKeySpec(passphrase.toCharArray(), salt, KDF_ITERATIONS, RAW_KEY_BYTES * Byte.SIZE_BITS)
+        return SecretKeyFactory.getInstance("PBKDF2WithHmacSHA512")
+            .generateSecret(spec)
+            .encoded
+            .toHex()
+    }
+
+    internal fun readSalt(dbFile: File): ByteArray = dbFile.inputStream().use { stream ->
+        val salt = ByteArray(SALT_BYTES)
+        var read = 0
+        while (read < SALT_BYTES) {
+            val n = stream.read(salt, read, SALT_BYTES - read)
+            if (n < 0) error("Database file shorter than its ${SALT_BYTES}-byte SQLCipher salt")
+            read += n
+        }
+        salt
+    }
+
+    internal fun isRawKeyHex(value: String): Boolean =
+        value.length == RAW_KEY_HEX_LENGTH && value.all { it in '0'..'9' || it in 'a'..'f' }
+
+    private fun newRawKeyHex(): String =
+        ByteArray(RAW_KEY_BYTES).also { SecureRandom().nextBytes(it) }.toHex()
+
+    private fun opens(url: String): Boolean = try {
+        DriverManager.getConnection(url, tuningProperties()).use { connection ->
+            connection.createStatement().use { statement ->
+                statement.executeQuery("SELECT count(*) FROM sqlite_master").close()
+            }
+        }
+        true
+    } catch (e: Exception) {
+        logger.d { "Key probe rejected: ${e.message}" }
+        false
+    }
+
+    private fun ByteArray.toHex(): String = joinToString("") { byte ->
+        (byte.toInt() and 0xff).toString(16).padStart(2, '0')
+    }
+}
+
+internal fun tuningProperties(): Properties = Properties().apply {
+    SQLITE_TUNING_PRAGMAS.forEach { (key, value) -> setProperty(key, value) }
+}

--- a/homebase-api/src/jvmTest/kotlin/id/homebase/api/sync/database/SqlCipherKeyModeTest.kt
+++ b/homebase-api/src/jvmTest/kotlin/id/homebase/api/sync/database/SqlCipherKeyModeTest.kt
@@ -1,0 +1,169 @@
+package id.homebase.api.sync.database
+
+import java.io.File
+import java.nio.file.Files
+import java.sql.DriverManager
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Guards the desktop passphrase → raw-key migration. Getting this wrong locks a user
+ * out of their database permanently, so every case runs against a real SQLCipher file
+ * written by the real driver rather than a mock.
+ */
+class SqlCipherKeyModeTest {
+
+    private val tempDir: File = Files.createTempDirectory("sqlcipher-key-mode").toFile()
+
+    private class FakeStore(var value: String? = null) : RawKeyStore {
+        var writes = 0
+        override fun get(): String? = value
+        override fun put(hex: String) {
+            value = hex
+            writes++
+        }
+
+        override fun remove() {
+            value = null
+        }
+    }
+
+    @AfterTest
+    fun cleanup() {
+        tempDir.deleteRecursively()
+    }
+
+    private fun dbFile(name: String) = File(tempDir, name)
+
+    private fun createWith(url: String, marker: String) {
+        DriverManager.getConnection(url, tuningProperties()).use { connection ->
+            connection.createStatement().use { statement ->
+                statement.executeUpdate("CREATE TABLE IF NOT EXISTS probe (v TEXT)")
+                statement.executeUpdate("INSERT INTO probe VALUES ('$marker')")
+            }
+        }
+    }
+
+    private fun readMarker(url: String): String? =
+        DriverManager.getConnection(url, tuningProperties()).use { connection ->
+            connection.createStatement().use { statement ->
+                statement.executeQuery("SELECT v FROM probe").use { rs ->
+                    if (rs.next()) rs.getString(1) else null
+                }
+            }
+        }
+
+    @Test
+    fun `derives the raw key an existing passphrase database was encrypted with`() {
+        val db = dbFile("migrate.db")
+        val passphrase = "a-passphrase-that-is-not-a-raw-key"
+        createWith(SqlCipherKeyMode.passphraseUrl(db, passphrase), "kept")
+
+        val store = FakeStore()
+        val url = SqlCipherKeyMode.jdbcUrl(db, passphrase, store)
+
+        val cached = assertNotNull(store.value, "raw key should be cached after migration")
+        assertTrue(SqlCipherKeyMode.isRawKeyHex(cached))
+        assertEquals(SqlCipherKeyMode.rawKeyUrl(db, cached), url)
+        assertEquals("kept", readMarker(url), "migrated URL must open the untouched file")
+        assertEquals(
+            "kept",
+            readMarker(SqlCipherKeyMode.passphraseUrl(db, passphrase)),
+            "the file must still open with the original passphrase — no re-encryption",
+        )
+    }
+
+    @Test
+    fun `derivation is deterministic and reuses the cached key on later opens`() {
+        val db = dbFile("cached.db")
+        val passphrase = "another-passphrase"
+        createWith(SqlCipherKeyMode.passphraseUrl(db, passphrase), "kept")
+
+        val store = FakeStore()
+        val first = SqlCipherKeyMode.jdbcUrl(db, passphrase, store)
+        val writesAfterMigration = store.writes
+        val second = SqlCipherKeyMode.jdbcUrl(db, passphrase, store)
+
+        assertEquals(first, second)
+        assertEquals(writesAfterMigration, store.writes, "a cached key must not be re-derived")
+    }
+
+    @Test
+    fun `a corrupt cached key falls back to deriving from the passphrase`() {
+        val db = dbFile("corrupt-cache.db")
+        val passphrase = "yet-another-passphrase"
+        createWith(SqlCipherKeyMode.passphraseUrl(db, passphrase), "kept")
+
+        val wrongKey = "00".repeat(32)
+        val store = FakeStore(wrongKey)
+        val url = SqlCipherKeyMode.jdbcUrl(db, passphrase, store)
+
+        assertEquals("kept", readMarker(url))
+        assertEquals(
+            SqlCipherKeyMode.deriveRawKeyHex(passphrase, SqlCipherKeyMode.readSalt(db)),
+            store.value,
+        )
+    }
+
+    @Test
+    fun `an undecryptable database falls back to passphrase mode instead of being lost`() {
+        val db = dbFile("foreign.db")
+        createWith(SqlCipherKeyMode.passphraseUrl(db, "the-real-passphrase"), "kept")
+
+        val store = FakeStore("11".repeat(32))
+        val url = SqlCipherKeyMode.jdbcUrl(db, "a-passphrase-that-was-never-used", store)
+
+        assertEquals(
+            SqlCipherKeyMode.passphraseUrl(db, "a-passphrase-that-was-never-used"),
+            url,
+            "must hand back the passphrase URL so DatabaseManager's recovery decides",
+        )
+        assertNull(store.value, "a key that cannot open the file must not stay cached")
+        assertEquals(
+            "kept",
+            readMarker(SqlCipherKeyMode.passphraseUrl(db, "the-real-passphrase")),
+            "the file must be untouched by the failed probes",
+        )
+    }
+
+    @Test
+    fun `a fresh install is born in raw-key mode and never runs the KDF`() {
+        val db = dbFile("fresh.db")
+        val store = FakeStore()
+
+        val url = SqlCipherKeyMode.jdbcUrl(db, "unused-passphrase", store)
+        val cached = assertNotNull(store.value)
+        assertTrue(SqlCipherKeyMode.isRawKeyHex(cached))
+        assertEquals(SqlCipherKeyMode.rawKeyUrl(db, cached), url)
+
+        createWith(url, "born-raw")
+
+        assertEquals(
+            url,
+            SqlCipherKeyMode.jdbcUrl(db, "unused-passphrase", store),
+            "reopening must reuse the cached key, not derive from the passphrase",
+        )
+        assertEquals("born-raw", readMarker(url))
+        assertFalse(
+            SqlCipherKeyMode.isRawKeyHex("not-hex"),
+            "hex validation must reject a garbled cache entry",
+        )
+    }
+
+    @Test
+    fun `raw key derivation matches SQLCipher for a known salt`() {
+        val salt = ByteArray(16) { (it + 1).toByte() }
+        val a = SqlCipherKeyMode.deriveRawKeyHex("passphrase", salt)
+        val b = SqlCipherKeyMode.deriveRawKeyHex("passphrase", salt)
+        val c = SqlCipherKeyMode.deriveRawKeyHex("passphrase", ByteArray(16))
+
+        assertEquals(a, b)
+        assertTrue(SqlCipherKeyMode.isRawKeyHex(a))
+        assertTrue(a != c, "the file's own salt must feed the derivation")
+    }
+}


### PR DESCRIPTION
Desktop startup was data-load-bound, but not for the reason #888 assumed. The
cost was not the SQL, and not the JSON-header mapper — it was **SQLCipher's key
derivation, re-run on every connection open**.

## What was actually happening

`DatabaseDriverFactory.jvm.kt` built a *passphrase-mode* SQLCipher URL
(`?cipher=sqlcipher&legacy=4&key=<172-char base64>`). In passphrase mode SQLCipher
runs PBKDF2-HMAC-SHA512 × 256,000 to turn the passphrase into the 32-byte file key
— **on every single connection open**. And SQLDelight's `JdbcSqliteDriver` uses
`ThreadedConnectionManager`, which closes its connection whenever no transaction is
active, so a cold start opens dozens of them.

Measured against a copy of a real 12 MB desktop database, driving the *real*
`JdbcSqliteDriver` + the real `OdinDatabase.Schema.create` through a counting JDBC
driver:

| | passphrase mode | raw-key mode |
|---|---|---|
| schema init | 4091 ms | 529 ms |
| …of which inside `DriverManager.getConnection` | **4038 ms (98.7%)** | 491 ms |
| connection opens for schema init | 18 | 18 |
| a burst of 10 further reads | 1677 ms | 13 ms |
| per read | ~168 ms | ~1.3 ms |

Same statements, same 18 opens — the entire difference is the KDF.

This also corrects two claims in the issue:

- **The `mapper=168–403 ms` figures were a measurement artifact.** `SlowDbRead`
  computes `mapper` as `total − time-inside-cursor.next()`. The connection open
  happens inside `driver.executeQuery` but outside `next()`, so the KDF was being
  billed to the mapper. After this change the same `driveMainIndex` query reports
  `mapper=49 ms`. Header deserialization was never the hot spot.
- **`queueWait` was not read-pool contention.** Four reads on the read lane each
  blocked ~165 ms in their own connection open, so the fifth waited. Peak
  `queueWait` was 337 ms before; it is 44 µs after.

## The change

Derive the raw key **once** — `PBKDF2-HMAC-SHA512(passphrase, the file's own
16-byte header salt, 256,000)` — cache the 32 bytes as hex in `SecureStorage`
alongside the existing `odin_db_encryption_key`, and from then on open with
`key=x'<64 hex>'`, which hands SQLCipher the KDF's *output* and skips the
derivation.

**Nothing is re-encrypted.** It is the same key against the same ciphertext; the
file is not rewritten. Verified after a full app run against a real database: the
16-byte salt is byte-identical, and the original passphrase still opens the
app-written file (both modes read the same 4116 rows). Deleting the cached key
reverts to the old path. `PRAGMA rekey` was considered and rejected — it fails
under WAL, is one-way, and took 1538 ms on a 52 MB database.

A fresh install is born with a random 32-byte key and never runs the KDF at all.
Security is unchanged: the stored passphrase is already 128 random bytes, so
PBKDF2 over it adds no entropy — it only added latency.

### Failure handling

Getting this wrong would lock a user out of their data permanently, so the resolver
degrades in steps rather than trusting the cache:

1. Cached key present and it opens the file → raw-key mode.
2. Cached key missing, corrupt, or it does not open the file → derive from the
   passphrase, probe, cache only on success.
3. Neither opens the file → return the **passphrase** URL, so a genuinely broken
   database fails exactly where it used to, inside `DatabaseManager`'s recovery,
   instead of being wiped on a key mismatch.

The probe costs ~1 ms in raw-key mode.

## Measurements

`StartupLogger` checkpoints, ms from process launch. Same commit, same machine,
same real 12 MB database — the only difference between the columns is
`DatabaseDriverFactory.jvm.kt`. Unpackaged `java -cp` launch, so absolute numbers
are pessimistic against a packaged distributable; the delta is the point.

| checkpoint | before ①  | before ② | after (migrating) | after (steady) |
|---|---|---|---|---|
| `main()` entered | 159 | 195 | 170 | 154 |
| `Database initialized` | 3999 | 4596 | **1374** | **967** |
| `checkpoint: database initialized` | 4482 | 5100 | 1385 | 976 |
| `Koin DI graph built` | 4890 | 5580 | 1791 | 1386 |
| `Compose application{} entered` | 5451 | 6215 | 2307 | 1565 |
| `App() first composition` | 5996 | 6746 | **2644** | **1938** |
| `onWindowVisible -> STARTED` | 8237 | 9263 | **3327** | **2612** |
| `SlowDbRead` warnings | 35 | 35 | 2 | **1** |
| peak `queueWait` | 337 ms | 337 ms | — | 44 µs |

The migrating column is the one-and-only run that pays the PBKDF2 (~230 ms) plus
two probe opens; every run after it is the steady column.

Conversation-list cold load, which #888 proposed parallelizing, needed no
parallelization — the serialization was the KDF:

| pass | before | after |
|---|---|---|
| `loadBasicConversations` | 326 ms (query 305) | 100 ms (query 80) |
| `enrichWithLastMessages` | 314 ms (query 303) | 43 ms (query 33) |
| `enrichWithAdmins` | 187 ms | 12 ms |
| `enrichAllConversationsWithUnreadCounts` | 195 ms | 13 ms |
| **total** | **1022 ms** | **168 ms** |

## Tested

- **Migration path** — full app run against a copy of a real passphrase-mode
  database: migrates once, logs it, caches the key, reopens from cache on the next
  launch with no re-derivation, no recovery, no wipe.
- **Fresh install path** — empty data directory: born in raw-key mode, no KDF, DB
  header confirmed still encrypted (not plaintext SQLite), reopens cleanly.
- **No re-encryption** — salt unchanged and the original passphrase still opens the
  app-written file.
- `SqlCipherKeyModeTest` — 6 cases against real SQLCipher files written by the real
  driver, covering migration, cache reuse, a corrupt cached key, an undecryptable
  database, and fresh install.
- `:homebase-api:jvmTest` 1213 passed · `:homebase-common:jvmTest` 542 passed ·
  `:desktopApp:jvmTest` passed.
- `:homebase-api:compileKotlinJvm`, `:compileAndroidMain`,
  `:compileKotlinIosSimulatorArm64` all green.

## Scope

JVM/Desktop only — the diff touches `src/jvmMain` and `src/jvmTest` and nothing
else. Android's SQLCipher path and the native/iOS path are untouched.

## What this does not do

The remaining #888 acceptance criteria are not met by this PR and are left for a
follow-up, since the measurement no longer justifies the machinery originally
proposed:

- Window-visible is 2.6 s here, not under 1 s. The remainder is no longer database
  work: ~813 ms `DatabaseManager` init (native SQLite load, class loading, 31
  `CREATE TABLE/INDEX` statements at ~1 ms/open), ~410 ms `startKoin`, ~373 ms to
  first composition, ~674 ms of Skiko/AWT window realization. Much of that is an
  artifact of launching unpackaged from loose jars.
- `VaultStream` / `StickerStream` / `ContactBookStream` / `MomentsFeed` still load
  before first composition, but they now cost ~20 ms combined instead of ~1.5 s, so
  deferring them buys almost nothing.
- The conversation-list enrich passes are not parallelized, and do not need to be
  (1022 ms → 168 ms serial).

Closes #888 is deliberately **not** claimed — this fixes the dominant cause and the
DB-read criteria; the shell-first-frame criterion is a separate call.
