### PR TITLE
Show a resize cursor over the desktop two-pane splitter

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListScreen.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListScreen.kt
@@ -74,6 +74,7 @@ import id.homebase.core.connections.ConnectRequestViewModel
 import id.homebase.core.localization.TranslationUtil
 import id.homebase.core.ui.theme.HomebaseTheme
 import id.homebase.core.util.getUriHandler
+import id.homebase.core.util.horizontalResizeCursor
 import id.homebase.core.util.isDesktopOrWeb
 import id.homebase.core.util.isExpandedLayout
 import id.homebase.core.widget.DialogButtons
@@ -1004,6 +1005,7 @@ fun ConversationListUi(
                             .onGloballyPositioned {
                                 splitterCenter = it.positionInRoot().x + it.size.width / 2f
                             }
+                            .horizontalResizeCursor()
                             .paneExpansionDraggable(
                                 state = state,
                                 minTouchTargetSize = SPLITTER_HIT_WIDTH,

--- a/homebase-common/src/androidMain/kotlin/id/homebase/core/util/ModifierExtensions.android.kt
+++ b/homebase-common/src/androidMain/kotlin/id/homebase/core/util/ModifierExtensions.android.kt
@@ -1,0 +1,5 @@
+package id.homebase.core.util
+
+import androidx.compose.ui.Modifier
+
+actual fun Modifier.horizontalResizeCursor(): Modifier = this

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/util/ModifierExtensions.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/util/ModifierExtensions.kt
@@ -28,3 +28,6 @@ fun Modifier.conditional(condition : Boolean, modifier : Modifier.() -> Modifier
         this
     }
 }
+
+/** East-west resize cursor for drag-to-resize splitters; no-op where there is no mouse. */
+expect fun Modifier.horizontalResizeCursor(): Modifier

--- a/homebase-common/src/jvmMain/kotlin/id/homebase/core/util/ModifierExtensions.jvm.kt
+++ b/homebase-common/src/jvmMain/kotlin/id/homebase/core/util/ModifierExtensions.jvm.kt
@@ -1,0 +1,10 @@
+package id.homebase.core.util
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
+import java.awt.Cursor
+
+private val EastWestResize = PointerIcon(Cursor(Cursor.E_RESIZE_CURSOR))
+
+actual fun Modifier.horizontalResizeCursor(): Modifier = pointerHoverIcon(EastWestResize)

--- a/homebase-common/src/nativeMain/kotlin/id/homebase/core/util/ModifierExtensions.native.kt
+++ b/homebase-common/src/nativeMain/kotlin/id/homebase/core/util/ModifierExtensions.native.kt
@@ -1,0 +1,5 @@
+package id.homebase.core.util
+
+import androidx.compose.ui.Modifier
+
+actual fun Modifier.horizontalResizeCursor(): Modifier = this

--- a/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/util/ModifierExtensions.web.kt
+++ b/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/util/ModifierExtensions.web.kt
@@ -1,0 +1,12 @@
+package id.homebase.core.util
+
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.fromKeyword
+import androidx.compose.ui.input.pointer.pointerHoverIcon
+
+@OptIn(ExperimentalComposeUiApi::class)
+private val EastWestResize = PointerIcon.fromKeyword("ew-resize")
+
+actual fun Modifier.horizontalResizeCursor(): Modifier = pointerHoverIcon(EastWestResize)


### PR DESCRIPTION
Hovering the two-pane splitter on Desktop gave no affordance that the divider was draggable — the pointer stayed a plain arrow. `PointerIcon` had never been used anywhere in the repo, so this was never implemented rather than a regression.

The drag handle is now `.horizontalResizeCursor()`.

## The expect/actual surface

One function in `homebase-common`, `id.homebase.core.util`:

```kotlin
expect fun Modifier.horizontalResizeCursor(): Modifier
```

| target | actual |
|---|---|
| JVM / Desktop | `pointerHoverIcon(PointerIcon(Cursor(Cursor.E_RESIZE_CURSOR)))` |
| wasmJs / Web | `pointerHoverIcon(PointerIcon.fromKeyword("ew-resize"))` |
| Android, iOS | `= this` (touch, no cursor) |

Compose Multiplatform 1.10.3's common `PointerIcon` companion only exposes `Default`, `Crosshair`, `Text` and `Hand`, so the east-west icon has to come from each platform: `java.awt.Cursor` on Desktop and the CSS `cursor` keyword on Web. No new dependency. The `PointerIcon` is a top-level `val` per platform, so the modifier element compares equal across recompositions and does not churn nodes.

It sits behind the same `isDesktopOrWeb()` gate the handle already had, so Android and iOS never reach the no-op actuals in practice.

## The Skiko hover landmine

The comment above this handle records a real perf bug: M3's `VerticalDragHandle` animates off the hover interaction, which on Skiko never goes quiet, and that pinned the desktop render loop at ~164 fps and ~15% GPU while idle. That is why the handle is a bare invisible `Box` with nothing to animate.

The argument that `pointerHoverIcon` does not re-arm it: it is a different mechanism — `PointerHoverIconModifierNode` calls `PointerIconService.setIcon` on enter/exit. It emits nothing into an `InteractionSource`, starts no animation, and does not invalidate draw, so there is no frame loop for a never-quiet hover signal to feed.

That is reasoning, not a measurement. See below.

## Verification status — read this before merging

**The cursor: confirmed programmatically, not by eye.** The macOS cursor is never included in
screen captures, so a screenshot cannot show it. Instead the pointer was scanned across the
window while reading the live system cursor: `NSCursor.resizeLeftRight` (the arrow) appears at
exactly one x — frac 0.32, the splitter — and the plain arrow everywhere else. That is good
evidence `E_RESIZE_CURSOR` maps to the arrow on macOS and lands on the right node. No human has
watched it change. Web (`ew-resize`) is compile-verified only.

**Idle CPU/GPU: not properly measured.** This is the weak spot. A passive 60s sample read 1.3%
CPU with the change, which is nowhere near a pinned render loop — but:

- There is **no before number**. The baseline build was never measured, so there is no A/B.
- The mouse-on-splitter vs mouse-away comparison was never completed.
- An earlier attempt was invalid twice over: the window moved between locating and sampling
  (so the pointer was off-window), and the probe linked AppKit and stole focus on every call,
  backgrounding the app — and a backgrounded Compose window throttles rendering.

So: no evidence of a render-loop wake, plus the mechanism argument above, but not proof. If you
want certainty, hover the splitter for ~30s and watch Activity Monitor — a repeat of the old bug
would show a sustained ~15%, not ~1%.

## Verification that was done

- `homebase-common` and `homebase-chat`, both compiled on `jvm`, `androidMain`, `wasmJs` and `iosSimulatorArm64` — all green.
- `homebase-common:jvmTest` and `homebase-chat:jvmTest` — 0 failures.
