### PR TITLE
Report a share as saved only when its writes actually landed

### DIFF
--- a/iosApp/ShareExtension/SharedContentSaver.swift
+++ b/iosApp/ShareExtension/SharedContentSaver.swift
@@ -41,12 +41,14 @@ struct SharedContentSaver {
         let targetConversationId: String
     }
 
+    /// Tests pass `containerURL` to redirect the writes into a directory they can make unwritable.
     static func save(
         extensionContext: NSExtensionContext,
         conversationId: String,
+        containerURL: URL? = nil,
         completion: @escaping (Bool) -> Void
     ) {
-        guard let containerURL = FileManager.default
+        guard let containerURL = containerURL ?? FileManager.default
             .containerURL(forSecurityApplicationGroupIdentifier: appGroupId)
         else {
             completion(false)
@@ -126,9 +128,12 @@ struct SharedContentSaver {
                             let ext = imageExtensionForData(imageData)
                             let name = "share_\(Int(Date().timeIntervalSince1970 * 1000)).\(ext)"
                             let destURL = filesDir.appendingPathComponent(name)
-                            try? imageData.write(to: destURL)
-                            fileNames.append(name)
-                            mimeTypes.append(mimeTypeForExtension(ext))
+                            do {
+                                try imageData.write(to: destURL)
+                                fileNames.append(name)
+                                mimeTypes.append(mimeTypeForExtension(ext))
+                            } catch {
+                            }
                         }
                         group.leave()
                     }
@@ -215,12 +220,11 @@ struct SharedContentSaver {
                 targetConversationId: conversationId
             )
 
-            // Write descriptor JSON
-            if let jsonData = try? JSONEncoder().encode(descriptor) {
-                let descriptorURL = containerURL.appendingPathComponent(sharedContentFile)
-                try? jsonData.write(to: descriptorURL)
+            do {
+                let jsonData = try JSONEncoder().encode(descriptor)
+                try jsonData.write(to: containerURL.appendingPathComponent(sharedContentFile))
                 completion(true)
-            } else {
+            } catch {
                 completion(false)
             }
         }

--- a/iosApp/ShareExtension/SharedContentSaver.swift
+++ b/iosApp/ShareExtension/SharedContentSaver.swift
@@ -1,5 +1,6 @@
 import Foundation
 import UniformTypeIdentifiers
+import os
 
 /// Saves shared content from the extension context into the App Group container
 /// for the main app to pick up and send.
@@ -133,6 +134,8 @@ struct SharedContentSaver {
                                 fileNames.append(name)
                                 mimeTypes.append(mimeTypeForExtension(ext))
                             } catch {
+                                os_log("Share extension: dropping image %{public}@, write failed: %{public}@",
+                                       name, error.localizedDescription)
                             }
                         }
                         group.leave()
@@ -220,11 +223,14 @@ struct SharedContentSaver {
                 targetConversationId: conversationId
             )
 
+            let descriptorURL = containerURL.appendingPathComponent(sharedContentFile)
             do {
                 let jsonData = try JSONEncoder().encode(descriptor)
-                try jsonData.write(to: containerURL.appendingPathComponent(sharedContentFile))
+                try jsonData.write(to: descriptorURL)
                 completion(true)
             } catch {
+                os_log("Share extension: descriptor write to %{public}@ failed (%d file(s) staged), reporting failure: %{public}@",
+                       descriptorURL.path, fileNames.count, error.localizedDescription)
                 completion(false)
             }
         }

--- a/iosApp/iosAppTests/SharedContentSaverTests.swift
+++ b/iosApp/iosAppTests/SharedContentSaverTests.swift
@@ -20,6 +20,12 @@ final class SharedContentSaverTests: XCTestCase {
     private var tempDir: URL!
     private var preexistingFiles: Set<String> = []
     private var preexistingDescriptor: Data?
+    private var lockedDirs: [URL] = []
+
+    /// `save()` completes on `group.notify(queue: .main)`, and the test host is the whole app —
+    /// its Kotlin/Native startup owns the main queue for >10s, so whichever test the runner
+    /// happens to put first pays for the launch.
+    private let saveTimeout: TimeInterval = 90
 
     private let vcardBytes = Data("BEGIN:VCARD\nVERSION:3.0\nFN:Ada Vance\nEND:VCARD\n".utf8)
     private let movieBytes = Data([0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70, 0x6D, 0x70, 0x34, 0x32])
@@ -56,6 +62,12 @@ final class SharedContentSaverTests: XCTestCase {
         } else {
             try? FileManager.default.removeItem(at: descriptorURL)
         }
+        for url in lockedDirs {
+            try? FileManager.default.setAttributes(
+                [.posixPermissions: 0o700], ofItemAtPath: url.path
+            )
+        }
+        lockedDirs = []
         try? FileManager.default.removeItem(at: tempDir)
 
         try super.tearDownWithError()
@@ -194,6 +206,51 @@ final class SharedContentSaverTests: XCTestCase {
         XCTAssertEqual(try writtenBytes(descriptor), pngBytes)
     }
 
+    // MARK: - Write failures (#1309)
+
+    func testStagedShareLandsInTheInjectedContainer() throws {
+        let container = try injectedContainer()
+
+        XCTAssertTrue(try saveInto(container, [dataProvider(pngBytes, .png)]))
+
+        let descriptor = try decodeDescriptor(in: container)
+        XCTAssertEqual(descriptor.contentType, "IMAGE")
+        XCTAssertEqual(descriptor.mimeTypes, ["image/png"])
+        let name = try XCTUnwrap(descriptor.fileNames.first)
+        XCTAssertEqual(try Data(contentsOf: filesDir(in: container).appendingPathComponent(name)), pngBytes)
+    }
+
+    func testDescriptorWriteFailureIsReportedAsFailure() throws {
+        let container = try injectedContainer()
+        try makeReadOnly(container)
+
+        XCTAssertFalse(
+            try saveInto(container, [dataProvider(vcardBytes, .vCard)], text: "look at this"),
+            "a descriptor that never reached disk must not be reported as a saved share"
+        )
+        XCTAssertFalse(
+            FileManager.default.fileExists(
+                atPath: container.appendingPathComponent(SharedContentSaver.sharedContentFile).path
+            )
+        )
+    }
+
+    func testFailedImageDataWriteIsNotClaimedInTheDescriptor() throws {
+        let container = try injectedContainer()
+        try makeReadOnly(filesDir(in: container))
+
+        XCTAssertTrue(try saveInto(container, [dataProvider(pngBytes, .png)], text: "look at this"))
+
+        let descriptor = try decodeDescriptor(in: container)
+        XCTAssertEqual(descriptor.fileNames, [], "the descriptor names a file that was never written")
+        XCTAssertEqual(descriptor.mimeTypes, [])
+        XCTAssertEqual(descriptor.contentType, "TEXT")
+        XCTAssertEqual(descriptor.text, "look at this")
+        XCTAssertEqual(
+            try FileManager.default.contentsOfDirectory(atPath: filesDir(in: container).path), []
+        )
+    }
+
     // MARK: - Helpers
 
     private func save(
@@ -217,7 +274,7 @@ final class SharedContentSaverTests: XCTestCase {
             saved = success
             finished.fulfill()
         }
-        wait(for: [finished], timeout: 10)
+        wait(for: [finished], timeout: saveTimeout)
         XCTAssertTrue(saved, "save() reported failure", file: file, line: line)
 
         return try JSONDecoder().decode(
@@ -249,5 +306,68 @@ final class SharedContentSaverTests: XCTestCase {
         let url = tempDir.appendingPathComponent(name)
         try bytes.write(to: url)
         return url
+    }
+
+    private func filesDir(in container: URL) -> URL {
+        container.appendingPathComponent(SharedContentSaver.sharedFilesDir)
+    }
+
+    private func injectedContainer() throws -> URL {
+        let container = tempDir.appendingPathComponent("container_\(UUID().uuidString)")
+        try FileManager.default.createDirectory(
+            at: filesDir(in: container), withIntermediateDirectories: true
+        )
+        return container
+    }
+
+    private func makeReadOnly(
+        _ url: URL,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws {
+        try FileManager.default.setAttributes([.posixPermissions: 0o500], ofItemAtPath: url.path)
+        lockedDirs.append(url)
+
+        let probe = url.appendingPathComponent("probe_\(UUID().uuidString)")
+        let wrote = (try? Data([0x00]).write(to: probe)) != nil
+        try? FileManager.default.removeItem(at: probe)
+        XCTAssertFalse(
+            wrote,
+            "\(url.lastPathComponent) is still writable — the injected failure never happened",
+            file: file,
+            line: line
+        )
+    }
+
+    private func saveInto(
+        _ container: URL,
+        _ providers: [NSItemProvider],
+        text: String? = nil
+    ) throws -> Bool {
+        let item = NSExtensionItem()
+        item.attachments = providers
+        if let text {
+            item.attributedContentText = NSAttributedString(string: text)
+        }
+
+        var saved: Bool?
+        let finished = expectation(description: "SharedContentSaver.save")
+        SharedContentSaver.save(
+            extensionContext: StubExtensionContext([item]),
+            conversationId: "conversation-under-test",
+            containerURL: container
+        ) { success in
+            saved = success
+            finished.fulfill()
+        }
+        wait(for: [finished], timeout: saveTimeout)
+        return try XCTUnwrap(saved)
+    }
+
+    private func decodeDescriptor(in container: URL) throws -> SharedContentSaver.ContentDescriptor {
+        try JSONDecoder().decode(
+            SharedContentSaver.ContentDescriptor.self,
+            from: Data(contentsOf: container.appendingPathComponent(SharedContentSaver.sharedContentFile))
+        )
     }
 }


### PR DESCRIPTION
Fixes #1309.

`SharedContentSaver` had two writes whose failure was discarded and then reported as success.

## 1. A failed descriptor write reported success

```swift
if let jsonData = try? JSONEncoder().encode(descriptor) {
    let descriptorURL = containerURL.appendingPathComponent(sharedContentFile)
    try? jsonData.write(to: descriptorURL)   // failure discarded
    completion(true)                          // runs regardless
} else {
    completion(false)
}
```

The `else` catches an **encode** failure, never a **write** failure. When the descriptor did not
reach disk the extension still reported success, so `ShareViewController` opened the main app on a
share that was never staged and the user landed in an app with nothing to send. Observed once in 37
runs of a test harness during #1302's verification — rare and non-deterministic, which is the worst
shape for a bug that presents as "sharing randomly does nothing".

Encode and write now sit inside one `do`/`catch`, so either failure reports `completion(false)` and
the extension shows its existing "Failed to prepare shared content." error instead of handing off.

## 2. The image `Data` arm claimed files it may not have written

`try? imageData.write(to: destURL)` was followed by an unconditional `fileNames.append(name)`. A
failed write left the descriptor naming a file that does not exist — worse than an empty share,
because `hasSendableContent()` then returns true and the failure surfaces later and further from its
cause. The appends now happen only after a successful write, which is what the sibling `copyFile` /
`writeData` paths (added by #1302) already did.

## Neither catch is silent

Dropping the file is the fix; dropping the *reason* would not be. This descriptor failure was seen
once in 37 runs and its real-world cause is still unknown — a read-only directory is only the
stand-in the tests use — and these two catches are the only place that evidence can ever surface,
especially with no CI compiling this file. Both log the underlying error via `os_log`, matching
`NotificationServiceExtension`, the sibling out-of-process extension (the share extension had no
logging of its own, and Kermit/`homebase.log` is not initialized in an extension process):

```swift
} catch {
    os_log("Share extension: dropping image %{public}@, write failed: %{public}@",
           name, error.localizedDescription)
}
```

```swift
} catch {
    os_log("Share extension: descriptor write to %{public}@ failed (%d file(s) staged), reporting failure: %{public}@",
           descriptorURL.path, fileNames.count, error.localizedDescription)
    completion(false)
}
```

Both fire in the failure-injection tests with the real reason attached:

```
Share extension: descriptor write to …/container_DE97…/shared_content.json failed (1 file(s)
    staged), reporting failure: You don't have permission to save the file "shared_content.json"
    in the folder "container_DE97…".
Share extension: dropping image share_1788176997983.png, write failed: You don't have permission
    to save the file "share_1788176997983.png" in the folder "shared_files".
```

## What was deliberately left alone

`try? FileManager.default.createDirectory(at: filesDir, …)` is still a `try?`. It is not the same
defect once the two writes above are honest: if that directory cannot be created, every file write
into it now throws and the item is dropped rather than falsely claimed. Making it fatal would be a
regression — a text- or URL-only share never touches `shared_files` and has no reason to fail
because that directory could not be created.

Also unchanged: a media-only share whose files all failed to stage still reports success with an
empty descriptor. That is the existing #1097 contract — `hasSendableContent()` is the main app's
policy and it already refuses to send a blank share — not a silent success.

The other `try?` uses in `ShareExtension/` (`ShareConversationCacheReader`, `SharePickerView`) are
all reads behind a `guard … else`, so no failure is discarded there.

## Test seam and failure injection

`save()` gains an optional `containerURL` defaulting to `nil`; production still resolves the App
Group container exactly as before and no call site changes. Tests point it at a temp directory they
own and then `chmod 0o500` either the container (descriptor write fails) or its `shared_files`
subdirectory (image write fails). `makeReadOnly()` probes with a throwaway write and fails the test
if the directory is still writable, so the injection can never silently no-op.

Three tests added to `iosApp/iosAppTests/SharedContentSaverTests.swift`:

- `testStagedShareLandsInTheInjectedContainer` — control: the seam really redirects, and the happy
  path through it works.
- `testDescriptorWriteFailureIsReportedAsFailure` — read-only container ⇒ `save()` reports `false`
  and no descriptor exists.
- `testFailedImageDataWriteIsNotClaimedInTheDescriptor` — read-only `shared_files` ⇒ the descriptor
  carries no `fileNames`/`mimeTypes` and `shared_files` is empty.

### Expectation timeout raised to 90s

The first run failed on a real, unrelated cause worth recording: `save()` completes on
`group.notify(queue: .main)` and the test host is the whole app, whose Kotlin/Native startup owns
the main queue on the first test in the class. The runner logged

```
🟡 (MainThreadWatchdog) Main/UI thread stalled >4010ms
  … kfun:id.homebase.chat.services.requests.ConnectionRequestService…launchRefresh …
Test Case '…testDescriptorWriteFailureIsReportedAsFailure' failed (16.104 seconds)
  Asynchronous wait failed: Exceeded timeout of 10 seconds
```

while every later test in the same run finished in <1s. The 10s ceiling inherited from #1302 was
simply shorter than a cold host-app launch, and whichever test sorts first pays it — that used to be
`testGenericFileVendedAsDataFallsBackToDat…`, so the latent flake was already there. Both wait sites
now use one `saveTimeout = 90`; it guards against a hang, it is not an assertion about speed.

## Verification — CI does not cover this file

Nothing in `.github/workflows/` runs `xcodebuild` on a PR: `build-check.yml` and `lint.yml` both run
on `ubuntu-latest`, and the only workflow that touches Xcode (`build-mobile-release-prod.yml`) is
tag/dispatch-triggered and builds the IPA without running `iosAppTests`. **`iosApp/ShareExtension/`
is never compiled by CI, so green checks on this PR say nothing about this change.** Verified
locally instead, on an iPhone 17e simulator (Xcode 26.6), signed — never `CODE_SIGNING_ALLOWED=NO`.

With the fix:

```
$ xcodebuild test -project iosApp.xcodeproj -scheme iosApp -configuration Debug \
    -destination 'platform=iOS Simulator,name=iPhone 17e' \
    -only-testing:iosAppTests/SharedContentSaverTests
Executed 15 tests, with 0 failures (0 unexpected) in 2.660 seconds
** TEST SUCCEEDED **
```

With `SharedContentSaver.swift` reverted to `main` (test seam kept, both bugs restored), same
command, same tests:

```
SharedContentSaverTests.swift:227: XCTAssertFalse failed - a descriptor that never reached disk
    must not be reported as a saved share
SharedContentSaverTests.swift:245: XCTAssertEqual failed: ("["share_1788176328129.png"]")
    is not equal to ("[]") - the descriptor names a file that was never written
SharedContentSaverTests.swift:246: XCTAssertEqual failed: ("["image/png"]") is not equal to ("[]")
SharedContentSaverTests.swift:247: XCTAssertEqual failed: ("MIXED") is not equal to ("TEXT")
Executed 15 tests, with 4 failures (0 unexpected) in 1.487 seconds
** TEST FAILED **
```

Only the two failure-injection tests fail there; the 13 pre-existing tests and the control test pass
in both directions.
