### PR TITLE
Pick an emoji by typing ":" in the desktop composer

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageInputBar.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageInputBar.kt
@@ -130,7 +130,9 @@ import id.homebase.core.util.isMobile
 import id.homebase.core.util.keyboardAsState
 import id.homebase.core.util.programmaticBackspace
 import id.homebase.core.util.toMessageMarkdown
+import id.homebase.core.widget.EmojiAutocomplete
 import id.homebase.core.widget.EmojiSelection
+import id.homebase.core.widget.rememberComposerAutocompleteController
 import id.homebase.resources.MR
 import id.homebase.resources.cancel
 import id.homebase.resources.chat_message_attachment_options
@@ -375,6 +377,7 @@ fun MessageTextFieldExpanded(
 ) {
     val pasteScope = rememberCoroutineScope()
     var isFieldFocused by remember { mutableStateOf(false) }
+    val autocomplete = rememberComposerAutocompleteController()
 
     // Web only: a pasted image arrives as a clipboard event on Compose's active clip target,
     // which only resolves to this field's backing input while the field holds focus.
@@ -416,85 +419,96 @@ fun MessageTextFieldExpanded(
             Modifier
         }
         val pasteImageLabel = stringResource(MR.string.chat_message_paste_image)
-        RichTextEditor(
-            state = state,
-            modifier = Modifier.fillMaxWidth()
-                .then(pasteModifier)
-                .then(
-                    if (onPasteImage != null)
-                        Modifier.pasteImageContextMenuItem(
-                            label = pasteImageLabel,
-                            enabled = true,
-                        ) {
-                            pasteScope.launch {
-                                readClipboardImage()?.let { onPasteImage.invoke(it) }
-                            }
-                        }
-                    else Modifier
-                )
-                .focusRequester(focusRequester)
-                .onFocusChanged { focusState ->
-                    isFieldFocused = focusState.isFocused
-                    if (focusState.isFocused) {
-                        onFocused()
-                    }
-                }
-                .onPreviewKeyEvent { keyEvent ->
-                    // Cmd/Ctrl+V image paste works on any platform with a hardware
-                    // keyboard — desktop, web, AND iOS/iPad. Enter-to-send (below)
-                    // stays desktop/web only; mobile uses the send button.
-                    if (keyEvent.type == KeyEventType.KeyDown &&
-                        (isDesktopOrWeb() ||
-                            (keyEvent.key == Key.V && (keyEvent.isCtrlPressed || keyEvent.isMetaPressed)))
-                    ) {
-                        when {
-                            // Shift+Enter inserts a newline; every other Enter/NumPadEnter
-                            // (incl. Cmd/Ctrl+Enter) sends. Match NumPadEnter too — macOS can
-                            // report Return as NumPadEnter, so Key.Enter alone never fired (#1043).
-                            (keyEvent.key == Key.Enter || keyEvent.key == Key.NumPadEnter) &&
-                                keyEvent.isShiftPressed -> {
-                                state.addTextAfterSelection("\n")
-                                true
-                            }
-
-                            keyEvent.key == Key.Enter || keyEvent.key == Key.NumPadEnter -> {
-                                sendMessage()
-                                true
-                            }
-
-                            keyEvent.key == Key.V && (keyEvent.isCtrlPressed || keyEvent.isMetaPressed) && onPasteImage != null -> {
-                                val imageBytes = getImageFromClipboard()
-                                if (imageBytes != null) {
-                                    onPasteImage.invoke(imageBytes)
-                                    true
-                                } else {
-                                    false
+        Box(modifier = Modifier.fillMaxWidth()) {
+            RichTextEditor(
+                state = state,
+                modifier = Modifier.fillMaxWidth()
+                    .then(pasteModifier)
+                    .then(
+                        if (onPasteImage != null)
+                            Modifier.pasteImageContextMenuItem(
+                                label = pasteImageLabel,
+                                enabled = true,
+                            ) {
+                                pasteScope.launch {
+                                    readClipboardImage()?.let { onPasteImage.invoke(it) }
                                 }
                             }
-
-                            else -> false
+                        else Modifier
+                    )
+                    .focusRequester(focusRequester)
+                    .onFocusChanged { focusState ->
+                        isFieldFocused = focusState.isFocused
+                        if (focusState.isFocused) {
+                            onFocused()
                         }
-                    } else {
-                        false
                     }
-                },
-            placeholder = { Text(stringResource(MR.string.chat_new_message_placeholder)) },
-            shape = if (editExistingMode) RoundedCornerShape(
-                bottomStart = 12.dp,
-                bottomEnd = 12.dp
-            ) else RoundedCornerShape(12.dp),
-            minLines = 10,
-            maxLines = 10,
-            keyboardOptions = KeyboardOptions(
-                capitalization = KeyboardCapitalization.Sentences, imeAction = ImeAction.Default
-            ),
-            colors = RichTextEditorDefaults.richTextEditorColors(
-                containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
-                focusedIndicatorColor = Color.Transparent,
-                unfocusedIndicatorColor = Color.Transparent,
-                disabledIndicatorColor = Color.Transparent,
-            ),
-        )
+                    .onPreviewKeyEvent { keyEvent ->
+                        // The autocomplete list owns arrows/Enter/Tab/Esc while it is showing;
+                        // preview events run root-to-leaf, so Enter-to-send below beats it otherwise.
+                        if (autocomplete.handleKeyEvent(keyEvent)) return@onPreviewKeyEvent true
+
+                        // Cmd/Ctrl+V image paste works on any platform with a hardware
+                        // keyboard — desktop, web, AND iOS/iPad. Enter-to-send (below)
+                        // stays desktop/web only; mobile uses the send button.
+                        if (keyEvent.type == KeyEventType.KeyDown &&
+                            (isDesktopOrWeb() ||
+                                (keyEvent.key == Key.V && (keyEvent.isCtrlPressed || keyEvent.isMetaPressed)))
+                        ) {
+                            when {
+                                // Shift+Enter inserts a newline; every other Enter/NumPadEnter
+                                // (incl. Cmd/Ctrl+Enter) sends. Match NumPadEnter too — macOS can
+                                // report Return as NumPadEnter, so Key.Enter alone never fired (#1043).
+                                (keyEvent.key == Key.Enter || keyEvent.key == Key.NumPadEnter) &&
+                                    keyEvent.isShiftPressed -> {
+                                    state.addTextAfterSelection("\n")
+                                    true
+                                }
+
+                                keyEvent.key == Key.Enter || keyEvent.key == Key.NumPadEnter -> {
+                                    sendMessage()
+                                    true
+                                }
+
+                                keyEvent.key == Key.V && (keyEvent.isCtrlPressed || keyEvent.isMetaPressed) && onPasteImage != null -> {
+                                    val imageBytes = getImageFromClipboard()
+                                    if (imageBytes != null) {
+                                        onPasteImage.invoke(imageBytes)
+                                        true
+                                    } else {
+                                        false
+                                    }
+                                }
+
+                                else -> false
+                            }
+                        } else {
+                            false
+                        }
+                    },
+                placeholder = { Text(stringResource(MR.string.chat_new_message_placeholder)) },
+                shape = if (editExistingMode) RoundedCornerShape(
+                    bottomStart = 12.dp,
+                    bottomEnd = 12.dp
+                ) else RoundedCornerShape(12.dp),
+                minLines = 10,
+                maxLines = 10,
+                keyboardOptions = KeyboardOptions(
+                    capitalization = KeyboardCapitalization.Sentences, imeAction = ImeAction.Default
+                ),
+                colors = RichTextEditorDefaults.richTextEditorColors(
+                    containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
+                    focusedIndicatorColor = Color.Transparent,
+                    unfocusedIndicatorColor = Color.Transparent,
+                    disabledIndicatorColor = Color.Transparent,
+                ),
+            )
+            EmojiAutocomplete(
+                state = state,
+                controller = autocomplete,
+                enabled = isFieldFocused && isDesktopOrWeb(),
+            )
+        }
         Spacer(modifier = Modifier.height(8.dp))
         Row(
             modifier = Modifier.fillMaxWidth(),
@@ -581,6 +595,7 @@ fun MessageTextFieldCompact(
     onCancelEdit: () -> Unit,
 ) {
     val pasteScope = rememberCoroutineScope()
+    val autocomplete = rememberComposerAutocompleteController()
     val showSendButton = hasSendableContent(state, payloadRenderers)
     val showRecordingButton by remember(
         editExistingMode,
@@ -720,167 +735,179 @@ fun MessageTextFieldCompact(
                             Modifier
                         }
                         val pasteImageLabel = stringResource(MR.string.chat_message_paste_image)
-                        RichTextEditor(
-                            state = state,
-                            modifier = Modifier
-                                .weight(1f)
-                                .then(pasteModifier)
-                                .then(
-                                    if (onPasteImage != null)
-                                        Modifier.pasteImageContextMenuItem(
-                                            label = pasteImageLabel,
-                                            enabled = true,
-                                        ) {
-                                            pasteScope.launch {
-                                                readClipboardImage()?.let { onPasteImage.invoke(it) }
-                                            }
-                                        }
-                                    else Modifier
-                                )
-                                .focusRequester(focusRequester)
-                                .onFocusChanged { focusState ->
-                                    isKeyboardFocused = focusState.isFocused
-                                    if (focusState.isFocused) {
-                                        onFocused()
-                                    }
-                                }
-                                .onPreviewKeyEvent { keyEvent ->
-                                    // Cmd/Ctrl+V image paste works on any platform with a hardware
-                                    // keyboard — desktop, web, AND iOS/iPad. Enter-to-send (below)
-                                    // stays desktop/web only; mobile uses the send button.
-                                    if (keyEvent.type == KeyEventType.KeyDown &&
-                                        (isDesktopOrWeb() ||
-                                            (keyEvent.key == Key.V && (keyEvent.isCtrlPressed || keyEvent.isMetaPressed)))
-                                    ) {
-                                        when {
-                                            // Shift+Enter inserts a newline; every other
-                                            // Enter/NumPadEnter (incl. Cmd/Ctrl+Enter) sends.
-                                            // Match NumPadEnter too — macOS can report Return as
-                                            // NumPadEnter, so Key.Enter alone never fired (#1043).
-                                            (keyEvent.key == Key.Enter || keyEvent.key == Key.NumPadEnter) &&
-                                                keyEvent.isShiftPressed -> {
-                                                state.addTextAfterSelection("\n")
-                                                true
-                                            }
-
-                                            keyEvent.key == Key.Enter || keyEvent.key == Key.NumPadEnter -> {
-                                                onSendMessage()
-                                                true
-                                            }
-
-                                            keyEvent.key == Key.V && (keyEvent.isCtrlPressed || keyEvent.isMetaPressed) && onPasteImage != null -> {
-                                                val imageBytes = getImageFromClipboard()
-                                                if (imageBytes != null) {
-                                                    onPasteImage.invoke(imageBytes)
-                                                    true
-                                                } else {
-                                                    false
+                        Box(modifier = Modifier.weight(1f)) {
+                            RichTextEditor(
+                                state = state,
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .then(pasteModifier)
+                                    .then(
+                                        if (onPasteImage != null)
+                                            Modifier.pasteImageContextMenuItem(
+                                                label = pasteImageLabel,
+                                                enabled = true,
+                                            ) {
+                                                pasteScope.launch {
+                                                    readClipboardImage()?.let { onPasteImage.invoke(it) }
                                                 }
                                             }
-
-                                            else -> false
+                                        else Modifier
+                                    )
+                                    .focusRequester(focusRequester)
+                                    .onFocusChanged { focusState ->
+                                        isKeyboardFocused = focusState.isFocused
+                                        if (focusState.isFocused) {
+                                            onFocused()
                                         }
-                                    } else {
-                                        false
+                                    }
+                                    .onPreviewKeyEvent { keyEvent ->
+                                        // The autocomplete list owns arrows/Enter/Tab/Esc while it is
+                                        // showing; preview events run root-to-leaf, so Enter-to-send
+                                        // below beats it otherwise.
+                                        if (autocomplete.handleKeyEvent(keyEvent)) return@onPreviewKeyEvent true
+
+                                        // Cmd/Ctrl+V image paste works on any platform with a hardware
+                                        // keyboard — desktop, web, AND iOS/iPad. Enter-to-send (below)
+                                        // stays desktop/web only; mobile uses the send button.
+                                        if (keyEvent.type == KeyEventType.KeyDown &&
+                                            (isDesktopOrWeb() ||
+                                                (keyEvent.key == Key.V && (keyEvent.isCtrlPressed || keyEvent.isMetaPressed)))
+                                        ) {
+                                            when {
+                                                // Shift+Enter inserts a newline; every other
+                                                // Enter/NumPadEnter (incl. Cmd/Ctrl+Enter) sends.
+                                                // Match NumPadEnter too — macOS can report Return as
+                                                // NumPadEnter, so Key.Enter alone never fired (#1043).
+                                                (keyEvent.key == Key.Enter || keyEvent.key == Key.NumPadEnter) &&
+                                                    keyEvent.isShiftPressed -> {
+                                                    state.addTextAfterSelection("\n")
+                                                    true
+                                                }
+
+                                                keyEvent.key == Key.Enter || keyEvent.key == Key.NumPadEnter -> {
+                                                    onSendMessage()
+                                                    true
+                                                }
+
+                                                keyEvent.key == Key.V && (keyEvent.isCtrlPressed || keyEvent.isMetaPressed) && onPasteImage != null -> {
+                                                    val imageBytes = getImageFromClipboard()
+                                                    if (imageBytes != null) {
+                                                        onPasteImage.invoke(imageBytes)
+                                                        true
+                                                    } else {
+                                                        false
+                                                    }
+                                                }
+
+                                                else -> false
+                                            }
+                                        } else {
+                                            false
+                                        }
+                                    },
+                                placeholder = { Text(stringResource(MR.string.chat_new_message_placeholder)) },
+                                leadingIcon = if (editExistingMode) null else {
+                                    {
+                                        if (!showingEmojiSheet) {
+                                            IconButton(onClick = onEmojiClick) {
+                                                Icon(
+                                                    imageVector = Icons.Default.EmojiEmotions,
+                                                    contentDescription = stringResource(MR.string.chat_message_emoji_options)
+                                                )
+                                            }
+                                        } else {
+                                            IconButton(onClick = onKeyboardClick) {
+                                                Icon(
+                                                    imageVector = Icons.Default.Keyboard,
+                                                    contentDescription = stringResource(MR.string.chat_message_emoji_options)
+                                                )
+                                            }
+                                        }
                                     }
                                 },
-                            placeholder = { Text(stringResource(MR.string.chat_new_message_placeholder)) },
-                            leadingIcon = if (editExistingMode) null else {
-                                {
-                                    if (!showingEmojiSheet) {
-                                        IconButton(onClick = onEmojiClick) {
-                                            Icon(
-                                                imageVector = Icons.Default.EmojiEmotions,
-                                                contentDescription = stringResource(MR.string.chat_message_emoji_options)
-                                            )
-                                        }
-                                    } else {
-                                        IconButton(onClick = onKeyboardClick) {
-                                            Icon(
-                                                imageVector = Icons.Default.Keyboard,
-                                                contentDescription = stringResource(MR.string.chat_message_emoji_options)
-                                            )
-                                        }
-                                    }
-                                }
-                            },
-                            trailingIcon = if (editExistingMode) null else {
-                                {
-                                    if (state.annotatedString.isNotBlank()) {
-                                        IconButton(
-                                            onClick = onAddAttachmentClick,
-                                            modifier = Modifier.testTag("inline_attach_button"),
-                                        ) {
-                                            Icon(
-                                                imageVector = Icons.Default.Add,
-                                                contentDescription = stringResource(MR.string.chat_message_attachment_options)
-                                            )
-                                        }
-                                    } else if (isMobile()) {
-                                        var showCameraMenu by remember { mutableStateOf(false) }
-                                        Box {
+                                trailingIcon = if (editExistingMode) null else {
+                                    {
+                                        if (state.annotatedString.isNotBlank()) {
                                             IconButton(
-                                                onClick = { showCameraMenu = true },
-                                                modifier = Modifier.testTag("camera_button"),
+                                                onClick = onAddAttachmentClick,
+                                                modifier = Modifier.testTag("inline_attach_button"),
                                             ) {
                                                 Icon(
-                                                    imageVector = Icons.Default.PhotoCamera,
-                                                    contentDescription = stringResource(MR.string.chat_message_camera)
+                                                    imageVector = Icons.Default.Add,
+                                                    contentDescription = stringResource(MR.string.chat_message_attachment_options)
                                                 )
                                             }
-                                            DropdownMenu(
-                                                expanded = showCameraMenu,
-                                                onDismissRequest = { showCameraMenu = false }
-                                            ) {
-                                                DropdownMenuItem(
-                                                    text = { Text(stringResource(MR.string.chat_message_take_photo)) },
-                                                    onClick = {
-                                                        showCameraMenu = false
-                                                        onCameraClick()
-                                                    },
-                                                    leadingIcon = {
-                                                        Icon(Icons.Default.PhotoCamera, contentDescription = null)
-                                                    }
-                                                )
-                                                DropdownMenuItem(
-                                                    text = { Text(stringResource(MR.string.chat_message_record_video)) },
-                                                    onClick = {
-                                                        showCameraMenu = false
-                                                        onVideoRecordClick()
-                                                    },
-                                                    leadingIcon = {
-                                                        Icon(Icons.Default.Videocam, contentDescription = null)
-                                                    }
-                                                )
+                                        } else if (isMobile()) {
+                                            var showCameraMenu by remember { mutableStateOf(false) }
+                                            Box {
+                                                IconButton(
+                                                    onClick = { showCameraMenu = true },
+                                                    modifier = Modifier.testTag("camera_button"),
+                                                ) {
+                                                    Icon(
+                                                        imageVector = Icons.Default.PhotoCamera,
+                                                        contentDescription = stringResource(MR.string.chat_message_camera)
+                                                    )
+                                                }
+                                                DropdownMenu(
+                                                    expanded = showCameraMenu,
+                                                    onDismissRequest = { showCameraMenu = false }
+                                                ) {
+                                                    DropdownMenuItem(
+                                                        text = { Text(stringResource(MR.string.chat_message_take_photo)) },
+                                                        onClick = {
+                                                            showCameraMenu = false
+                                                            onCameraClick()
+                                                        },
+                                                        leadingIcon = {
+                                                            Icon(Icons.Default.PhotoCamera, contentDescription = null)
+                                                        }
+                                                    )
+                                                    DropdownMenuItem(
+                                                        text = { Text(stringResource(MR.string.chat_message_record_video)) },
+                                                        onClick = {
+                                                            showCameraMenu = false
+                                                            onVideoRecordClick()
+                                                        },
+                                                        leadingIcon = {
+                                                            Icon(Icons.Default.Videocam, contentDescription = null)
+                                                        }
+                                                    )
+                                                }
                                             }
                                         }
                                     }
-                                }
-                            },
-                            shape = if (!showActionButtons)
-                                RoundedCornerShape(0.dp)
-                            else if (editExistingMode)
-                                RoundedCornerShape(bottomStart = 12.dp, bottomEnd = 12.dp)
-                            else if (showRecordingButton)
-                                RoundedCornerShape(bottomStart = 12.dp, topStart = 12.dp)
-                            else
-                                RoundedCornerShape(12.dp),
-                            colors = RichTextEditorDefaults.richTextEditorColors(
-                                containerColor = if (!showActionButtons)
-                                    Color.Transparent
+                                },
+                                shape = if (!showActionButtons)
+                                    RoundedCornerShape(0.dp)
+                                else if (editExistingMode)
+                                    RoundedCornerShape(bottomStart = 12.dp, bottomEnd = 12.dp)
+                                else if (showRecordingButton)
+                                    RoundedCornerShape(bottomStart = 12.dp, topStart = 12.dp)
                                 else
-                                    MaterialTheme.colorScheme.surfaceContainerHighest,
-                                focusedIndicatorColor = Color.Transparent,
-                                unfocusedIndicatorColor = Color.Transparent,
-                                disabledIndicatorColor = Color.Transparent,
-                            ),
-                            minLines = 1,
-                            maxLines = if (editExistingMode) 10 else 5,
-                            keyboardOptions = KeyboardOptions(
-                                capitalization = KeyboardCapitalization.Sentences,
-                                imeAction = ImeAction.Default
+                                    RoundedCornerShape(12.dp),
+                                colors = RichTextEditorDefaults.richTextEditorColors(
+                                    containerColor = if (!showActionButtons)
+                                        Color.Transparent
+                                    else
+                                        MaterialTheme.colorScheme.surfaceContainerHighest,
+                                    focusedIndicatorColor = Color.Transparent,
+                                    unfocusedIndicatorColor = Color.Transparent,
+                                    disabledIndicatorColor = Color.Transparent,
+                                ),
+                                minLines = 1,
+                                maxLines = if (editExistingMode) 10 else 5,
+                                keyboardOptions = KeyboardOptions(
+                                    capitalization = KeyboardCapitalization.Sentences,
+                                    imeAction = ImeAction.Default
+                                )
                             )
-                        )
+                            EmojiAutocomplete(
+                                state = state,
+                                controller = autocomplete,
+                                enabled = isKeyboardFocused && isDesktopOrWeb(),
+                            )
+                        }
                         if (showRecordingButton) {
                             // Mic button: a single pointerInput handles the full gesture (press,
                             // hold to record, slide-left to cancel, release to stop). It is always
@@ -1215,6 +1242,7 @@ fun MessageTextFieldForAttachment(
 ) {
     var hasSent by remember { mutableStateOf(false) }
     var showEmojiPicker by remember { mutableStateOf(false) }
+    val autocomplete = rememberComposerAutocompleteController()
     val isKeyboardVisible by keyboardAsState()
     val keyboardController = LocalSoftwareKeyboardController.current
     val focusManager = LocalFocusManager.current
@@ -1241,64 +1269,75 @@ fun MessageTextFieldForAttachment(
             modifier = Modifier.fillMaxWidth(),
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            RichTextEditor(
-                state = state,
-                modifier = Modifier.weight(1f).testTag(ATTACHMENT_CAPTION_FIELD_TAG)
-                    // Tapping into the caption closes the panel; the keyboard reclaims the space.
-                    .onFocusChanged { if (it.isFocused) setEmojiPicker(false) }
-                    .onPreviewKeyEvent { keyEvent ->
-                        if (isDesktopOrWeb() && keyEvent.key == Key.Enter && keyEvent.type == KeyEventType.KeyDown) {
-                            if (keyEvent.isShiftPressed) {
-                                state.addTextAfterSelection("\n")
-                                true
-                            } else if (!hasSent) {
-                                hasSent = true
-                                onSendMessage()
-                                true
+            Box(modifier = Modifier.weight(1f)) {
+                RichTextEditor(
+                    state = state,
+                    modifier = Modifier.fillMaxWidth().testTag(ATTACHMENT_CAPTION_FIELD_TAG)
+                        // Tapping into the caption closes the panel; the keyboard reclaims the space.
+                        .onFocusChanged { if (it.isFocused) setEmojiPicker(false) }
+                        .onPreviewKeyEvent { keyEvent ->
+                            // The autocomplete list owns arrows/Enter/Tab/Esc while it is showing;
+                            // preview events run root-to-leaf, so Enter-to-send below beats it otherwise.
+                            if (autocomplete.handleKeyEvent(keyEvent)) return@onPreviewKeyEvent true
+
+                            if (isDesktopOrWeb() && keyEvent.key == Key.Enter && keyEvent.type == KeyEventType.KeyDown) {
+                                if (keyEvent.isShiftPressed) {
+                                    state.addTextAfterSelection("\n")
+                                    true
+                                } else if (!hasSent) {
+                                    hasSent = true
+                                    onSendMessage()
+                                    true
+                                } else {
+                                    true
+                                }
                             } else {
-                                true
-                            }
-                        } else {
-                            false
-                        }
-                    },
-                placeholder = {
-                    Text(stringResource(MR.string.chat_new_message_placeholder))
-                },
-                leadingIcon = {
-                    IconButton(
-                        onClick = {
-                            if (showEmojiPicker) {
-                                setEmojiPicker(false)
-                            } else {
-                                keyboardController?.hide()
-                                focusManager.clearFocus()
-                                setEmojiPicker(true)
+                                false
                             }
                         },
-                        modifier = Modifier.testTag(ATTACHMENT_EMOJI_BUTTON_TAG),
-                    ) {
-                        Icon(
-                            imageVector = Icons.Default.EmojiEmotions,
-                            contentDescription = stringResource(
-                                MR.string.chat_message_emoji_options
+                    placeholder = {
+                        Text(stringResource(MR.string.chat_new_message_placeholder))
+                    },
+                    leadingIcon = {
+                        IconButton(
+                            onClick = {
+                                if (showEmojiPicker) {
+                                    setEmojiPicker(false)
+                                } else {
+                                    keyboardController?.hide()
+                                    focusManager.clearFocus()
+                                    setEmojiPicker(true)
+                                }
+                            },
+                            modifier = Modifier.testTag(ATTACHMENT_EMOJI_BUTTON_TAG),
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.EmojiEmotions,
+                                contentDescription = stringResource(
+                                    MR.string.chat_message_emoji_options
+                                )
                             )
-                        )
-                    }
-                },
-                shape = RoundedCornerShape(12.dp),
-                colors = RichTextEditorDefaults.richTextEditorColors(
-                    containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
-                    focusedIndicatorColor = Color.Transparent,
-                    unfocusedIndicatorColor = Color.Transparent,
-                    disabledIndicatorColor = Color.Transparent,
-                ),
-                minLines = 1,
-                maxLines = 3,
-                keyboardOptions = KeyboardOptions(
-                    capitalization = KeyboardCapitalization.Sentences, imeAction = ImeAction.Default
+                        }
+                    },
+                    shape = RoundedCornerShape(12.dp),
+                    colors = RichTextEditorDefaults.richTextEditorColors(
+                        containerColor = MaterialTheme.colorScheme.surfaceContainerHighest,
+                        focusedIndicatorColor = Color.Transparent,
+                        unfocusedIndicatorColor = Color.Transparent,
+                        disabledIndicatorColor = Color.Transparent,
+                    ),
+                    minLines = 1,
+                    maxLines = 3,
+                    keyboardOptions = KeyboardOptions(
+                        capitalization = KeyboardCapitalization.Sentences, imeAction = ImeAction.Default
+                    )
                 )
-            )
+                EmojiAutocomplete(
+                    state = state,
+                    controller = autocomplete,
+                    enabled = isDesktopOrWeb(),
+                )
+            }
             Spacer(modifier = Modifier.width(8.dp))
             if (!isKeyboardVisible) {
                 IconButton(

--- a/homebase-chat/src/commonTest/kotlin/id/homebase/chat/widget/ComposerEmojiTypeaheadTest.kt
+++ b/homebase-chat/src/commonTest/kotlin/id/homebase/chat/widget/ComposerEmojiTypeaheadTest.kt
@@ -1,0 +1,100 @@
+package id.homebase.chat.widget
+
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performKeyInput
+import androidx.compose.ui.test.pressKey
+import androidx.compose.ui.test.requestFocus
+import androidx.compose.ui.test.runComposeUiTest
+import com.mohamedrejeb.richeditor.model.RichTextState
+import com.mohamedrejeb.richeditor.model.rememberRichTextState
+import id.homebase.core.ui.theme.HomebaseTheme
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * End-to-end wiring for the `:shortcode` typeahead in a real composer, against the shipped emoji
+ * index. Runs on the JVM, where `isDesktopOrWeb()` is true; the mobile branch is covered by
+ * `ComposerAutocompleteTest`, which drives the gate directly.
+ */
+@OptIn(ExperimentalTestApi::class)
+class ComposerEmojiTypeaheadTest {
+
+    @Test
+    fun typingAShortcodePrefixOffersTheMatchingEmoji() = runComposeUiTest {
+        lateinit var state: RichTextState
+        setContent {
+            HomebaseTheme {
+                state = rememberRichTextState()
+                MessageTextFieldForAttachment(state = state, onSendMessage = {})
+            }
+        }
+
+        runOnIdle { state.addTextAfterSelection(":par") }
+        waitUntil(timeoutMillis = 10_000) {
+            onAllNodes(hasText(":party:")).fetchSemanticsNodes().isNotEmpty()
+        }
+    }
+
+    @Test
+    fun enterCommitsTheEmojiInsteadOfSendingTheMessage() = runComposeUiTest {
+        lateinit var state: RichTextState
+        var sends = 0
+        setContent {
+            HomebaseTheme {
+                state = rememberRichTextState()
+                MessageTextFieldForAttachment(state = state, onSendMessage = { sends++ })
+            }
+        }
+
+        onNodeWithTag(ATTACHMENT_CAPTION_FIELD_TAG).requestFocus()
+        runOnIdle { state.addTextAfterSelection("hi :par") }
+        waitUntil(timeoutMillis = 10_000) {
+            onAllNodes(hasText(":party:")).fetchSemanticsNodes().isNotEmpty()
+        }
+
+        onNodeWithTag(ATTACHMENT_CAPTION_FIELD_TAG).performKeyInput { pressKey(Key.Enter) }
+        waitForIdle()
+
+        assertEquals(0, sends, "Enter must commit the emoji, not send the message")
+        assertEquals("hi 🎉", state.annotatedString.text)
+    }
+
+    @Test
+    fun enterStillSendsWithNoListOpen() = runComposeUiTest {
+        lateinit var state: RichTextState
+        var sends = 0
+        setContent {
+            HomebaseTheme {
+                state = rememberRichTextState()
+                MessageTextFieldForAttachment(state = state, onSendMessage = { sends++ })
+            }
+        }
+
+        onNodeWithTag(ATTACHMENT_CAPTION_FIELD_TAG).requestFocus()
+        runOnIdle { state.addTextAfterSelection("just a caption") }
+        waitForIdle()
+
+        onNodeWithTag(ATTACHMENT_CAPTION_FIELD_TAG).performKeyInput { pressKey(Key.Enter) }
+        waitForIdle()
+
+        assertEquals(1, sends)
+    }
+
+    /** The completed token is the inline replacement's job — the list must not shadow it. */
+    @Test
+    fun aClosingColonFallsThroughToTheInlineReplacement() = runComposeUiTest {
+        lateinit var state: RichTextState
+        setContent {
+            HomebaseTheme {
+                state = rememberRichTextState()
+                MessageTextFieldForAttachment(state = state, onSendMessage = {})
+            }
+        }
+
+        runOnIdle { state.addTextAfterSelection("hi :party:") }
+        waitUntil(timeoutMillis = 10_000) { state.annotatedString.text == "hi 🎉" }
+    }
+}

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/emoji/EmojiShortcodeSuggestions.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/emoji/EmojiShortcodeSuggestions.kt
@@ -1,0 +1,44 @@
+package id.homebase.core.emoji
+
+data class EmojiSuggestion(val shortcode: String, val emoji: String)
+
+/**
+ * Shortest query that opens the list. A bare `:` — and `:` plus one character — matches far too
+ * much to rank usefully, and popping a list on every colon is noise.
+ */
+const val EmojiSuggestionMinQueryLength: Int = 2
+
+const val EmojiSuggestionLimit: Int = 8
+
+/**
+ * Ranks the shortcode index from a partial `:query`. Exact beats prefix beats substring; within a
+ * tier the shorter shortcode wins, then alphabetical order so the list never reshuffles between
+ * identical queries.
+ */
+fun emojiSuggestions(
+    query: String,
+    shortcodes: Map<String, String>,
+    limit: Int = EmojiSuggestionLimit,
+): List<EmojiSuggestion> {
+    if (query.length < EmojiSuggestionMinQueryLength) return emptyList()
+    if (!query.all { it.isShortcodeChar() }) return emptyList()
+
+    val needle = query.lowercase()
+    return shortcodes.asSequence()
+        .mapNotNull { (shortcode, emoji) ->
+            val tier = when {
+                shortcode == needle -> 0
+                shortcode.startsWith(needle) -> 1
+                shortcode.contains(needle) -> 2
+                else -> return@mapNotNull null
+            }
+            Triple(tier, shortcode, emoji)
+        }
+        .sortedWith(compareBy({ it.first }, { it.second.length }, { it.second }))
+        // Several shortcodes reach the same glyph (party/party_popper, smirk/smirking); showing
+        // each glyph once keeps the short list varied.
+        .distinctBy { it.third }
+        .take(limit)
+        .map { EmojiSuggestion(shortcode = it.second, emoji = it.third) }
+        .toList()
+}

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/emoji/EmojiShortcodes.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/emoji/EmojiShortcodes.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.text.TextRange
 import com.mohamedrejeb.richeditor.model.RichTextState
+import id.homebase.core.util.replaceTextRangeSafely
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
@@ -26,7 +27,7 @@ data class ShortcodeReplacement(
     val emoji: String,
 )
 
-private fun Char.isShortcodeChar(): Boolean =
+internal fun Char.isShortcodeChar(): Boolean =
     this in 'a'..'z' || this in 'A'..'Z' || this in '0'..'9' ||
         this == '_' || this == '+' || this == '-'
 
@@ -61,7 +62,7 @@ fun RichTextState.replaceCompletedEmojiShortcode(shortcodes: Map<String, String>
     val cursor = selection
     if (!cursor.collapsed) return
     val match = replaceEmojiShortcode(annotatedString.text, cursor.start, shortcodes) ?: return
-    replaceTextRange(TextRange(match.start, cursor.start), match.emoji)
+    replaceTextRangeSafely(TextRange(match.start, cursor.start), match.emoji)
 }
 
 @Composable

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/util/RichTextSplice.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/util/RichTextSplice.kt
@@ -1,0 +1,25 @@
+package id.homebase.core.util
+
+import androidx.compose.ui.text.TextRange
+import com.mohamedrejeb.richeditor.model.RichTextState
+
+/**
+ * The single splice the inline `:shortcode:` replacement and the composer autocomplete commit both
+ * go through. A range end that lands between the two halves of a surrogate pair would leave a lone
+ * surrogate behind, so each end snaps outward to the enclosing code-point boundary first.
+ */
+fun RichTextState.replaceTextRangeSafely(range: TextRange, replacement: String) {
+    replaceTextRange(annotatedString.text.codePointBoundedRange(range), replacement)
+}
+
+fun String.codePointBoundedRange(range: TextRange): TextRange {
+    val start = range.min.coerceIn(0, length)
+    val end = range.max.coerceIn(0, length)
+    return TextRange(
+        if (splitsSurrogatePairAt(start)) start - 1 else start,
+        if (splitsSurrogatePairAt(end)) end + 1 else end,
+    )
+}
+
+private fun String.splitsSurrogatePairAt(index: Int): Boolean =
+    index in 1..lastIndex && this[index - 1].isHighSurrogate() && this[index].isLowSurrogate()

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/widget/ComposerAutocomplete.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/widget/ComposerAutocomplete.kt
@@ -1,0 +1,244 @@
+package id.homebase.core.widget
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.isShiftPressed
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.PopupPositionProvider
+import androidx.compose.ui.window.PopupProperties
+import com.mohamedrejeb.richeditor.annotation.ExperimentalRichTextApi
+import com.mohamedrejeb.richeditor.model.RichTextState
+import com.mohamedrejeb.richeditor.model.trigger.Trigger
+import id.homebase.core.util.replaceTextRangeSafely
+
+const val ComposerAutocompleteTag: String = "composer_autocomplete"
+
+/**
+ * Owns the arrow/Enter/Tab/Escape keys while a [ComposerAutocomplete] list is showing.
+ *
+ * richeditor's own `triggerKeyHandler` is internal, and the composer's Enter-to-send lives in an
+ * `onPreviewKeyEvent` on the editor's outer modifier — preview events run root-to-leaf, so that
+ * handler sees Enter before the editor does. Without giving this first refusal there, Enter sends
+ * `:sm` as a message instead of committing the highlighted suggestion.
+ */
+@Stable
+class ComposerAutocompleteController internal constructor() {
+    internal var keyHandler: ((KeyEvent) -> Boolean)? by mutableStateOf(null)
+
+    fun handleKeyEvent(event: KeyEvent): Boolean = keyHandler?.invoke(event) ?: false
+}
+
+@Composable
+fun rememberComposerAutocompleteController(): ComposerAutocompleteController =
+    remember { ComposerAutocompleteController() }
+
+/**
+ * Typeahead dropdown for a [RichTextState] composer: typing [triggerChar] opens a list, typing on
+ * filters it, and picking an entry splices [replacementFor] over the trigger token.
+ *
+ * Place it as a sibling of the editor inside a `Box` that wraps ONLY the editor — that Box is the
+ * anchor — and route the editor's `onPreviewKeyEvent` through [ComposerAutocompleteController]
+ * first.
+ *
+ * The trigger detection comes from richeditor, which brings the word-boundary rule that keeps
+ * `10:30` and `https://` from opening the list. Commit goes through [replacementFor] and
+ * `replaceTextRange` rather than richeditor's `insertToken`: a token is an atomic styled span, and
+ * the composer ships `toMessageMarkdown()`, so a replacement has to land as literal text.
+ *
+ * [suggestionsFor] is cancelled and restarted on every keystroke, so a remote lookup can debounce
+ * itself with a leading `delay`.
+ */
+@OptIn(ExperimentalRichTextApi::class)
+@Composable
+fun <T> ComposerAutocomplete(
+    state: RichTextState,
+    controller: ComposerAutocompleteController,
+    triggerId: String,
+    triggerChar: Char,
+    suggestionsFor: suspend (String) -> List<T>,
+    replacementFor: (T) -> String,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    itemContent: @Composable (item: T, selected: Boolean) -> Unit,
+) {
+    if (!enabled) return
+
+    DisposableEffect(state, triggerId, triggerChar) {
+        state.registerTrigger(Trigger(id = triggerId, char = triggerChar))
+        onDispose { state.unregisterTrigger(triggerId) }
+    }
+
+    val query = state.activeTriggerQuery?.takeIf { it.triggerId == triggerId }
+    var suggestions by remember { mutableStateOf(emptyList<T>()) }
+    LaunchedEffect(query?.query) {
+        suggestions = query?.let { suggestionsFor(it.query) }.orEmpty()
+    }
+
+    if (query == null || suggestions.isEmpty()) return
+
+    SuggestionList(
+        state = state,
+        controller = controller,
+        range = query.range,
+        suggestions = suggestions,
+        replacementFor = replacementFor,
+        modifier = modifier,
+        itemContent = itemContent,
+    )
+}
+
+@OptIn(ExperimentalRichTextApi::class)
+@Composable
+private fun <T> SuggestionList(
+    state: RichTextState,
+    controller: ComposerAutocompleteController,
+    range: TextRange,
+    suggestions: List<T>,
+    replacementFor: (T) -> String,
+    modifier: Modifier,
+    itemContent: @Composable (item: T, selected: Boolean) -> Unit,
+) {
+    var selected by remember(suggestions) { mutableStateOf(0) }
+    val safeSelected = selected.coerceIn(0, suggestions.lastIndex)
+
+    val currentSuggestions by rememberUpdatedState(suggestions)
+    val currentRange by rememberUpdatedState(range)
+    val currentReplacement by rememberUpdatedState(replacementFor)
+
+    fun commit(item: T) = state.replaceTextRangeSafely(currentRange, currentReplacement(item))
+
+    DisposableEffect(controller) {
+        controller.keyHandler = handler@{ event ->
+            if (event.type != KeyEventType.KeyDown) return@handler false
+            val items = currentSuggestions
+            if (items.isEmpty()) return@handler false
+            when (event.key) {
+                Key.DirectionDown -> {
+                    selected = (selected.coerceIn(0, items.lastIndex) + 1).mod(items.size)
+                    true
+                }
+
+                Key.DirectionUp -> {
+                    selected = (selected.coerceIn(0, items.lastIndex) - 1).mod(items.size)
+                    true
+                }
+
+                // NumPadEnter too: macOS can report Return as NumPadEnter (#1043). Shift+Enter is
+                // the composer's newline and stays the composer's, open list or not.
+                Key.Enter, Key.NumPadEnter, Key.Tab -> {
+                    if (event.isShiftPressed && event.key != Key.Tab) {
+                        false
+                    } else {
+                        items.getOrNull(selected.coerceIn(0, items.lastIndex))?.let(::commit)
+                        true
+                    }
+                }
+
+                Key.Escape -> {
+                    state.cancelActiveTrigger()
+                    true
+                }
+
+                else -> false
+            }
+        }
+        onDispose { controller.keyHandler = null }
+    }
+
+    val gapPx = with(LocalDensity.current) { 4.dp.roundToPx() }
+    val positionProvider = remember(gapPx) { AboveAnchorPositionProvider(gapPx) }
+
+    Popup(
+        popupPositionProvider = positionProvider,
+        onDismissRequest = { state.cancelActiveTrigger() },
+        // Focusable would pull the caret out of the editor; the editor keeps receiving keystrokes
+        // and forwards the navigation keys through the controller instead.
+        properties = PopupProperties(focusable = false),
+    ) {
+        Surface(
+            shape = MaterialTheme.shapes.medium,
+            color = MaterialTheme.colorScheme.surfaceContainerHigh,
+            contentColor = MaterialTheme.colorScheme.onSurface,
+            tonalElevation = 3.dp,
+            shadowElevation = 6.dp,
+            modifier = modifier.testTag(ComposerAutocompleteTag).widthIn(min = 200.dp, max = 320.dp),
+        ) {
+            Column(modifier = Modifier.fillMaxWidth()) {
+                suggestions.forEachIndexed { index, item ->
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .background(
+                                if (index == safeSelected) {
+                                    MaterialTheme.colorScheme.secondaryContainer
+                                } else {
+                                    Color.Transparent
+                                }
+                            )
+                            .clickable { commit(item) },
+                    ) {
+                        itemContent(item, index == safeSelected)
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Sits above the editor rather than at the caret: richeditor keeps the text field's window position
+ * and its TextLayoutResult internal, and the caret rect that is public is relative to the inner
+ * field, offset from the decoration box by the leading icon.
+ *
+ * [anchorBounds] is Compose's own measurement of the parent Box, handed over during placement.
+ * Deriving the anchor any other way — `onGloballyPositioned` writing a state that composition then
+ * reads — makes every layout pass invalidate composition, which re-lays out, which writes again;
+ * the composer resizes the editor continuously while the mic button runs a 1000 ms animation, so
+ * those bounds never settle.
+ */
+private class AboveAnchorPositionProvider(private val gapPx: Int) : PopupPositionProvider {
+    override fun calculatePosition(
+        anchorBounds: IntRect,
+        windowSize: IntSize,
+        layoutDirection: LayoutDirection,
+        popupContentSize: IntSize,
+    ): IntOffset {
+        val maxX = (windowSize.width - popupContentSize.width).coerceAtLeast(0)
+        val x = anchorBounds.left.coerceIn(0, maxX)
+
+        val above = anchorBounds.top - gapPx - popupContentSize.height
+        val maxY = (windowSize.height - popupContentSize.height).coerceAtLeast(0)
+        val y = if (above >= 0) above else (anchorBounds.bottom + gapPx).coerceIn(0, maxY)
+
+        return IntOffset(x, y)
+    }
+}

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/widget/EmojiAutocomplete.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/widget/EmojiAutocomplete.kt
@@ -1,0 +1,75 @@
+package id.homebase.core.widget
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.mohamedrejeb.richeditor.model.RichTextState
+import id.homebase.core.emoji.EmojiShortcodes
+import id.homebase.core.emoji.EmojiSuggestion
+import id.homebase.core.emoji.emojiSuggestions
+import id.homebase.core.ui.theme.withEmojiFont
+import id.homebase.core.util.isDesktopOrWeb
+
+private const val EmojiTriggerId = "emoji-shortcode"
+
+/**
+ * `:shortcode` typeahead for a composer. Desktop/web only — mobile has a system emoji keyboard one
+ * tap away and the app ships [EmojiSelection] on every platform.
+ *
+ * Placement and key routing follow [ComposerAutocomplete]: a `Box` around the editor alone, and the
+ * editor's `onPreviewKeyEvent` running through the controller first.
+ */
+@Composable
+fun EmojiAutocomplete(
+    state: RichTextState,
+    controller: ComposerAutocompleteController,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = isDesktopOrWeb(),
+) {
+    ComposerAutocomplete(
+        state = state,
+        controller = controller,
+        triggerId = EmojiTriggerId,
+        triggerChar = ':',
+        suggestionsFor = { query -> emojiSuggestions(query, EmojiShortcodes.index()) },
+        replacementFor = { it.emoji },
+        modifier = modifier,
+        enabled = enabled,
+    ) { suggestion, selected ->
+        EmojiSuggestionRow(suggestion = suggestion, selected = selected)
+    }
+}
+
+@Composable
+private fun EmojiSuggestionRow(suggestion: EmojiSuggestion, selected: Boolean) {
+    val shortcode = ":${suggestion.shortcode}:"
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 12.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Text(
+            text = suggestion.emoji.withEmojiFont(),
+            style = MaterialTheme.typography.titleMedium,
+        )
+        Text(
+            text = shortcode,
+            style = MaterialTheme.typography.bodyMedium,
+            color = if (selected) {
+                MaterialTheme.colorScheme.onSecondaryContainer
+            } else {
+                MaterialTheme.colorScheme.onSurfaceVariant
+            },
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+    }
+}

--- a/homebase-common/src/commonTest/kotlin/id/homebase/core/emoji/EmojiShortcodeSuggestionsTest.kt
+++ b/homebase-common/src/commonTest/kotlin/id/homebase/core/emoji/EmojiShortcodeSuggestionsTest.kt
@@ -1,0 +1,102 @@
+package id.homebase.core.emoji
+
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class EmojiShortcodeSuggestionsTest {
+
+    private val sample = mapOf(
+        "party" to "🎉",
+        "party_popper" to "🎉",
+        "parrot" to "🦜",
+        "parking" to "🅿️",
+        "unicorn" to "🦄",
+    )
+
+    @Test
+    fun queriesShorterThanTheMinimumReturnNothing() {
+        assertTrue(emojiSuggestions("", sample).isEmpty())
+        assertTrue(emojiSuggestions("p", sample).isEmpty())
+        assertTrue(emojiSuggestions("pa", sample).isNotEmpty())
+    }
+
+    @Test
+    fun exactBeatsPrefixBeatsSubstring() {
+        val ranked = emojiSuggestions(
+            "par",
+            mapOf("par" to "A", "parrot" to "B", "spare" to "C"),
+        )
+
+        assertEquals(listOf("A", "B", "C"), ranked.map { it.emoji })
+    }
+
+    @Test
+    fun withinATierTheShorterShortcodeWinsThenAlphabetical() {
+        val ranked = emojiSuggestions(
+            "par",
+            mapOf("parking" to "A", "parrot" to "B", "params" to "C"),
+        )
+
+        assertEquals(listOf("params", "parrot", "parking"), ranked.map { it.shortcode })
+    }
+
+    @Test
+    fun eachGlyphAppearsOnceUnderItsBestShortcode() {
+        val ranked = emojiSuggestions("par", sample)
+
+        assertEquals(listOf("party", "parrot", "parking"), ranked.map { it.shortcode })
+    }
+
+    @Test
+    fun matchingIsCaseInsensitive() {
+        assertEquals("🎉", emojiSuggestions("PaRt", sample).first().emoji)
+    }
+
+    @Test
+    fun resultsAreCappedAtTheLimit() {
+        val many = (1..50).associate { "smile$it" to "$it" }
+
+        assertEquals(EmojiSuggestionLimit, emojiSuggestions("smile", many).size)
+        assertEquals(3, emojiSuggestions("smile", many, limit = 3).size)
+    }
+
+    /**
+     * A completed `:party:` is the inline replacement's job, not the list's. The trailing colon
+     * arrives in the query before the token closes, and nothing may match it.
+     */
+    @Test
+    fun aQueryHoldingNonShortcodeCharactersMatchesNothing() {
+        assertTrue(emojiSuggestions("party:", sample).isEmpty())
+        assertTrue(emojiSuggestions("par ", sample).isEmpty())
+        assertTrue(emojiSuggestions("par/", sample).isEmpty())
+    }
+
+    @Test
+    fun nonMatchingQueryReturnsNothing() {
+        assertTrue(emojiSuggestions("zzz", sample).isEmpty())
+    }
+
+    @Test
+    fun theShippedIndexResolvesTheShortcodesPeopleActuallyType() = runTest {
+        val index = EmojiShortcodes.index()
+
+        val expected = mapOf(
+            "par" to "🎉",
+            "tad" to "🎉",
+            "roc" to "🪨",
+            "joy" to "😂",
+            "thumbs" to "👍️",
+            "sob" to "😭",
+            "white_check" to "✅️",
+        )
+
+        val failures = expected.mapNotNull { (query, want) ->
+            val top = emojiSuggestions(query, index).firstOrNull()?.emoji
+            if (top == want) null else ":$query got $top want $want"
+        }
+
+        assertTrue(failures.isEmpty(), "shortcode ranking regressed: $failures")
+    }
+}

--- a/homebase-common/src/commonTest/kotlin/id/homebase/core/util/RichTextSpliceTest.kt
+++ b/homebase-common/src/commonTest/kotlin/id/homebase/core/util/RichTextSpliceTest.kt
@@ -1,0 +1,60 @@
+package id.homebase.core.util
+
+import androidx.compose.ui.text.TextRange
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class RichTextSpliceTest {
+
+    @Test
+    fun anAsciiBoundedRangeIsLeftAlone() {
+        assertEquals(TextRange(3, 7), "hi :par".codePointBoundedRange(TextRange(3, 7)))
+    }
+
+    @Test
+    fun aRangeSplittingASurrogatePairSnapsOutwardToSwallowIt() {
+        // "🎉" is a surrogate pair at 0..1, so offset 1 sits between its halves.
+        assertEquals(TextRange(0, 2), "🎉ab".codePointBoundedRange(TextRange(1, 2)))
+        assertEquals(TextRange(0, 4), "ab🎉".codePointBoundedRange(TextRange(0, 3)))
+    }
+
+    @Test
+    fun aReversedRangeIsNormalised() {
+        assertEquals(TextRange(2, 5), "hello".codePointBoundedRange(TextRange(5, 2)))
+    }
+
+    @Test
+    fun offsetsPastTheEndOfTheTextAreClamped() {
+        assertEquals(TextRange(0, 5), "hello".codePointBoundedRange(TextRange(0, 99)))
+    }
+
+    @Test
+    fun snappedRangesNeverLeaveALoneSurrogate() {
+        val text = "🎉:par🎉"
+        for (start in 0..text.length) {
+            for (end in start..text.length) {
+                val snapped = text.codePointBoundedRange(TextRange(start, end))
+                val spliced = text.substring(0, snapped.start) + "😄" + text.substring(snapped.end)
+                assertNoLoneSurrogate(spliced)
+            }
+        }
+    }
+}
+
+private fun assertNoLoneSurrogate(text: String) {
+    var i = 0
+    while (i < text.length) {
+        val c = text[i]
+        when {
+            c.isHighSurrogate() -> {
+                check(i + 1 < text.length && text[i + 1].isLowSurrogate()) {
+                    "lone high surrogate at $i in $text"
+                }
+                i += 2
+            }
+
+            c.isLowSurrogate() -> throw AssertionError("lone low surrogate at $i in $text")
+            else -> i++
+        }
+    }
+}

--- a/homebase-common/src/commonTest/kotlin/id/homebase/core/widget/ComposerAutocompleteTest.kt
+++ b/homebase-common/src/commonTest/kotlin/id/homebase/core/widget/ComposerAutocompleteTest.kt
@@ -1,0 +1,256 @@
+package id.homebase.core.widget
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.isShiftPressed
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performKeyInput
+import androidx.compose.ui.test.pressKey
+import androidx.compose.ui.test.requestFocus
+import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.test.withKeyDown
+import com.mohamedrejeb.richeditor.model.RichTextState
+import com.mohamedrejeb.richeditor.model.rememberRichTextState
+import com.mohamedrejeb.richeditor.ui.material3.RichTextEditor
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+private val Candidates = listOf("smile", "smirk", "smiley")
+
+@OptIn(ExperimentalTestApi::class)
+class ComposerAutocompleteTest {
+
+    /**
+     * Mirrors the three composer editors in `MessageInputBar`: a Box wrapping ONLY the editor is
+     * the popup's anchor, and the editor's preview-key handler gives the controller first refusal
+     * before Enter-to-send.
+     */
+    private fun harness(
+        enabled: Boolean = true,
+        onSend: () -> Unit = {},
+        capture: (RichTextState) -> Unit,
+    ): @Composable () -> Unit = {
+        MaterialTheme {
+            val state = rememberRichTextState()
+            val controller = rememberComposerAutocompleteController()
+            capture(state)
+            Box {
+                RichTextEditor(
+                    state = state,
+                    modifier = Modifier
+                        .onPreviewKeyEvent { event ->
+                            if (controller.handleKeyEvent(event)) {
+                                true
+                            } else if (event.key == Key.Enter && event.type == KeyEventType.KeyDown) {
+                                if (event.isShiftPressed) state.addTextAfterSelection("\n") else onSend()
+                                true
+                            } else {
+                                false
+                            }
+                        }
+                        .testTag("editor"),
+                )
+                ComposerAutocomplete(
+                    state = state,
+                    controller = controller,
+                    triggerId = "test",
+                    triggerChar = ':',
+                    suggestionsFor = { query ->
+                        if (query.length < 2) emptyList()
+                        else Candidates.filter { it.startsWith(query) }
+                    },
+                    replacementFor = { "<$it>" },
+                    enabled = enabled,
+                ) { item, selected ->
+                    Text(text = if (selected) "*$item" else item)
+                }
+            }
+        }
+    }
+
+    private fun androidx.compose.ui.test.ComposeUiTest.awaitList() =
+        waitUntil(timeoutMillis = 10_000) {
+            onAllNodes(hasText("smile", substring = true)).fetchSemanticsNodes().isNotEmpty()
+        }
+
+    @Test
+    fun typingTheTriggerAndAQueryOpensTheList() = runComposeUiTest {
+        lateinit var state: RichTextState
+        setContent(harness { state = it })
+
+        runOnIdle { state.addTextAfterSelection(":sm") }
+        awaitList()
+
+        onNodeWithTag(ComposerAutocompleteTag).assertExists()
+    }
+
+    @Test
+    fun aOneCharacterQueryStaysBelowTheThreshold() = runComposeUiTest {
+        lateinit var state: RichTextState
+        setContent(harness { state = it })
+
+        runOnIdle { state.addTextAfterSelection(":s") }
+        waitForIdle()
+
+        assertEquals(0, onAllNodes(hasText("smile", substring = true)).fetchSemanticsNodes().size)
+    }
+
+    @Test
+    fun aTriggerInsideAWordNeverOpensTheList() = runComposeUiTest {
+        lateinit var state: RichTextState
+        setContent(harness { state = it })
+
+        // The classic false positives: a URL scheme and a clock time.
+        runOnIdle { state.addTextAfterSelection("https://sm and 10:sm") }
+        waitForIdle()
+
+        assertEquals(0, onAllNodes(hasText("smile", substring = true)).fetchSemanticsNodes().size)
+    }
+
+    @Test
+    fun theListNeverOpensWhenDisabled() = runComposeUiTest {
+        lateinit var state: RichTextState
+        setContent(harness(enabled = false) { state = it })
+
+        runOnIdle { state.addTextAfterSelection(":sm") }
+        waitForIdle()
+
+        assertEquals(0, onAllNodes(hasText("smile", substring = true)).fetchSemanticsNodes().size)
+    }
+
+    @Test
+    fun clickingAnItemSplicesItsReplacementOverTheTriggerToken() = runComposeUiTest {
+        lateinit var state: RichTextState
+        setContent(harness { state = it })
+
+        runOnIdle { state.addTextAfterSelection("hi :sm") }
+        awaitList()
+
+        onNodeWithText("*smile").performClick()
+        waitForIdle()
+
+        assertEquals("hi <smile>", state.annotatedString.text)
+    }
+
+    @Test
+    fun enterCommitsTheSelectedItemInsteadOfSendingTheMessage() = runComposeUiTest {
+        lateinit var state: RichTextState
+        var sends = 0
+        setContent(harness(onSend = { sends++ }) { state = it })
+
+        onNodeWithTag("editor").requestFocus()
+        runOnIdle { state.addTextAfterSelection("hi :sm") }
+        awaitList()
+
+        onNodeWithTag("editor").performKeyInput { pressKey(Key.Enter) }
+        waitForIdle()
+
+        assertEquals(0, sends, "Enter must commit the suggestion, not send the message")
+        assertEquals("hi <smile>", state.annotatedString.text)
+    }
+
+    @Test
+    fun enterStillSendsWhenNoListIsShowing() = runComposeUiTest {
+        lateinit var state: RichTextState
+        var sends = 0
+        setContent(harness(onSend = { sends++ }) { state = it })
+
+        onNodeWithTag("editor").requestFocus()
+        runOnIdle { state.addTextAfterSelection("just a message") }
+        waitForIdle()
+
+        onNodeWithTag("editor").performKeyInput { pressKey(Key.Enter) }
+        waitForIdle()
+
+        assertEquals(1, sends)
+    }
+
+    @Test
+    fun shiftEnterStillInsertsANewlineWithTheListOpen() = runComposeUiTest {
+        lateinit var state: RichTextState
+        var sends = 0
+        setContent(harness(onSend = { sends++ }) { state = it })
+
+        onNodeWithTag("editor").requestFocus()
+        runOnIdle { state.addTextAfterSelection("hi :sm") }
+        awaitList()
+
+        onNodeWithTag("editor").performKeyInput { withKeyDown(Key.ShiftLeft) { pressKey(Key.Enter) } }
+        waitForIdle()
+
+        assertEquals(0, sends)
+        assertTrue(
+            state.annotatedString.text.startsWith("hi :sm"),
+            "Shift+Enter must not commit, got: ${state.annotatedString.text}",
+        )
+    }
+
+    @Test
+    fun arrowKeysMoveTheSelectionAndEnterCommitsIt() = runComposeUiTest {
+        lateinit var state: RichTextState
+        setContent(harness { state = it })
+
+        onNodeWithTag("editor").requestFocus()
+        runOnIdle { state.addTextAfterSelection(":sm") }
+        awaitList()
+
+        onNodeWithTag("editor").performKeyInput { pressKey(Key.DirectionDown) }
+        waitForIdle()
+        onNodeWithText("*smirk").assertExists()
+
+        onNodeWithTag("editor").performKeyInput { pressKey(Key.DirectionUp) }
+        waitForIdle()
+        onNodeWithText("*smile").assertExists()
+
+        onNodeWithTag("editor").performKeyInput { pressKey(Key.Enter) }
+        waitForIdle()
+
+        assertEquals("<smile>", state.annotatedString.text)
+    }
+
+    /**
+     * richeditor paints the live trigger token in its link colour. That is presentation only — it
+     * must not reach the markdown the composer sends.
+     */
+    @Test
+    fun anOpenTriggerNeverLeaksStylingIntoTheMarkdown() = runComposeUiTest {
+        lateinit var state: RichTextState
+        setContent(harness { state = it })
+
+        runOnIdle { state.addTextAfterSelection("hi :sm") }
+        awaitList()
+
+        assertEquals("hi :sm", state.toMarkdown())
+    }
+
+    @Test
+    fun escapeDismissesTheListAndLeavesTheTypedTextAlone() = runComposeUiTest {
+        lateinit var state: RichTextState
+        setContent(harness { state = it })
+
+        onNodeWithTag("editor").requestFocus()
+        runOnIdle { state.addTextAfterSelection("hi :sm") }
+        awaitList()
+
+        onNodeWithTag("editor").performKeyInput { pressKey(Key.Escape) }
+        waitUntil(timeoutMillis = 5_000) {
+            onAllNodes(hasText("smile", substring = true)).fetchSemanticsNodes().isEmpty()
+        }
+
+        assertEquals("hi :sm", state.annotatedString.text)
+    }
+}


### PR DESCRIPTION
Closes #1402.

Typing `:` plus two or more characters in the desktop/web composer opens a list of matching emoji; typing on filters it, ↑/↓ move, Enter/Tab commit, Esc dismisses, a click commits. Deleting back past the `:`, a space, or the closing `:` all close it — a closed `:party:` token still falls through to the inline replacement from #1404.

## The reusable piece

`ComposerAutocomplete` (homebase-common, `id.homebase.core.widget`) is generic over the item type and parameterised on exactly the four things #1403's `@mentions` will need:

| parameter | emoji today | `@mentions` next |
| --- | --- | --- |
| `triggerChar` / `triggerId` | `':'` | `'@'` |
| `suggestionsFor: suspend (String) -> List<T>` | rank the #1404 shortcode index | contact search (cancelled and restarted per keystroke, so it can debounce itself with a leading `delay`) |
| `itemContent: @Composable (T, Boolean) -> Unit` | glyph + `:shortcode:` | avatar + name |
| `replacementFor: (T) -> String` | the glyph | `"@odinid "` |

`EmojiAutocomplete` is the whole emoji consumer — 40 lines wiring those four in. Mentions adds a second one beside it. No registry, no plugin surface, no knobs for values that never change; if `@mentions` needs something this shape can't express, widen it then.

## Enter

Enter-to-send lives in an `onPreviewKeyEvent` on the editor's *outer* modifier, and preview events run root-to-leaf — that handler sees Enter before the editor does. So the list gets first refusal via `ComposerAutocompleteController.handleKeyEvent`, called as the first statement of all three composer key handlers. With the list open Enter commits and nothing sends; with it closed the controller returns false and Enter sends exactly as before. Shift+Enter is deliberately *not* intercepted — the composer's newline stays the composer's, open list or not.

Covered by tests both at the widget level and through the real composer (`MessageTextFieldForAttachment`, real emoji index): `hi :par` + Enter yields `hi 🎉` with the send callback never fired, and `just a caption` + Enter fires it exactly once.

## Anchoring

Each of the three editors is now wrapped in a `Box` that contains only the editor, and the popup reads `Popup`'s own `anchorBounds` — Compose's measurement of that Box, handed to the position provider during placement. Deriving the anchor any other way (`onGloballyPositioned` storing bounds that composition then reads) writes Compose state from the layout phase, and the composer resizes the editor continuously while the mic button runs a 1000 ms `animateDpAsState`, so those bounds never settle.

## One splice, not two

The commit and the inline `:shortcode:` replacement both go through `RichTextState.replaceTextRangeSafely`, which snaps a range end outward to the enclosing code-point boundary before splicing, so a range can't cut a surrogate pair in half. Exhaustive test over every start/end pair of `🎉:par🎉`.

## Ranking

A straight lookup over `EmojiShortcodes.index()` from #1404: exact beats prefix beats substring, then shorter shortcode, then alphabetical, one row per glyph. `:par` → 🎉 `:party:`, `:tad` → 🎉, `:white_check` → ✅️. None of #1340's label/tag heuristics came back — those existed only while the dataset shipped no shortcodes.

## Gating

`isDesktopOrWeb()`, the same gate the formatting toolbar uses. Mobile has a system emoji keyboard one tap away and `EmojiSelection` ships on every platform.

## Verification

- `:homebase-common:` and `:homebase-chat:` compile on `compileKotlinJvm`, `compileAndroidMain`, `compileKotlinWasmJs`, `compileKotlinIosSimulatorArm64`.
- `./gradlew homebase-chat:jvmTest homebase-common:jvmTest --rerun-tasks` — 1826 tests, 0 failures. 20 are new: 11 widget-level (open/filter/threshold/word-boundary/disabled/click/Enter/Shift+Enter/arrows/Esc/no markdown leak from the live trigger span), 9 ranking, 5 splice, 4 end-to-end through the real composer.
- Ran the desktop app off this branch against an isolated copy of the app data dir; it starts clean with no watchdog stalls.
