### PR TITLE
Tame wasm-opt memory: lighter binaryen passes

### DIFF
--- a/webApp/build.gradle.kts
+++ b/webApp/build.gradle.kts
@@ -10,6 +10,33 @@ plugins {
     alias(libs.plugins.kotlinSerialization)
 }
 
+// wasm-opt with Kotlin's default pass list (--type-ssa, -O3 four times over, --type-merging, -Oz)
+// peaked at 10.3 GB RSS on this app (measured 2026-08-31). Next to the 8 GB Gradle and Kotlin
+// daemons, that OOM-killed every CI image build on GitHub's 16 GB runners - surfacing as
+// "The operation was canceled" mid compileProductionExecutableKotlinWasmJsOptimize. The lighter
+// pass list below measured 4.4 GB peak and ran 3x faster on the same input, costing ~9% output
+// size (22.2 MB -> 24.2 MB). Feature and safety flags are identical to Kotlin's defaults; only
+// the optimization passes changed. Revisit if binaryen or the runners change shape.
+tasks.withType<org.jetbrains.kotlin.gradle.targets.wasm.binaryen.BinaryenExec>().configureEach {
+    binaryenArgs = mutableListOf(
+        "--enable-gc",
+        "--enable-reference-types",
+        "--enable-exception-handling",
+        "--enable-bulk-memory",
+        "--enable-nontrapping-float-to-int",
+        "--closed-world",
+        "--no-inline=kotlin.wasm.internal.throwValue",
+        "--no-inline=kotlin.wasm.internal.getKotlinException",
+        "--no-inline=kotlin.wasm.internal.jsToKotlinStringAdapter",
+        "--inline-functions-with-loops",
+        "--traps-never-happen",
+        "--fast-math",
+        "-O2",
+        "--gufa",
+        "-Oz",
+    )
+}
+
 // Sub-path mount support. Pass -PpublicPath=/apps/chat-wasm/ to host the bundle under a sub-path
 // (odin-core's CI does this); defaults to "/" for standalone runs. The normalized value flows to:
 //   - webpack `output.publicPath` (via the generated webpack.config.d/00-publicPath.js)


### PR DESCRIPTION
CI image builds in odin-core started dying with "The operation was canceled" mid `compileProductionExecutableKotlinWasmJsOptimize` (twice on 2026-08-31, at different elapsed times). Root cause: Kotlin's default binaryen pass list peaks over 10 GB RSS on this app as it has grown, and together with the 8 GB-capped Gradle and Kotlin daemons that brushes the 16 GB GitHub runners have — the kernel OOM-kills the optimizer.

## Measurements (same input, binaryen 125)

| pass list | peak RSS | wall time | output |
|---|---|---|---|
| default (`--type-ssa`, `-O3` ×4, `--gufa`, `--type-merging`, `-Oz`) | 10.3 GB | ~7 min | 22.2 MB |
| this PR (`-O2 --gufa -Oz`) | 4.3 GB | 2m21s | 24.2 MB |

~9% larger bundle for an optimizer that fits on any runner and is 3× faster. Feature and safety flags (`--enable-*`, `--closed-world`, `--no-inline` trio, `--traps-never-happen`, `--fast-math`) are byte-identical to Kotlin's defaults — only the optimization passes changed. Rationale and numbers live in a comment at the override so future readers know why this deviates from stock.

Verified: full `wasmJsBrowserDistribution` build green with the new args confirmed on the live wasm-opt process (peak 4.32 GB, 4m41s total).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ePkqms6AQdGGUWsVrGyzx