### PR TITLE
Share into a WebDrop from the OS share sheet

### DIFF
--- a/androidApp/src/main/kotlin/id/homebase/feed/MainActivity.kt
+++ b/androidApp/src/main/kotlin/id/homebase/feed/MainActivity.kt
@@ -152,6 +152,16 @@ class MainActivity : AppCompatActivity() {
                 return
             }
 
+            // Share-into-"New WebDrop" deep link: homebase-fchat://web-drop-compose
+            // The share flow already seeded WebDropShareFlowState with the chosen
+            // files; this only steers the nav stack onto the WebDrop screen.
+            if (data.host == "web-drop-compose") {
+                Logger.i(tag = "MainActivity") { "Deep link: navigating to WebDrop compose" }
+                notificationService.navigateToWebDropCompose()
+                intent.data = null
+                return
+            }
+
             // Owner-console "Extend Permissions" return URL.
             // Path: homebase-fchat://permission-callback?status=[canceled|...]
             if (data.host == "permission-callback") {

--- a/androidApp/src/main/kotlin/id/homebase/feed/share/SharePickerScreen.kt
+++ b/androidApp/src/main/kotlin/id/homebase/feed/share/SharePickerScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.outlined.AutoAwesome
+import androidx.compose.material.icons.outlined.Redeem
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilledTonalButton
@@ -73,6 +74,8 @@ import id.homebase.resources.recents
 import id.homebase.resources.sending_to_conversations
 import id.homebase.resources.share_picker_new_moment
 import id.homebase.resources.share_picker_new_moment_subtitle
+import id.homebase.resources.share_picker_new_webdrop
+import id.homebase.resources.share_picker_new_webdrop_subtitle
 import id.homebase.resources.share_picker_next
 import id.homebase.resources.share_picker_send
 import id.homebase.resources.share_to
@@ -94,6 +97,7 @@ fun SharePickerScreen(
     hasFiles: Boolean,
     isSending: Boolean,
     showNewMomentOption: Boolean,
+    showNewWebDropOption: Boolean,
     onTargetSelected: (ShareTarget) -> Unit,
     onCancel: () -> Unit,
 ) {
@@ -240,10 +244,16 @@ fun SharePickerScreen(
 
             HorizontalDivider()
 
-            // A "New Moment" destination sits above the conversation list (only
-            // when files are present and Moments is activated). It's an action,
-            // not a selectable checkbox row, so it dispatches immediately rather
-            // than joining the multi-select set.
+            // "New WebDrop" and "New Moment" destinations sit above the
+            // conversation list (each only when files are present and its
+            // feature is activated). They are actions, not selectable checkbox
+            // rows, so they dispatch immediately rather than joining the
+            // multi-select set. WebDrop first: it is the newer, outward-facing
+            // share (files leave the identity as a link).
+            if (showNewWebDropOption && !isSending && conversationsData.dataReady) {
+                NewWebDropRow(onClick = { onTargetSelected(ShareTarget.NewWebDrop) })
+                HorizontalDivider()
+            }
             if (showNewMomentOption && !isSending && conversationsData.dataReady) {
                 NewMomentRow(onClick = { onTargetSelected(ShareTarget.NewMoment) })
                 HorizontalDivider()
@@ -389,6 +399,46 @@ private fun ShareSendBar(
             FilledTonalButton(onClick = onSend) {
                 Text(buttonText)
             }
+        }
+    }
+}
+
+@Composable
+private fun NewWebDropRow(onClick: () -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(horizontal = 28.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Box(
+            modifier = Modifier
+                .size(48.dp)
+                .background(MaterialTheme.colorScheme.primaryContainer, CircleShape),
+            contentAlignment = Alignment.Center,
+        ) {
+            Icon(
+                imageVector = Icons.Outlined.Redeem,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                modifier = Modifier.size(24.dp),
+            )
+        }
+
+        Spacer(modifier = Modifier.width(12.dp))
+
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = stringResource(MR.string.share_picker_new_webdrop),
+                style = MaterialTheme.typography.bodyLarge,
+                fontWeight = FontWeight.Medium,
+            )
+            Text(
+                text = stringResource(MR.string.share_picker_new_webdrop_subtitle),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
         }
     }
 }

--- a/androidApp/src/main/kotlin/id/homebase/feed/share/ShareReceiverActivity.kt
+++ b/androidApp/src/main/kotlin/id/homebase/feed/share/ShareReceiverActivity.kt
@@ -81,6 +81,9 @@ import id.homebase.imageeditor.ui.DrawScreen
 import id.homebase.core.config.momentsLabeledDrive
 import id.homebase.core.sync.OptionalDriveActivation
 import id.homebase.core.moments.services.MomentCreateFlowState
+import id.homebase.core.config.webDropLabeledDrive
+import id.homebase.core.ui.screens.webdrop.WebDropShareFlowState
+import id.homebase.core.ui.screens.webdrop.model.PickedDropFile
 import id.homebase.core.settings.ThemeState
 import id.homebase.core.settings.UserPreferences
 import id.homebase.core.contactbook.ContactOverrideStore
@@ -131,6 +134,7 @@ class ShareReceiverActivity : ComponentActivity(), KoinComponent {
     private val authConnectionCoordinator: AuthConnectionCoordinator by inject()
     private val momentCreateFlowState: MomentCreateFlowState by inject()
     private val optionalDriveActivation: OptionalDriveActivation by inject()
+    private val webDropShareFlowState: WebDropShareFlowState by inject()
     private val cropResultBus: CropResultBus by inject()
     private val drawResultBus: DrawResultBus by inject()
 
@@ -268,6 +272,9 @@ class ShareReceiverActivity : ComponentActivity(), KoinComponent {
             val momentsActivatedFlow = remember { optionalDriveActivation.isActivatedFlow(momentsLabeledDrive) }
             val momentsActivated by momentsActivatedFlow
                 .collectAsStateWithLifecycle(optionalDriveActivation.isActivated(momentsLabeledDrive))
+            val webDropActivatedFlow = remember { optionalDriveActivation.isActivatedFlow(webDropLabeledDrive) }
+            val webDropActivated by webDropActivatedFlow
+                .collectAsStateWithLifecycle(optionalDriveActivation.isActivated(webDropLabeledDrive))
             val isDarkTheme = if (prefState.theme == ThemeState.System) isSystemInDarkTheme()
             else prefState.theme == ThemeState.Dark
 
@@ -311,12 +318,17 @@ class ShareReceiverActivity : ComponentActivity(), KoinComponent {
                             // share carries files and the feature is activated.
                             showNewMomentOption = sharedContent.hasFiles &&
                                 momentsActivated,
+                            // Same rule for WebDrop: a drop IS its files.
+                            showNewWebDropOption = sharedContent.hasFiles &&
+                                webDropActivated,
                             onTargetSelected = { target ->
                                 when (target) {
                                     is ShareTarget.Conversations ->
                                         onConversationsPicked(target.ids, sharedContent)
                                     ShareTarget.NewMoment ->
                                         startNewMoment(sharedContent)
+                                    ShareTarget.NewWebDrop ->
+                                        startNewWebDrop(sharedContent)
                                 }
                             },
                             onCancel = { finish() },
@@ -565,6 +577,35 @@ class ShareReceiverActivity : ComponentActivity(), KoinComponent {
         }
     }
 
+    /**
+     * Terminal dispatch for the [ShareTarget.NewWebDrop] branch. The shared
+     * files are already materialized to real paths, which is exactly what
+     * [PickedDropFile] wants - seed [WebDropShareFlowState] (a process-wide
+     * Koin singleton the WebDrop view model consumes on init) and hand off to
+     * `Route.WebDrop`; the compose sheet opens there with the files picked, and
+     * TTL / recipient / terms / theme all live in that sheet.
+     */
+    private fun startNewWebDrop(content: SharedContent) {
+        if (!content.hasFiles) {
+            finish()
+            return
+        }
+        webDropShareFlowState.setDraft(
+            content.files.map { shared ->
+                PickedDropFile(
+                    path = shared.path,
+                    name = shared.displayName,
+                    contentType = shared.mimeType,
+                    size = java.io.File(shared.path).length(),
+                )
+            }
+        )
+        Logger.d(tag = COLD_TAG) { "startNewWebDrop: seeded draft with ${content.files.size} files" }
+        // The WebDrop composer owns the temp files now; don't reap share_temp.
+        startActivity(openWebDropComposeIntent())
+        finish()
+    }
+
     private fun sendToMultipleConversations(conversationIds: Set<Uuid>, content: SharedContent) {
         if (isSending) return
         isSending = true
@@ -801,6 +842,19 @@ class ShareReceiverActivity : ComponentActivity(), KoinComponent {
     internal fun openMomentComposeIntent(): Intent =
         Intent(this, MainActivity::class.java).apply {
             data = "homebase-fchat://moment-compose".toUri()
+            flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP
+        }
+
+    /**
+     * Re-opens [MainActivity] on the WebDrop screen. The draft has already been
+     * seeded into [WebDropShareFlowState]; MainActivity.handleIntent reads this
+     * `homebase-fchat://web-drop-compose` deep link and emits the
+     * OpenWebDropCompose navigation event that AppNavHost routes to
+     * `Route.WebDrop`.
+     */
+    internal fun openWebDropComposeIntent(): Intent =
+        Intent(this, MainActivity::class.java).apply {
+            data = "homebase-fchat://web-drop-compose".toUri()
             flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP
         }
 

--- a/androidApp/src/main/kotlin/id/homebase/feed/share/ShareTarget.kt
+++ b/androidApp/src/main/kotlin/id/homebase/feed/share/ShareTarget.kt
@@ -11,9 +11,12 @@ import kotlin.uuid.Uuid
  * - [Conversations] runs the chat send path ([ChatMessageSenderService]).
  * - [NewMoment] seeds the moments composer draft and hands off to
  *   `Route.MomentCompose`, reusing the same media-upload pipeline downstream.
+ * - [NewWebDrop] seeds the WebDrop share draft and hands off to `Route.WebDrop`,
+ *   where the compose sheet opens with the shared files already picked.
  */
 @OptIn(ExperimentalUuidApi::class)
 sealed interface ShareTarget {
     data class Conversations(val ids: Set<Uuid>) : ShareTarget
     data object NewMoment : ShareTarget
+    data object NewWebDrop : ShareTarget
 }

--- a/homebase-common/src/commonMain/composeResources/values-da/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values-da/strings.xml
@@ -686,6 +686,8 @@
     <string name="chat_message_record_video">Optag video</string>
     <string name="share_picker_next">Næste</string>
     <string name="share_picker_send">Send</string>
+    <string name="share_picker_new_webdrop">Nyt WebDrop</string>
+    <string name="share_picker_new_webdrop_subtitle">Del som et selvdestruerende link</string>
     <string name="share_picker_new_moment">Nyt øjeblik</string>
     <string name="share_picker_new_moment_subtitle">Del til dine Moments</string>
     <string name="chat_message_emoji_options">Emoji menu</string>

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -722,6 +722,8 @@
     <string name="chat_message_record_video">Record video</string>
     <string name="share_picker_next">Next</string>
     <string name="share_picker_send">Send</string>
+    <string name="share_picker_new_webdrop">New WebDrop</string>
+    <string name="share_picker_new_webdrop_subtitle">Share as a self-destructing link</string>
     <string name="share_picker_new_moment">New Moment</string>
     <string name="share_picker_new_moment_subtitle">Share to your Moments</string>
     <string name="chat_message_emoji_options">Emoji options</string>

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/notifications/NotificationNavigationEvent.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/notifications/NotificationNavigationEvent.kt
@@ -42,4 +42,12 @@ sealed class NotificationNavigationEvent {
      * this event only steers the back stack into the composer.
      */
     data object OpenMomentCompose : NotificationNavigationEvent()
+
+    /**
+     * Navigate to the WebDrop screen after the user shares files into "New
+     * WebDrop" from the OS share sheet: the share flow has already seeded
+     * `WebDropShareFlowState`, so this event only steers the back stack there —
+     * the WebDrop view model opens the composer with the seeded files on init.
+     */
+    data object OpenWebDropCompose : NotificationNavigationEvent()
 }

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/notifications/NotificationService.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/notifications/NotificationService.kt
@@ -729,6 +729,11 @@ class NotificationService(
         _navigationEvents.trySend(NotificationNavigationEvent.OpenMomentCompose)
     }
 
+    /** Navigate to the WebDrop composer (used for the "New WebDrop" share deep link). */
+    fun navigateToWebDropCompose() {
+        _navigationEvents.trySend(NotificationNavigationEvent.OpenWebDropCompose)
+    }
+
     /** Displays a rich notification using platform-specific APIs. */
     private fun showRichNotification(data: RichNotificationData) {
         try {

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
@@ -114,6 +114,7 @@ import id.homebase.core.ui.screens.vault.settings.VaultSettingsViewModel
 import id.homebase.core.ui.screens.vault.VaultUploaderService
 import id.homebase.core.ui.screens.vault.VaultViewModel
 import id.homebase.core.ui.screens.webdrop.WebDropService
+import id.homebase.core.ui.screens.webdrop.WebDropShareFlowState
 import id.homebase.core.ui.screens.webdrop.WebDropStream
 import id.homebase.core.ui.screens.webdrop.WebDropViewModel
 import id.homebase.core.ui.screens.vault.note.VaultNoteEditorViewModel
@@ -684,6 +685,7 @@ val appModule = module {
             get<EmailStream>().apply { reset(); start() }
                 get<VaultStream>().apply { reset(); start() }
                 get<WebDropStream>().apply { reset(); start() }
+                get<WebDropShareFlowState>().clear()
                 // Contact Book: re-seed prefs + reload the contact list for the new
                 // identity (singletons survive logout — clear stale in-memory state).
                 get<ContactBookPreferences>().reset()
@@ -844,6 +846,7 @@ val appModule = module {
 
     singleOf(::WebDropStream)
     single { WebDropService(get(), get(), get()) }
+    single { WebDropShareFlowState() }
 
     // Sticker library (saved "My Stickers" tray) — mirrors the Vault singles. The
     // Stickers drive is optional/on-demand (mounted lazily by StickerService), so it
@@ -1192,6 +1195,7 @@ val appModule = module {
             webDropStream = get(),
             webDropPermissionViewModel = get(WebDropPermissionQualifier),
             optionalDriveActivation = get(),
+            webDropShareFlowState = get(),
         )
     }
     viewModel {

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
@@ -608,6 +608,16 @@ fun AppNavHost(
                         navController.navigate(Route.MomentCompose)
                     }
                 }
+
+                is NotificationNavigationEvent.OpenWebDropCompose -> {
+                    Logger.i(tag = "AppNavHost") { "OpenWebDropCompose received" }
+                    // The share flow seeded WebDropShareFlowState before launching us;
+                    // WebDropViewModel consumes it on init and opens the compose sheet.
+                    // The share picker only offers "New WebDrop" when the drive is
+                    // activated, so no extra gate here - and if it ever fires without
+                    // activation, the WebDrop screen itself shows onboarding.
+                    openWebDrop()
+                }
             }
         }
     }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/webdrop/WebDropShareFlowState.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/webdrop/WebDropShareFlowState.kt
@@ -1,0 +1,30 @@
+package id.homebase.core.ui.screens.webdrop
+
+import id.homebase.core.ui.screens.webdrop.model.PickedDropFile
+
+/**
+ * In-memory hand-off from the platform share sheet into the WebDrop composer.
+ * The share flow materializes the shared files to real paths, seeds this, and
+ * deep-links into `Route.WebDrop`; [WebDropViewModel] consumes the draft on
+ * init and opens the compose sheet with the files already picked.
+ *
+ * Consume-once by design — unlike the moments draft there is no second screen
+ * that needs to rehydrate from it, and a stale draft must never resurface on a
+ * later, unrelated visit to the WebDrop screen. A Koin singleton, so it is
+ * [clear]ed on identity switch alongside the other WebDrop singletons.
+ */
+class WebDropShareFlowState {
+
+    private var draft: List<PickedDropFile>? = null
+
+    fun setDraft(files: List<PickedDropFile>) {
+        draft = files.takeIf { it.isNotEmpty() }
+    }
+
+    /** Returns the seeded files and forgets them. */
+    fun consume(): List<PickedDropFile>? = draft.also { draft = null }
+
+    fun clear() {
+        draft = null
+    }
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/webdrop/WebDropViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/webdrop/WebDropViewModel.kt
@@ -31,6 +31,7 @@ class WebDropViewModel(
     private val webDropStream: WebDropStream,
     private val webDropPermissionViewModel: ExtendPermissionViewModel,
     private val optionalDriveActivation: OptionalDriveActivation,
+    webDropShareFlowState: WebDropShareFlowState,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(WebDropUiState())
@@ -44,6 +45,12 @@ class WebDropViewModel(
         get() = webDropPermissionViewModel
 
     init {
+        // Files shared in from the OS share sheet: the share flow seeded these before
+        // deep-linking here, so land straight in the composer with them picked.
+        webDropShareFlowState.consume()?.let { shared ->
+            _uiState.update { it.copy(composeOpen = true, pickedFiles = shared) }
+        }
+
         viewModelScope.launch {
             optionalDriveActivation.isActivatedFlow(webDropLabeledDrive).collect { activated ->
                 _uiState.update { it.copy(driveActivated = activated) }


### PR DESCRIPTION
The share picker gains a **New WebDrop** action row directly above **New Moment** — share files into the Homebase app, tap it, and land in the WebDrop composer with the files already picked; TTL, recipient, terms and theme all live in the sheet as usual.

Follows the Moment share hand-off pattern exactly:

- `ShareTarget.NewWebDrop` + picker row (gated the same way: share carries files ∧ drive activated via `OptionalDriveActivation`)
- `WebDropShareFlowState` — Koin singleton draft, cleared on identity switch alongside the other WebDrop singletons; **consume-once**, since no second screen rehydrates from it and a stale draft must never resurface on a later visit
- Deep link `homebase-fchat://web-drop-compose` → `MainActivity.handleIntent` → `OpenWebDropCompose` nav event → `Route.WebDrop`
- `WebDropViewModel` consumes the draft on init and opens the compose sheet

The shared files are already materialized to real paths by the share extractor, which is exactly what `PickedDropFile` wants — the conversion is a straight field mapping.

Strings EN/DA. Verified: jvm + wasmJs + Android compile targets green; `homebase-common` / `homebase-core` / `homebase-chat` jvmTest green (incl. Konsist), branch on latest main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ePkqms6AQdGGUWsVrGyzx