### PR TITLE
Suggest group members by typing "@" in the composer

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
@@ -1691,6 +1691,11 @@ fun ConversationContent(
                                 payloadRenderers = payloadRenderers,
                                 onPayloadRenderersChange = { payloadRenderers = it },
                                 onSendMessage = { text, attachments -> performSend(text, attachments) },
+                                mentionTargets = if (conversation.conversation.isGroupConversation) {
+                                    conversation.participants
+                                } else {
+                                    emptyList()
+                                },
                                 onEmojiClick = {
                                     showAttachmentSheet = false
                                     if (showEmojiSheet && !isKeyboardVisible) {

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MentionAutocomplete.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MentionAutocomplete.kt
@@ -1,0 +1,118 @@
+package id.homebase.chat.widget
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.mohamedrejeb.richeditor.model.RichTextState
+import id.homebase.chat.data.ContactUiModel
+import id.homebase.core.widget.ComposerAutocomplete
+import id.homebase.core.widget.ComposerAutocompleteController
+
+private const val MentionTriggerId = "mention"
+
+private const val MaxMentionSuggestions = 5
+
+/**
+ * `@mention` typeahead over a group's members. A mention is plain text — `@<odinId> ` — because
+ * that is what the web client sends and linkifies; nothing rides the message header.
+ *
+ * Ships on every platform, unlike the `:` emoji sibling — no soft keyboard can tell you who is in
+ * this group. Empty [targets] leaves the trigger unregistered, and that is the 1:1 gate.
+ */
+@Composable
+fun MentionAutocomplete(
+    state: RichTextState,
+    controller: ComposerAutocompleteController,
+    targets: List<ContactUiModel>,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+) {
+    ComposerAutocomplete(
+        state = state,
+        controller = controller,
+        triggerId = MentionTriggerId,
+        triggerChar = '@',
+        suggestionsFor = { query -> mentionSuggestions(query, targets) },
+        replacementFor = { "@${it.odinId.domainName} " },
+        modifier = modifier,
+        enabled = enabled && targets.isNotEmpty(),
+    ) { target, selected ->
+        MentionSuggestionRow(target = target, selected = selected)
+    }
+}
+
+/** [query] is the text after `@`. An exact hit is dropped so a fully typed handle leaves Enter
+ *  free to send the message instead of re-committing what is already there. */
+internal fun mentionSuggestions(
+    query: String,
+    targets: List<ContactUiModel>,
+): List<ContactUiModel> {
+    if (targets.isEmpty()) return emptyList()
+
+    if (query.isEmpty()) {
+        return targets.sortedBy { it.name.lowercase() }.take(MaxMentionSuggestions)
+    }
+
+    return targets
+        .mapNotNull { target -> matchRank(query, target)?.let { target to it } }
+        .sortedWith(compareBy({ it.second }, { it.first.name.lowercase() }))
+        .map { it.first }
+        .take(MaxMentionSuggestions)
+}
+
+private fun matchRank(query: String, target: ContactUiModel): Int? {
+    val name = target.name
+    val handle = target.odinId.domainName
+    if (query.equals(name, ignoreCase = true) || query.equals(handle, ignoreCase = true)) return null
+    return when {
+        name.startsWith(query, ignoreCase = true) -> 0
+        handle.startsWith(query, ignoreCase = true) -> 1
+        name.contains(query, ignoreCase = true) -> 2
+        handle.contains(query, ignoreCase = true) -> 3
+        else -> null
+    }
+}
+
+@Composable
+private fun MentionSuggestionRow(target: ContactUiModel, selected: Boolean) {
+    val handle = target.odinId.domainName
+    Row(
+        // Tapped on mobile, not just arrowed through: 48dp is the M3 minimum touch target.
+        modifier = Modifier
+            .fillMaxWidth()
+            .defaultMinSize(minHeight = 48.dp)
+            .padding(horizontal = 12.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Text(
+            text = target.name,
+            style = MaterialTheme.typography.bodyMedium,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.weight(1f, fill = false),
+        )
+        if (!target.name.equals(handle, ignoreCase = true)) {
+            Text(
+                text = handle,
+                style = MaterialTheme.typography.bodySmall,
+                color = if (selected) {
+                    MaterialTheme.colorScheme.onSecondaryContainer
+                } else {
+                    MaterialTheme.colorScheme.onSurfaceVariant
+                },
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+    }
+}

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageInputBar.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageInputBar.kt
@@ -113,6 +113,7 @@ import com.mohamedrejeb.richeditor.ui.material3.RichTextEditorDefaults
 import id.homebase.api.client.link.LinkPreviewProvider
 import id.homebase.chat.conversationlist.RecordingData
 import id.homebase.chat.conversationlist.shouldSendComposerMessage
+import id.homebase.chat.data.ContactUiModel
 import id.homebase.chat.services.renderer.PayloadRenderer
 import id.homebase.chat.services.renderer.LinkPreviewRenderer
 import id.homebase.core.audio.rememberRecordAudioPermissionState
@@ -211,6 +212,9 @@ fun MessageInputBar(
     payloadRenderers: List<PayloadRenderer>,
     onPayloadRenderersChange: (List<PayloadRenderer>) -> Unit,
     onSendMessage: (String, List<PayloadRenderer>) -> Unit,
+    /** Group members offered by the `@` typeahead. Empty in a 1:1, which leaves the trigger
+     *  unregistered so no mention affordance appears there. */
+    mentionTargets: List<ContactUiModel> = emptyList(),
     onPasteImage: ((ByteArray) -> Unit)? = null,
     onCancelEdit: () -> Unit,
 ) {
@@ -308,6 +312,7 @@ fun MessageInputBar(
                     .padding(bottom = 16.dp),
                 focusRequester = focusRequester,
                 state = textFieldState,
+                mentionTargets = mentionTargets,
                 payloadRenderers = payloadRenderers,
                 onCancelAttachment = ::cancelRenderer,
                 editExistingMode = editExistingMode,
@@ -330,6 +335,7 @@ fun MessageInputBar(
                 ),
                 focusRequester = focusRequester,
                 state = textFieldState,
+                mentionTargets = mentionTargets,
                 editExistingMode = editExistingMode,
                 payloadRenderers = payloadRenderers,
                 recordingData = recordingData,
@@ -364,6 +370,7 @@ fun MessageTextFieldExpanded(
     modifier: Modifier = Modifier,
     focusRequester: FocusRequester,
     state: RichTextState,
+    mentionTargets: List<ContactUiModel>,
     editExistingMode: Boolean,
     payloadRenderers: List<PayloadRenderer>,
     onCancelAttachment: (id: String) -> Unit,
@@ -508,6 +515,12 @@ fun MessageTextFieldExpanded(
                 controller = autocomplete,
                 enabled = isFieldFocused && isDesktopOrWeb(),
             )
+            MentionAutocomplete(
+                state = state,
+                controller = autocomplete,
+                targets = mentionTargets,
+                enabled = isFieldFocused,
+            )
         }
         Spacer(modifier = Modifier.height(8.dp))
         Row(
@@ -570,6 +583,7 @@ fun MessageTextFieldCompact(
     modifier: Modifier = Modifier,
     focusRequester: FocusRequester,
     state: RichTextState,
+    mentionTargets: List<ContactUiModel>,
     payloadRenderers: List<PayloadRenderer>,
     recordingData: RecordingData?,
     onCancelAttachment: (id: String) -> Unit,
@@ -906,6 +920,12 @@ fun MessageTextFieldCompact(
                                 state = state,
                                 controller = autocomplete,
                                 enabled = isKeyboardFocused && isDesktopOrWeb(),
+                            )
+                            MentionAutocomplete(
+                                state = state,
+                                controller = autocomplete,
+                                targets = mentionTargets,
+                                enabled = isKeyboardFocused,
                             )
                         }
                         if (showRecordingButton) {

--- a/homebase-chat/src/commonTest/kotlin/id/homebase/chat/widget/ComposerMentionTypeaheadTest.kt
+++ b/homebase-chat/src/commonTest/kotlin/id/homebase/chat/widget/ComposerMentionTypeaheadTest.kt
@@ -1,6 +1,11 @@
 package id.homebase.chat.widget
 
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -12,6 +17,7 @@ import androidx.compose.ui.input.key.type
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsFocused
+import androidx.compose.ui.test.getBoundsInRoot
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
@@ -21,12 +27,14 @@ import androidx.compose.ui.test.pressKey
 import androidx.compose.ui.test.requestFocus
 import androidx.compose.ui.test.runComposeUiTest
 import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.unit.dp
 import com.mohamedrejeb.richeditor.annotation.ExperimentalRichTextApi
 import com.mohamedrejeb.richeditor.model.RichTextState
 import com.mohamedrejeb.richeditor.model.rememberRichTextState
 import com.mohamedrejeb.richeditor.ui.material3.RichTextEditor
 import id.homebase.api.common.OdinId
 import id.homebase.chat.data.ContactUiModel
+import id.homebase.core.widget.ComposerAutocompleteTag
 import id.homebase.core.widget.EmojiAutocomplete
 import id.homebase.core.widget.rememberComposerAutocompleteController
 import kotlin.test.Test
@@ -76,6 +84,30 @@ class ComposerMentionTypeaheadTest {
                 MentionAutocomplete(state = state, controller = controller, targets = targets)
                 if (withEmoji) {
                     EmojiAutocomplete(state = state, controller = controller, enabled = true)
+                }
+            }
+        }
+    }
+
+    /** [topSpacer] null pushes the composer to the bottom of the window; a small value starves it
+     *  of room above. */
+    private fun spacedHarness(
+        topSpacer: androidx.compose.ui.unit.Dp?,
+        capture: (RichTextState) -> Unit,
+    ): @Composable () -> Unit = {
+        MaterialTheme {
+            val state = rememberRichTextState()
+            val controller = rememberComposerAutocompleteController()
+            capture(state)
+            Column(Modifier.fillMaxSize()) {
+                if (topSpacer == null) Spacer(Modifier.weight(1f)) else Spacer(Modifier.height(topSpacer))
+                Box(Modifier.fillMaxWidth().testTag("anchor")) {
+                    RichTextEditor(state = state, modifier = Modifier.fillMaxWidth())
+                    MentionAutocomplete(
+                        state = state,
+                        controller = controller,
+                        targets = GroupMembers,
+                    )
                 }
             }
         }
@@ -242,6 +274,43 @@ class ComposerMentionTypeaheadTest {
 
         onNodeWithTag("editor").assertIsFocused()
         assertEquals("@alice.example.com ", state.annotatedString.text)
+    }
+
+    /**
+     * A composer pinned to the bottom is the geometry a soft keyboard produces, and the one the
+     * list has to survive on mobile: it must open into the space above the composer, not under it.
+     */
+    @Test
+    fun theListOpensAboveAComposerPinnedToTheBottom() = runComposeUiTest {
+        lateinit var state: RichTextState
+        setContent(spacedHarness(topSpacer = null) { state = it })
+
+        runOnIdle { state.addTextAfterSelection("@") }
+        awaitText("Alice Anderson")
+
+        val anchor = onNodeWithTag("anchor").getBoundsInRoot()
+        val list = onNodeWithTag(ComposerAutocompleteTag).getBoundsInRoot()
+        assertTrue(
+            list.bottom <= anchor.top,
+            "list must sit above the composer; list=$list anchor=$anchor",
+        )
+    }
+
+    /** With no room above, the list flips below the anchor rather than being clipped off-screen. */
+    @Test
+    fun theListFlipsBelowWhenThereIsNoRoomAbove() = runComposeUiTest {
+        lateinit var state: RichTextState
+        setContent(spacedHarness(topSpacer = 40.dp) { state = it })
+
+        runOnIdle { state.addTextAfterSelection("@") }
+        awaitText("Alice Anderson")
+
+        val anchor = onNodeWithTag("anchor").getBoundsInRoot()
+        val list = onNodeWithTag(ComposerAutocompleteTag).getBoundsInRoot()
+        assertTrue(
+            list.top >= anchor.bottom,
+            "list must fall back below the composer; list=$list anchor=$anchor",
+        )
     }
 
     /** Both triggers live on one RichTextState and share one key controller. */

--- a/homebase-chat/src/commonTest/kotlin/id/homebase/chat/widget/ComposerMentionTypeaheadTest.kt
+++ b/homebase-chat/src/commonTest/kotlin/id/homebase/chat/widget/ComposerMentionTypeaheadTest.kt
@@ -1,0 +1,263 @@
+package id.homebase.chat.widget
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsFocused
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performKeyInput
+import androidx.compose.ui.test.pressKey
+import androidx.compose.ui.test.requestFocus
+import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.text.TextRange
+import com.mohamedrejeb.richeditor.annotation.ExperimentalRichTextApi
+import com.mohamedrejeb.richeditor.model.RichTextState
+import com.mohamedrejeb.richeditor.model.rememberRichTextState
+import com.mohamedrejeb.richeditor.ui.material3.RichTextEditor
+import id.homebase.api.common.OdinId
+import id.homebase.chat.data.ContactUiModel
+import id.homebase.core.widget.EmojiAutocomplete
+import id.homebase.core.widget.rememberComposerAutocompleteController
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+private fun member(handle: String, name: String) =
+    ContactUiModel.fallbackFor(OdinId(handle)).copy(name = name)
+
+private val GroupMembers = listOf(
+    member("alice.example.com", "Alice Anderson"),
+    member("bob.example.com", "Bob Brown"),
+)
+
+@OptIn(ExperimentalTestApi::class, ExperimentalRichTextApi::class)
+class ComposerMentionTypeaheadTest {
+
+    /** Mirrors the composer: a Box wrapping only the editor anchors the popup, and the editor's
+     *  preview-key handler gives the autocomplete first refusal before Enter-to-send. */
+    private fun harness(
+        targets: List<ContactUiModel> = GroupMembers,
+        withEmoji: Boolean = false,
+        onSend: () -> Unit = {},
+        capture: (RichTextState) -> Unit,
+    ): @Composable () -> Unit = {
+        MaterialTheme {
+            val state = rememberRichTextState()
+            val controller = rememberComposerAutocompleteController()
+            capture(state)
+            Box {
+                RichTextEditor(
+                    state = state,
+                    modifier = Modifier
+                        .onPreviewKeyEvent { event ->
+                            if (controller.handleKeyEvent(event)) {
+                                true
+                            } else if (event.key == Key.Enter && event.type == KeyEventType.KeyDown) {
+                                onSend()
+                                true
+                            } else {
+                                false
+                            }
+                        }
+                        .testTag("editor"),
+                )
+                MentionAutocomplete(state = state, controller = controller, targets = targets)
+                if (withEmoji) {
+                    EmojiAutocomplete(state = state, controller = controller, enabled = true)
+                }
+            }
+        }
+    }
+
+    private fun androidx.compose.ui.test.ComposeUiTest.awaitText(text: String) =
+        waitUntil(timeoutMillis = 10_000) {
+            onAllNodes(hasText(text, substring = true)).fetchSemanticsNodes().isNotEmpty()
+        }
+
+    private fun androidx.compose.ui.test.ComposeUiTest.assertNoText(text: String) =
+        assertEquals(0, onAllNodes(hasText(text, substring = true)).fetchSemanticsNodes().size)
+
+    @Test
+    fun aBareTriggerListsTheGroupMembers() = runComposeUiTest {
+        lateinit var state: RichTextState
+        setContent(harness { state = it })
+
+        runOnIdle { state.addTextAfterSelection("@") }
+        awaitText("Alice Anderson")
+
+        onNodeWithText("Bob Brown", substring = true).assertExists()
+    }
+
+    @Test
+    fun typingFiltersTheList() = runComposeUiTest {
+        lateinit var state: RichTextState
+        setContent(harness { state = it })
+
+        runOnIdle { state.addTextAfterSelection("@bo") }
+        awaitText("Bob Brown")
+
+        assertNoText("Alice Anderson")
+    }
+
+    /** The 1:1 gate: no members, no trigger, no affordance. */
+    @Test
+    fun noMembersMeansTheTriggerNeverOpens() = runComposeUiTest {
+        lateinit var state: RichTextState
+        setContent(harness(targets = emptyList()) { state = it })
+
+        runOnIdle { state.addTextAfterSelection("@ali") }
+        waitForIdle()
+
+        assertNoText("Alice Anderson")
+        assertEquals("@ali", state.annotatedString.text)
+        // Not merely "no list": the trigger is never registered, so richeditor does not paint the
+        // live `@ali` token as a pending mention either.
+        assertNull(state.activeTriggerQuery)
+    }
+
+    @Test
+    fun committingInsertsTheHandleAndLeavesTheCaretAfterIt() = runComposeUiTest {
+        lateinit var state: RichTextState
+        setContent(harness { state = it })
+
+        runOnIdle { state.addTextAfterSelection("hey @ali") }
+        awaitText("Alice Anderson")
+
+        onNodeWithText("Alice Anderson", substring = true).performClick()
+        waitForIdle()
+
+        assertEquals("hey @alice.example.com ", state.annotatedString.text)
+        assertEquals(TextRange(state.annotatedString.text.length), state.selection)
+    }
+
+    /** The plain-text mention has to survive the markdown the composer actually sends. */
+    @Test
+    fun theCommittedMentionSurvivesTheMarkdownSerialisation() = runComposeUiTest {
+        lateinit var state: RichTextState
+        setContent(harness { state = it })
+
+        runOnIdle { state.addTextAfterSelection("hey @ali") }
+        awaitText("Alice Anderson")
+
+        onNodeWithText("Alice Anderson", substring = true).performClick()
+        waitForIdle()
+
+        assertTrue(
+            state.toMarkdown().contains("@alice.example.com"),
+            "got: ${state.toMarkdown()}",
+        )
+    }
+
+    /** Display names and message text carry emoji, so the commit goes through the shared
+     *  surrogate-safe splice rather than a raw replaceTextRange. */
+    @Test
+    fun commitIsSurrogateSafeAroundAdjacentEmoji() = runComposeUiTest {
+        lateinit var state: RichTextState
+        setContent(harness { state = it })
+
+        runOnIdle { state.addTextAfterSelection("🎉 @ali") }
+        awaitText("Alice Anderson")
+
+        onNodeWithText("Alice Anderson", substring = true).performClick()
+        waitForIdle()
+
+        assertEquals("🎉 @alice.example.com ", state.annotatedString.text)
+    }
+
+    @Test
+    fun theTriggerNeverOpensInsideAWord() = runComposeUiTest {
+        lateinit var state: RichTextState
+        setContent(harness { state = it })
+
+        runOnIdle { state.addTextAfterSelection("write to bob@ali") }
+        waitForIdle()
+
+        assertNoText("Alice Anderson")
+    }
+
+    /** A fully typed handle drops out of the list, so Enter still sends the message. */
+    @Test
+    fun aFullyTypedHandleLeavesEnterFreeToSend() = runComposeUiTest {
+        lateinit var state: RichTextState
+        var sends = 0
+        setContent(harness(onSend = { sends++ }) { state = it })
+
+        onNodeWithTag("editor").requestFocus()
+        runOnIdle { state.addTextAfterSelection("hey @alice.example.com") }
+        waitForIdle()
+
+        onNodeWithTag("editor").performKeyInput { pressKey(Key.Enter) }
+        waitForIdle()
+
+        assertEquals(1, sends)
+    }
+
+    @Test
+    fun arrowKeysAndEnterCommitTheHighlightedMember() = runComposeUiTest {
+        lateinit var state: RichTextState
+        var sends = 0
+        setContent(harness(onSend = { sends++ }) { state = it })
+
+        onNodeWithTag("editor").requestFocus()
+        runOnIdle { state.addTextAfterSelection("@") }
+        awaitText("Bob Brown")
+
+        onNodeWithTag("editor").performKeyInput { pressKey(Key.DirectionDown) }
+        waitForIdle()
+        onNodeWithTag("editor").performKeyInput { pressKey(Key.Enter) }
+        waitForIdle()
+
+        assertEquals(0, sends, "Enter must commit the member, not send the message")
+        assertEquals("@bob.example.com ", state.annotatedString.text)
+    }
+
+    /**
+     * Tapping a row must not move focus off the editor — on mobile that focus is what holds the
+     * soft keyboard open. This asserts the focus only; no IME runs in a JVM test.
+     */
+    @Test
+    fun tappingASuggestionLeavesFocusOnTheEditor() = runComposeUiTest {
+        lateinit var state: RichTextState
+        setContent(harness { state = it })
+
+        onNodeWithTag("editor").requestFocus()
+        runOnIdle { state.addTextAfterSelection("@ali") }
+        awaitText("Alice Anderson")
+        onNodeWithTag("editor").assertIsFocused()
+
+        onNodeWithText("Alice Anderson", substring = true).performClick()
+        waitForIdle()
+
+        onNodeWithTag("editor").assertIsFocused()
+        assertEquals("@alice.example.com ", state.annotatedString.text)
+    }
+
+    /** Both triggers live on one RichTextState and share one key controller. */
+    @Test
+    fun theMentionAndEmojiTriggersCoexist() = runComposeUiTest {
+        lateinit var state: RichTextState
+        setContent(harness(withEmoji = true) { state = it })
+
+        runOnIdle { state.addTextAfterSelection("@ali") }
+        awaitText("Alice Anderson")
+
+        runOnIdle { state.addTextAfterSelection(" ") }
+        waitForIdle()
+        assertNoText("Alice Anderson")
+
+        runOnIdle { state.addTextAfterSelection(":par") }
+        awaitText(":party:")
+    }
+}

--- a/homebase-chat/src/commonTest/kotlin/id/homebase/chat/widget/MentionSuggestionsTest.kt
+++ b/homebase-chat/src/commonTest/kotlin/id/homebase/chat/widget/MentionSuggestionsTest.kt
@@ -1,0 +1,86 @@
+package id.homebase.chat.widget
+
+import id.homebase.api.common.OdinId
+import id.homebase.chat.data.ContactUiModel
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+private fun member(handle: String, name: String) =
+    ContactUiModel.fallbackFor(OdinId(handle)).copy(name = name)
+
+private val Alice = member("alice.example.com", "Alice Anderson")
+private val Bob = member("bob.example.com", "Bob Brown")
+private val Carol = member("carol.sample.com", "Carol Clark")
+private val Dave = member("dave.example.com", "Dave Davis")
+private val Erin = member("erin.example.com", "Erin Evans")
+private val Frank = member("frank.example.com", "Frank Fisher")
+
+private val Group = listOf(Erin, Alice, Dave, Bob, Carol, Frank)
+
+private fun handles(items: List<ContactUiModel>) = items.map { it.odinId.domainName }
+
+class MentionSuggestionsTest {
+
+    @Test
+    fun anEmptyQueryListsTheGroupAlphabetically() {
+        assertEquals(
+            listOf(Alice, Bob, Carol, Dave, Erin).let(::handles),
+            handles(mentionSuggestions("", Group)),
+        )
+    }
+
+    @Test
+    fun theListIsCappedAtFive() {
+        assertEquals(5, mentionSuggestions("", Group).size)
+        assertEquals(5, mentionSuggestions("e", Group).size)
+    }
+
+    @Test
+    fun matchingIsCaseInsensitive() {
+        assertEquals(handles(listOf(Alice)), handles(mentionSuggestions("ali", Group)))
+        assertEquals(handles(listOf(Alice)), handles(mentionSuggestions("ALI", Group)))
+    }
+
+    @Test
+    fun aHandleMatchesAsWellAsAName() {
+        assertEquals(handles(listOf(Carol)), handles(mentionSuggestions("carol.sam", Group)))
+    }
+
+    @Test
+    fun aNamePrefixOutranksASubstring() {
+        val bea = member("zeta.example.com", "Bea Baker")
+        val substringOnly = member("abbey.example.com", "Abbey Abbott")
+        val ranked = mentionSuggestions("b", listOf(substringOnly, bea))
+        assertEquals(handles(listOf(bea, substringOnly)), handles(ranked))
+    }
+
+    @Test
+    fun aNameMatchOutranksAHandleMatch() {
+        val byName = member("zulu.example.com", "Quinn Quill")
+        val byHandle = member("quinn.example.com", "Zoe Zimmer")
+        assertEquals(
+            handles(listOf(byName, byHandle)),
+            handles(mentionSuggestions("quinn", listOf(byHandle, byName))),
+        )
+    }
+
+    /** A fully typed handle must leave Enter free to send, not re-commit what is already there. */
+    @Test
+    fun anExactHandleOrNameIsDropped() {
+        assertTrue(mentionSuggestions("alice.example.com", Group).isEmpty())
+        assertTrue(mentionSuggestions("Alice Anderson", Group).isEmpty())
+        assertTrue(mentionSuggestions("ALICE.EXAMPLE.COM", Group).isEmpty())
+    }
+
+    @Test
+    fun aNonMatchingQueryYieldsNothing() {
+        assertTrue(mentionSuggestions("zzz", Group).isEmpty())
+    }
+
+    @Test
+    fun noMembersMeansNoSuggestions() {
+        assertTrue(mentionSuggestions("", emptyList()).isEmpty())
+        assertTrue(mentionSuggestions("a", emptyList()).isEmpty())
+    }
+}


### PR DESCRIPTION
Closes #1403. Builds on #1413's `ComposerAutocomplete<T>`.

Typing `@` in a **group** conversation opens a list of that group's members; typing on filters it,
↑/↓ move, Enter/Tab commit, Esc dismisses, a tap or click commits. A 1:1 gets no `@` affordance.

## Open question 1: plain text or structured? — plain text, decided from the web client

The web chat client sends a mention as **plain body text**, `@<odinId>` plus a trailing space.
Nothing rides the message header. Evidence, all in `dotyoucore-js`:

| what | where |
| --- | --- |
| the chat composer wires the mention dropdown into `VolatileInput` — a `contentEditable` div, not the Slate rich-text editor | `packages/apps/chat-app/src/components/Chat/Composer/ChatComposer.tsx:217` |
| candidates = `useAllContacts()` filtered to the conversation's `recipients` | `.../Composer/ConversationMentionDropdown.tsx:19-26` |
| **the insert: ``onInput(`@${odinId} `)``** | `packages/common/common-app/src/form/VolatileInput/MentionDropdown.tsx:41` |
| the odinId, not the display name; list capped at 5; row is `{name} ({odinId})` | `MentionDropdown.tsx:41, 82, 92` |
| on receipt, a **regex linkifier over the plain body** — `/(?:^|\s|[\r\n])@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/` → `<a href={`https://${odinId}`}>` | `packages/apps/chat-app/src/components/Chat/Detail/ChatMessageItem.tsx:181-185, 232-247` |

There *is* a structured mention in that repo — `packages/common/rich-text-editor/src/editor/Mention/*`
— but it belongs to the feed/mail/owner rich-text editor. **Chat does not use it.** A receiver
recognises a chat mention purely by shape, so there is nothing for a descriptor to carry and
nothing for another client to learn. Plain text it is, and per CLAUDE.md's typed-message rules a
descriptor here would have been duplicating envelope fields anyway.

Three deliberate deviations from web, all in `mentionSuggestions`:

- **Matching is case-insensitive.** Web uses `String.includes`, so typing `ali` there does not find
  `Alice`. That is a bug, not a baseline.
- **A bare `@` lists the group** (alphabetically, capped at 5). Web requires a character first
  because its dropdown is over *all* contacts; a group's member list is bounded, and #1403's
  acceptance asks for exactly this.
- **Ranked** (name-prefix → handle-prefix → name-substring → handle-substring, then alphabetical)
  rather than left in contact order, so a bare `@` is deterministic.

Web's exact-match exclusion is **kept**, and the reason is worth stating: without it, typing a full
handle and pressing Enter re-commits the handle instead of sending the message.

## Open questions 2 and 3: both deferred, both filed

- **#1417 — does a mention notify through a mute?** Deferred. It touches the notification/mute path,
  not the composer, and because the format is plain text it has to scan the body rather than read a
  descriptor. Independently reviewable. I did **not** research the web notification path; #1417 says so.
- **#1418 — render a mention distinctly in the bubble.** Deferred, and it is *not* trivial. Bubbles
  render through `ChatMarkdown` (mikepenz over `org.jetbrains:markdown`, CommonMark), which does not
  linkify a bare `@alice.example.com` — GFM's email autolink needs a local part before the `@`. So a
  mention lands as plain text today, where web shows a link. Fixing it means covering all three
  rendering shapes `MarkdownRenderer.kt:101-118` documents, under the constraint that
  `MessageBubbleRaw`'s timestamp-tuck `Layout` reads the inline shape's `TextLayoutResult` during its
  own measure pass. Plus deciding the tap action.

**This means a mention you send from this build renders as plain text on this client until #1418
lands.** It renders as a link in the web client today, because the linkifier there is receive-side.

## Did `ComposerAutocomplete<T>` hold up?

Yes — `homebase-common` is **untouched by this PR**. The second trigger is one new file,
`MentionAutocomplete.kt` (118 lines: the wiring, the ranking, and an M3 row), wiring the same four
parameters as the emoji consumer. For scale, the first trigger was 119 lines across
`EmojiAutocomplete.kt` + `EmojiShortcodeSuggestions.kt`. The second cost the same as the first,
which is what #1413 predicted.

Two limits found, neither worth widening the component for:

- `suggestionsFor` is re-run on query change only (`LaunchedEffect(query?.query)`), so a suggestion
  source that mutates mid-query goes stale. Here the member list is settled before you type, and
  `enabled = targets.isNotEmpty()` means an unsettled one registers no trigger at all.
- `AboveAnchorPositionProvider` falls back to placing the list *below* the anchor when it does not
  fit above; under a soft keyboard that would put it behind the IME. I stopped guessing about this
  and measured it (see Verification): with the composer pinned to the bottom the list opens above it
  as intended, and the fallback only engages when the space above is smaller than the list. With 5
  rows at 48dp that needs a very short viewport — phone landscape with the keyboard up. Since it does
  not reproduce in the normal geometry, CLAUDE.md's rule against patching an unobserved symptom
  applies: noted, not worked around.

## The 1:1 gate

`mentionTargets` is empty for a 1:1, which makes `ComposerAutocomplete`'s `enabled` false, which
means `registerTrigger` is never called. Not just "no list": richeditor never paints the live `@ali`
token in its trigger colour either, so there is no affordance of any kind. Asserted via
`state.activeTriggerQuery == null`, not just via the absence of a popup.

Members come from `EnrichedConversationUiModel.participants` — already resolved through
`ContactService`, already self-excluded. **Known gap, shared with web:** `ConversationEnricher.kt:44`
is a `mapNotNull { contactMap[odinId] }`, so a group member with no saved contact is absent from the
list. Web has the identical gap (`useAllContacts`). Fixing it means either changing that
`mapNotNull` to fall back to `ContactUiModel.fallbackFor` — which also changes group display names
and search — or plumbing `ContactService` into the composer. Both are out of scope for this PR; say
the word and I will do the former as a separate change.

## Verification

**Ran, passed:**

- `./gradlew homebase-chat:jvmTest homebase-common:jvmTest homebase-core:jvmTest` — 2474 tests,
  0 failures. 22 are new: 9 ranking/filtering (`MentionSuggestionsTest`) and 13 through a real
  `RichTextEditor` (`ComposerMentionTypeaheadTest`) covering bare-`@` listing, filtering, commit
  text + caret position, markdown survival, adjacent emoji, the word-boundary rule (`bob@ali` never
  triggers), the empty-targets gate, arrow+Enter commit, a fully typed handle leaving Enter free to
  send, and `@` and `:` coexisting on one `RichTextState` and one key controller.
- **Where the list opens, measured not assumed.** Two of those tests read the popup's and the
  anchor's `getBoundsInRoot()` and compare them. With the composer pinned to the bottom of the
  window — the geometry a soft keyboard produces — the list lands at 612–708dp against an anchor at
  712–768dp, i.e. entirely above it with the intended 4dp gap. Starved of room above (anchor at
  40–96dp) it flips to 100–196dp, below the anchor, rather than being clipped. Mutating the position
  provider to always place below fails the first of these.
- `:homebase-chat:compileKotlinJvm`, `compileAndroidMain`, `compileKotlinWasmJs`,
  `compileKotlinIosSimulatorArm64`; the same four on `:homebase-common`; `:androidApp:compileDebugKotlin`.
- Mutation-checked the suite rather than trusting a first-try green: removing the `targets.isNotEmpty()`
  gate fails 1 test, dropping the trailing space from the replacement fails 3, and making the shared
  popup focusable fails the arrow-key test.

**Read from upstream source to understand the mechanism (note: `main`, not the rc14 tag the build
pins — so treat it as an explanation, and the tests as the evidence):** `TriggerDetector` shows
`.` and `-` are not stop chars, which is why a full odinId is typeable, and that
`requireWordBoundary` is what stops `foo@bar.com`; `addTextAtIndex` sets
`selection = TextRange(index + text.length)`, which is where caret-after-insert comes from. Both
behaviours are pinned by tests running against the actual rc14 artifact.

**NOT verified — I could not see this running.** I have no account I may log into on this machine,
and the app needs a signed-in identity with a group conversation before the composer is even
reachable. Nobody has looked at this feature in a running app, on any platform. Specifically unverified:

- the popup on a real Android or iOS screen with an actual soft keyboard up — the mobile
  requirement that is the whole point of this issue. The placement tests above pin the *layout*
  logic in the bottom-pinned geometry a keyboard produces, but a JVM test has no IME, no window
  insets and no platform popup window, so they are not a substitute for looking at a device;
- whether the soft keyboard stays up through a tap-commit. The mechanism is
  `PopupProperties(focusable = false)`, and a test asserts a tap leaves focus on the editor, but a
  JVM test runs no IME, so that is a proxy and not the thing itself;
- the appearance of the row on a real screen (touch-target size, truncation of a long display name);
- anything on desktop, where I also did not launch the app.

The repo has no instrumented-test source set, so adding one purely to see this dropdown would have
been a larger and unrelated build change than the feature.

## Out of scope

`MessageTextFieldForAttachment` (the media-caption editor) gets no mention trigger — it has no
conversation in context, and one of its two call sites is Android's share-receiver activity.
