### PR TITLE
Let a fully typed display name still commit the mention

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MentionAutocomplete.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MentionAutocomplete.kt
@@ -50,8 +50,9 @@ fun MentionAutocomplete(
     }
 }
 
-/** [query] is the text after `@`. An exact hit is dropped so a fully typed handle leaves Enter
- *  free to send the message instead of re-committing what is already there. */
+/** [query] is the text after `@`. A fully typed handle is dropped so Enter sends instead of
+ *  re-committing what is already there; a fully typed display name is not, because `@Sebastian`
+ *  is not the wire form and Enter there would send an unresolvable mention. */
 internal fun mentionSuggestions(
     query: String,
     targets: List<ContactUiModel>,
@@ -72,7 +73,7 @@ internal fun mentionSuggestions(
 private fun matchRank(query: String, target: ContactUiModel): Int? {
     val name = target.name
     val handle = target.odinId.domainName
-    if (query.equals(name, ignoreCase = true) || query.equals(handle, ignoreCase = true)) return null
+    if (query.equals(handle, ignoreCase = true)) return null
     return when {
         name.startsWith(query, ignoreCase = true) -> 0
         handle.startsWith(query, ignoreCase = true) -> 1

--- a/homebase-chat/src/commonTest/kotlin/id/homebase/chat/widget/ComposerMentionTypeaheadTest.kt
+++ b/homebase-chat/src/commonTest/kotlin/id/homebase/chat/widget/ComposerMentionTypeaheadTest.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsFocused
 import androidx.compose.ui.test.getBoundsInRoot
+import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
@@ -116,6 +117,12 @@ class ComposerMentionTypeaheadTest {
     private fun androidx.compose.ui.test.ComposeUiTest.awaitText(text: String) =
         waitUntil(timeoutMillis = 10_000) {
             onAllNodes(hasText(text, substring = true)).fetchSemanticsNodes().isNotEmpty()
+        }
+
+    /** Waits for the popup itself, for cases where the query text is also in the editor. */
+    private fun androidx.compose.ui.test.ComposeUiTest.awaitSuggestions() =
+        waitUntil(timeoutMillis = 10_000) {
+            onAllNodes(hasTestTag(ComposerAutocompleteTag)).fetchSemanticsNodes().isNotEmpty()
         }
 
     private fun androidx.compose.ui.test.ComposeUiTest.assertNoText(text: String) =
@@ -234,6 +241,32 @@ class ComposerMentionTypeaheadTest {
         waitForIdle()
 
         assertEquals(1, sends)
+    }
+
+    /**
+     * The handle is the wire form; a display name is not. So typing `@Sebastian` in full has to
+     * leave the list open and let Enter commit `@yagni.dk`, or the message goes out carrying a
+     * mention no client can resolve.
+     */
+    @Test
+    fun aFullyTypedDisplayNameStillCommitsTheHandle() = runComposeUiTest {
+        lateinit var state: RichTextState
+        var sends = 0
+        setContent(
+            harness(targets = listOf(member("yagni.dk", "Sebastian")), onSend = { sends++ }) {
+                state = it
+            }
+        )
+
+        onNodeWithTag("editor").requestFocus()
+        runOnIdle { state.addTextAfterSelection("hey @Sebastian") }
+        awaitSuggestions()
+
+        onNodeWithTag("editor").performKeyInput { pressKey(Key.Enter) }
+        waitForIdle()
+
+        assertEquals(0, sends, "Enter must commit the mention, not send @Sebastian")
+        assertEquals("hey @yagni.dk ", state.annotatedString.text)
     }
 
     @Test

--- a/homebase-chat/src/commonTest/kotlin/id/homebase/chat/widget/MentionSuggestionsTest.kt
+++ b/homebase-chat/src/commonTest/kotlin/id/homebase/chat/widget/MentionSuggestionsTest.kt
@@ -67,10 +67,27 @@ class MentionSuggestionsTest {
 
     /** A fully typed handle must leave Enter free to send, not re-commit what is already there. */
     @Test
-    fun anExactHandleOrNameIsDropped() {
+    fun anExactHandleIsDropped() {
         assertTrue(mentionSuggestions("alice.example.com", Group).isEmpty())
-        assertTrue(mentionSuggestions("Alice Anderson", Group).isEmpty())
         assertTrue(mentionSuggestions("ALICE.EXAMPLE.COM", Group).isEmpty())
+    }
+
+    /**
+     * `@Sebastian` is a display name, not the wire form. Dropping it on an exact match would leave
+     * Enter sending a mention no client can resolve, so a fully typed name stays committable.
+     */
+    @Test
+    fun anExactNameStaysCommittable() {
+        val sebastian = member("yagni.dk", "Sebastian")
+        assertEquals(handles(listOf(sebastian)), handles(mentionSuggestions("sebastian", listOf(sebastian))))
+        assertEquals(handles(listOf(sebastian)), handles(mentionSuggestions("Sebastian", listOf(sebastian))))
+    }
+
+    /** A contact with no saved name falls back to its handle, and that is still the wire form. */
+    @Test
+    fun anExactHandleIsDroppedEvenWhenItIsAlsoTheName() {
+        val nameless = ContactUiModel.fallbackFor(OdinId("yagni.dk"))
+        assertTrue(mentionSuggestions("yagni.dk", listOf(nameless)).isEmpty())
     }
 
     @Test


### PR DESCRIPTION
Stacked on #1419 (`feat-1403-mention-autocomplete`). One line of behaviour, because the owner's
own example does not work today.

## The report

> Someone whose display name is "Sebastian" but whose odinId is `yagni.dk` should be found by
> typing `@sebastian`.

Half of that already works. `mentionSuggestions` in #1419 matches **both** the display name and
the handle, case-insensitively, and ranks name-prefix above handle-prefix
(`MentionAutocomplete.kt:76-83`). Typing `@seb` finds Sebastian.

Typing `@sebastian` — the whole name — does not. The list goes empty at exactly the moment the
user has finished typing.

## Why that is a bug and not a nicety

The exclusion is deliberate and, for handles, correct:

```kotlin
if (query.equals(name, ignoreCase = true) || query.equals(handle, ignoreCase = true)) return null
```

Once the body already reads `@alice.example.com`, the text **is** the mention. Enter should send
the message, not re-commit what is already there. That is web's rule too
(`MentionDropdown.tsx:27-28`) and it stays.

A display name is not the mention. `@Sebastian` has no dot, so web's receive-side linkifier
(`/(?:^|\s|[\r\n])@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/`, `ChatMessageItem.tsx:181`) never matches it, and
this client renders it as plain text either way until #1418. So the old rule made Enter send a
mention that no client can resolve — silently, and looking exactly like a real one. Users with a
one-word display name (which is most of them) hit it by typing normally.

So: drop only on an exact **handle** match.

```kotlin
if (query.equals(handle, ignoreCase = true)) return null
```

A contact with no saved name falls back to `name == handle` (`ContactUiModel.fallbackFor`), and
that case is still dropped — by the handle rule, which is the one that was doing the work.

## Scope: one-word names

A space closes the trigger — measured, not assumed: after `@Alice` the active query is
`TriggerQuery(query=Alice, …)`; type one more space and `activeTriggerQuery` is `null`. So the
filter only ever sees the first word of a name, and the old rule's other branch
(`query == "Alice Anderson"`) was unreachable input. What was reachable, and broken, is the
one-word display name — which is most of them, and is the owner's example.

## Cost

Typing a member's full one-word name now leaves the list open, so Enter commits instead of
sending. Sending the literal text `@Sebastian` to a group containing a Sebastian takes an Esc
first. That is the right trade: the alternative is a mention that silently isn't one.

## Verification

- `./gradlew homebase-chat:jvmTest homebase-common:jvmTest homebase-core:jvmTest` — green.
- `:homebase-chat:compileAndroidMain`, `compileKotlinWasmJs`, `compileKotlinIosSimulatorArm64`.
- Three new tests: `anExactNameStaysCommittable`, `anExactHandleIsDroppedEvenWhenItIsAlsoTheName`
  (the fallback-contact case), and `aFullyTypedDisplayNameStillCommitsTheHandle`, which drives a
  real `RichTextEditor` end to end — types `hey @Sebastian`, presses Enter, and asserts the body
  became `hey @yagni.dk ` and that **nothing was sent**.
- Mutation-checked: restoring the old two-clause predicate fails exactly those two of the three
  (`anExactNameStaysCommittable`, `aFullyTypedDisplayNameStillCommitsTheHandle`) and nothing else,
  so they are pinning this change rather than passing by accident.

**Not verified:** nobody has looked at this in a running app. Same gap as #1419 — I have no
identity to sign in with on this machine. The behaviour is pinned by a test through the real
editor, not by eye.


---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
