### PR TITLE
Show the contact photo in the mention suggestion rows

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MentionAutocomplete.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MentionAutocomplete.kt
@@ -12,8 +12,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.mohamedrejeb.richeditor.model.RichTextState
 import id.homebase.chat.data.ContactUiModel
+import id.homebase.core.avatars.AvatarOptions
+import id.homebase.core.avatars.ContactAvatar
 import id.homebase.core.widget.ComposerAutocomplete
 import id.homebase.core.widget.ComposerAutocompleteController
 
@@ -83,6 +86,9 @@ private fun matchRank(query: String, target: ContactUiModel): Int? {
     }
 }
 
+/** Hoisted so the per-keystroke re-render of the list does not reallocate it per row. */
+private val MentionAvatarOptions = AvatarOptions(size = 28.dp, fontSize = 12.sp)
+
 @Composable
 private fun MentionSuggestionRow(target: ContactUiModel, selected: Boolean) {
     val handle = target.odinId.domainName
@@ -95,6 +101,12 @@ private fun MentionSuggestionRow(target: ContactUiModel, selected: Boolean) {
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(8.dp),
     ) {
+        ContactAvatar(
+            odinId = target.odinId,
+            profileImageData = null,
+            initials = target.avatarInitials,
+            options = MentionAvatarOptions,
+        )
         Text(
             text = target.name,
             style = MaterialTheme.typography.bodyMedium,
@@ -113,6 +125,9 @@ private fun MentionSuggestionRow(target: ContactUiModel, selected: Boolean) {
                 },
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
+                // Weighted, or a long handle is measured first at full width and clips the name
+                // that the user is actually reading down to "Wil…".
+                modifier = Modifier.weight(1f, fill = false),
             )
         }
     }

--- a/homebase-chat/src/commonTest/kotlin/id/homebase/chat/widget/ComposerMentionTypeaheadTest.kt
+++ b/homebase-chat/src/commonTest/kotlin/id/homebase/chat/widget/ComposerMentionTypeaheadTest.kt
@@ -29,27 +29,73 @@ import androidx.compose.ui.test.requestFocus
 import androidx.compose.ui.test.runComposeUiTest
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.width
+import coil3.ComponentRegistry
+import coil3.ImageLoader
+import coil3.disk.DiskCache
+import coil3.memory.MemoryCache
+import coil3.request.Disposable
+import coil3.request.ErrorResult
+import coil3.request.ImageRequest
+import coil3.request.ImageResult
 import com.mohamedrejeb.richeditor.annotation.ExperimentalRichTextApi
 import com.mohamedrejeb.richeditor.model.RichTextState
 import com.mohamedrejeb.richeditor.model.rememberRichTextState
 import com.mohamedrejeb.richeditor.ui.material3.RichTextEditor
 import id.homebase.api.common.OdinId
 import id.homebase.chat.data.ContactUiModel
+import id.homebase.core.util.initials
 import id.homebase.core.widget.ComposerAutocompleteTag
 import id.homebase.core.widget.EmojiAutocomplete
 import id.homebase.core.widget.rememberComposerAutocompleteController
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Deferred
+import org.koin.compose.KoinIsolatedContext
+import org.koin.dsl.koinApplication
+import org.koin.dsl.module
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 private fun member(handle: String, name: String) =
-    ContactUiModel.fallbackFor(OdinId(handle)).copy(name = name)
+    ContactUiModel.fallbackFor(OdinId(handle)).copy(name = name, avatarInitials = name.initials())
 
 private val GroupMembers = listOf(
     member("alice.example.com", "Alice Anderson"),
     member("bob.example.com", "Bob Brown"),
 )
+
+/**
+ * The row's `ContactAvatar` resolves its Coil loader through Koin, so a bare `runComposeUiTest`
+ * dies with "KoinApplication has not been started". This one fails every request, which puts every
+ * row on the initials fallback: deterministic, and it dials nobody.
+ */
+private class OfflineImageLoader : ImageLoader {
+    override val defaults: ImageRequest.Defaults = ImageRequest.Defaults.DEFAULT
+    override val components: ComponentRegistry = ComponentRegistry()
+    override val memoryCache: MemoryCache? = null
+    override val diskCache: DiskCache? = null
+
+    override fun enqueue(request: ImageRequest): Disposable = object : Disposable {
+        override val job: Deferred<ImageResult> = CompletableDeferred(refuse(request))
+        override val isDisposed: Boolean = true
+        override fun dispose() = Unit
+    }
+
+    override suspend fun execute(request: ImageRequest): ImageResult = refuse(request)
+
+    override fun shutdown() = Unit
+
+    override fun newBuilder(): ImageLoader.Builder = throw UnsupportedOperationException()
+
+    private fun refuse(request: ImageRequest) =
+        ErrorResult(null, request, UnsupportedOperationException("offline test loader"))
+}
+
+private val TestKoin = koinApplication {
+    modules(module { single<ImageLoader> { OfflineImageLoader() } })
+}
 
 @OptIn(ExperimentalTestApi::class, ExperimentalRichTextApi::class)
 class ComposerMentionTypeaheadTest {
@@ -62,29 +108,31 @@ class ComposerMentionTypeaheadTest {
         onSend: () -> Unit = {},
         capture: (RichTextState) -> Unit,
     ): @Composable () -> Unit = {
-        MaterialTheme {
-            val state = rememberRichTextState()
-            val controller = rememberComposerAutocompleteController()
-            capture(state)
-            Box {
-                RichTextEditor(
-                    state = state,
-                    modifier = Modifier
-                        .onPreviewKeyEvent { event ->
-                            if (controller.handleKeyEvent(event)) {
-                                true
-                            } else if (event.key == Key.Enter && event.type == KeyEventType.KeyDown) {
-                                onSend()
-                                true
-                            } else {
-                                false
+        KoinIsolatedContext(TestKoin) {
+            MaterialTheme {
+                val state = rememberRichTextState()
+                val controller = rememberComposerAutocompleteController()
+                capture(state)
+                Box {
+                    RichTextEditor(
+                        state = state,
+                        modifier = Modifier
+                            .onPreviewKeyEvent { event ->
+                                if (controller.handleKeyEvent(event)) {
+                                    true
+                                } else if (event.key == Key.Enter && event.type == KeyEventType.KeyDown) {
+                                    onSend()
+                                    true
+                                } else {
+                                    false
+                                }
                             }
-                        }
-                        .testTag("editor"),
-                )
-                MentionAutocomplete(state = state, controller = controller, targets = targets)
-                if (withEmoji) {
-                    EmojiAutocomplete(state = state, controller = controller, enabled = true)
+                            .testTag("editor"),
+                    )
+                    MentionAutocomplete(state = state, controller = controller, targets = targets)
+                    if (withEmoji) {
+                        EmojiAutocomplete(state = state, controller = controller, enabled = true)
+                    }
                 }
             }
         }
@@ -96,19 +144,21 @@ class ComposerMentionTypeaheadTest {
         topSpacer: androidx.compose.ui.unit.Dp?,
         capture: (RichTextState) -> Unit,
     ): @Composable () -> Unit = {
-        MaterialTheme {
-            val state = rememberRichTextState()
-            val controller = rememberComposerAutocompleteController()
-            capture(state)
-            Column(Modifier.fillMaxSize()) {
-                if (topSpacer == null) Spacer(Modifier.weight(1f)) else Spacer(Modifier.height(topSpacer))
-                Box(Modifier.fillMaxWidth().testTag("anchor")) {
-                    RichTextEditor(state = state, modifier = Modifier.fillMaxWidth())
-                    MentionAutocomplete(
-                        state = state,
-                        controller = controller,
-                        targets = GroupMembers,
-                    )
+        KoinIsolatedContext(TestKoin) {
+            MaterialTheme {
+                val state = rememberRichTextState()
+                val controller = rememberComposerAutocompleteController()
+                capture(state)
+                Column(Modifier.fillMaxSize()) {
+                    if (topSpacer == null) Spacer(Modifier.weight(1f)) else Spacer(Modifier.height(topSpacer))
+                    Box(Modifier.fillMaxWidth().testTag("anchor")) {
+                        RichTextEditor(state = state, modifier = Modifier.fillMaxWidth())
+                        MentionAutocomplete(
+                            state = state,
+                            controller = controller,
+                            targets = GroupMembers,
+                        )
+                    }
                 }
             }
         }
@@ -137,6 +187,44 @@ class ComposerMentionTypeaheadTest {
         awaitText("Alice Anderson")
 
         onNodeWithText("Bob Brown", substring = true).assertExists()
+    }
+
+    /** No published photo is the common case for a connection, so the row has to stay legible on
+     *  the initials alone. The test loader refuses every request, which is that path. */
+    @Test
+    fun aRowWithNoPhotoFallsBackToTheContactsInitials() = runComposeUiTest {
+        lateinit var state: RichTextState
+        setContent(harness { state = it })
+
+        runOnIdle { state.addTextAfterSelection("@") }
+        awaitText("Alice Anderson")
+
+        onNodeWithText("AA").assertExists()
+        onNodeWithText("BB").assertExists()
+    }
+
+    /**
+     * The name is what the user reads; the handle is the confirmation. Unweighted, the handle is
+     * measured first at the popup's full width and leaves the name a stub — with the avatar in the
+     * row the name fell to "Wil…" beside a fully drawn 32-character handle.
+     */
+    @Test
+    fun aLongHandleDoesNotStarveTheName() = runComposeUiTest {
+        lateinit var state: RichTextState
+        val long = member("verylongidentityname.example.com", "Wilhelmina Featherstonehaugh-Smythe")
+        setContent(harness(targets = listOf(long)) { state = it })
+
+        runOnIdle { state.addTextAfterSelection("@") }
+        awaitSuggestions()
+
+        val name = onNodeWithText("Wilhelmina", substring = true, useUnmergedTree = true)
+            .getBoundsInRoot().width
+        val handle = onNodeWithText("verylongidentityname", substring = true, useUnmergedTree = true)
+            .getBoundsInRoot().width
+        assertTrue(
+            name >= handle * 0.7f,
+            "name got ${name}, handle got ${handle}",
+        )
     }
 
     @Test

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/widget/MentionAvatarFetchTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/widget/MentionAvatarFetchTest.kt
@@ -1,0 +1,134 @@
+package id.homebase.chat.widget
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.runComposeUiTest
+import coil3.ImageLoader
+import coil3.PlatformContext
+import coil3.Uri
+import coil3.intercept.Interceptor
+import coil3.request.ErrorResult
+import com.mohamedrejeb.richeditor.annotation.ExperimentalRichTextApi
+import com.mohamedrejeb.richeditor.model.RichTextState
+import com.mohamedrejeb.richeditor.model.rememberRichTextState
+import com.mohamedrejeb.richeditor.ui.material3.RichTextEditor
+import id.homebase.api.common.OdinId
+import id.homebase.chat.data.ContactUiModel
+import id.homebase.core.util.initials
+import id.homebase.core.widget.ComposerAutocompleteTag
+import id.homebase.core.widget.rememberComposerAutocompleteController
+import org.koin.compose.KoinIsolatedContext
+import org.koin.dsl.koinApplication
+import org.koin.dsl.module
+import java.util.concurrent.CopyOnWriteArrayList
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * The suggestion list re-renders on every keystroke while you filter, and each row now draws a
+ * `ContactAvatar`. Asserts on Coil requests rather than on the tree: both avatar branches clear
+ * their semantics, so a screen-level assertion cannot tell a fetch from initials.
+ */
+@OptIn(ExperimentalTestApi::class, ExperimentalRichTextApi::class)
+class MentionAvatarFetchTest {
+
+    private val requested = CopyOnWriteArrayList<Any>()
+
+    private val recorder = Interceptor { chain ->
+        requested += chain.request.data
+        ErrorResult(null, chain.request, UnsupportedOperationException("recorded"))
+    }
+
+    private val koin = koinApplication {
+        modules(
+            module {
+                single {
+                    ImageLoader.Builder(PlatformContext.INSTANCE)
+                        .components { add(recorder) }
+                        .build()
+                }
+            },
+        )
+    }
+
+    private fun member(handle: String, name: String) =
+        ContactUiModel.fallbackFor(OdinId(handle)).copy(name = name, avatarInitials = name.initials())
+
+    private val group = listOf(
+        member("alice.example.com", "Alice Anderson"),
+        member("bob.example.com", "Bob Brown"),
+        member("carol.example.com", "Carol Clark"),
+    )
+
+    private fun harness(capture: (RichTextState) -> Unit): @Composable () -> Unit = {
+        KoinIsolatedContext(koin) {
+            MaterialTheme {
+                val state = rememberRichTextState()
+                val controller = rememberComposerAutocompleteController()
+                capture(state)
+                Box {
+                    RichTextEditor(state = state, modifier = Modifier.testTag("editor"))
+                    MentionAutocomplete(state = state, controller = controller, targets = group)
+                }
+            }
+        }
+    }
+
+    private fun publicImageHosts(): List<String> = requested.mapNotNull { data ->
+        val url = when (data) {
+            is String -> data
+            is Uri -> data.toString()
+            else -> return@mapNotNull null
+        }
+        url.takeIf { it.contains("/pub/image") }
+            ?.removePrefix("https://")
+            ?.substringBefore("/pub/image")
+    }
+
+    @Test
+    fun eachIdentityIsDialedOncePerListing() = runComposeUiTest {
+        lateinit var state: RichTextState
+        setContent(harness { state = it })
+
+        runOnIdle { state.addTextAfterSelection("@") }
+        waitUntil(timeoutMillis = 10_000) {
+            onAllNodes(hasTestTag(ComposerAutocompleteTag)).fetchSemanticsNodes().isNotEmpty()
+        }
+
+        assertEquals(
+            listOf("alice.example.com", "bob.example.com", "carol.example.com"),
+            publicImageHosts().sorted(),
+        )
+    }
+
+    /**
+     * Typing on narrows the list but leaves Alice in it. The URL is the Coil model, so the request
+     * stays equal across those recompositions and the painter never restarts: a keystroke that does
+     * not change who is on screen costs no load at all.
+     */
+    @Test
+    fun typingOnDoesNotRedialAnIdentityThatStaysInTheList() = runComposeUiTest {
+        lateinit var state: RichTextState
+        setContent(harness { state = it })
+
+        runOnIdle { state.addTextAfterSelection("@") }
+        waitUntil(timeoutMillis = 10_000) {
+            onAllNodes(hasTestTag(ComposerAutocompleteTag)).fetchSemanticsNodes().isNotEmpty()
+        }
+        for (char in "alic") {
+            runOnIdle { state.addTextAfterSelection(char.toString()) }
+            waitForIdle()
+        }
+
+        assertEquals(
+            1,
+            publicImageHosts().count { it == "alice.example.com" },
+            "five renderings of Alice's row must not be five loads; got ${publicImageHosts()}",
+        )
+    }
+}


### PR DESCRIPTION
Stacked on #1422 (which is stacked on #1419). Adds the contact photo to the `@mention` dropdown
rows, the way Signal and WhatsApp do.

## Did `ComposerAutocomplete<T>` hold up? Yes, again

#1403 described the mention `itemContent` as "avatar + name", and that parameter was in fact
enough: **`homebase-common` is untouched by this PR.** The whole feature is five lines inside
`MentionSuggestionRow`, calling the avatar the rest of the app already calls.

No new avatar composable either. `ContactAvatar` (`homebase-common/.../avatars/ContactAvatar.kt:19`)
with `profileImageData = null` routes to `PublicAvatar`, which is the published-avatar path:
Coil3 over `https://<odinId>/pub/image`, and on failure — which is what "this connection has no
photo" looks like — it renders `FallbackAvatar` with the initials. That fallback is not optional
here, it is the common case. Initials come from `ContactUiModel.avatarInitials`, precomputed via
`String.initials()`, so nothing in this PR chops a display name by index.

28.dp / 12.sp is the existing contact-list convention (`ContactItem.kt:41`,
`SelectMembersScreen.kt:214`, `GroupSettingsScreen.kt:1093`, and five more). `AvatarOptions` is
hoisted to a file-level `val` rather than built per row, since the list re-renders on every
keystroke.

## The cost, measured rather than assumed

The list re-renders per keystroke while you filter, and each row now draws an avatar. The worry
was a per-keystroke fetch across the whole member list. It is not one, and
`MentionAvatarFetchTest` pins both halves against a real `ImageLoader` with a recording
`Interceptor` (the same technique as `ContactCardAvatarFetchTest`):

- `eachIdentityIsDialedOncePerListing` — opening the list on a 3-member group produces exactly
  three `/pub/image` requests, one per identity.
- `typingOnDoesNotRedialAnIdentityThatStaysInTheList` — then typing `a`, `l`, `i`, `c` produces
  **no further request for Alice**, whose row is re-rendered five times. Coil's model is the URL
  string, which is recomputed equal on every composition, so the `ImageRequest` compares equal and
  `AsyncImagePainter` never restarts the load.

Behind that: a 25%-of-heap Coil memory cache keyed on the URL, a 200 MB `public_images` disk cache
in `PublicProfileProviderCached`, a per-key mutex coalescing concurrent loads, and a session
`notFoundCache` so identities with no published avatar stop dialing permanently. What the test
measures is request *executions*, not sockets — errors are not cached, so an execution is the
strictest thing to count.

Honest caveat: `PublicAvatar` uses `SubcomposeAsyncImage`, which is a `SubcomposeLayout` and the
priciest of the avatar options, and it draws an indefinite `CircularProgressIndicator` while a row
is still loading. At five rows that is not worth a cheaper bespoke avatar; at fifty it would be.

## What the render turned up

Rendered headlessly (`runDesktopComposeUiTest` + `captureToImage`) in light and dark, because I
have no app to look at. The photo work was fine. The **existing** row measurement was not: the
handle `Text` carried no weight, so a `Row` measures it first at the popup's full width and hands
the name whatever is left. With the avatar taking another 28dp, "Wilhelmina Featherstonehaugh-Smythe"
rendered as **"Wil…"** next to a fully drawn `verylongidentityname.example.com` — the confirmation
legible, the thing you are actually reading not.

Fixed by weighting the handle too, so the two share what is left. Measured, both ways:

| | name | handle |
| --- | --- | --- |
| before | **39.0dp** | 213.0dp |
| after | 126.0dp | 126.0dp |

`aLongHandleDoesNotStarveTheName` pins it (reading the unmerged tree — the merged row node reports
the popup's full 320dp for both and would pass regardless).

## Test plumbing

`ContactAvatar` resolves its `ImageLoader` through `koinInject`, so every existing test in
`ComposerMentionTypeaheadTest` began dying with "KoinApplication has not been started". Rather
than move the file to `jvmTest` — where the two other Koin-needing Compose tests in this module
live, but at the cost of the non-JVM test compilations — the harness now wraps in
`KoinIsolatedContext` over a 20-line `OfflineImageLoader` that refuses every request. That keeps
the file in `commonTest` and lands every row deterministically on the initials branch, which is
also what `aRowWithNoPhotoFallsBackToTheContactsInitials` asserts.

## Verification

- `./gradlew homebase-chat:jvmTest homebase-common:jvmTest homebase-core:jvmTest` — green.
  `homebase-common`'s Konsist `ArchitectureTest` runs `scopeFromProject()`, so it covers this row.
- `:homebase-chat:compileAndroidMain`, `compileKotlinWasmJs`, `compileKotlinIosSimulatorArm64`,
  `:androidApp:compileDebugKotlin`.
- Mutation-checked: deleting the `ContactAvatar` call fails exactly the three avatar tests;
  deleting the handle's weight fails exactly the layout test.

**Not verified — nobody has looked at this in a running app.** The owner is verifying #1419 by
hand from another worktree and I did not touch it. Specifically unverified: a real photo actually
decoding and drawing (every test and every render here refuses the fetch, so I have only ever seen
the initials branch); the row under a real soft keyboard; and scroll/jank while typing on a device.
The headless captures are Skia renders at 460x420, not a phone.


---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
