### PR TITLE
Give the profile disk caches the platform file system

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/profile/PublicProfileProviderCached.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/profile/PublicProfileProviderCached.kt
@@ -88,13 +88,22 @@ class PublicProfileProviderCached(
     private val profileDir = "$directory/homebase-public-profiles-v2"
     private val imageDir = "$directory/homebase-public-images-v2"
 
+    // fileSystem() is not optional decoration: coil's Builder defaults to okio
+    // FileSystem.SYSTEM, which on wasmJs is the throwing stub ("Javascript does
+    // not have access to the device's file system") - every cache read then
+    // errored on web and fell through to the network. The platform
+    // systemFileSystem (in-memory on web) is what the entry reads/writes below
+    // already use; the cache must live in the same one. Same shape as
+    // DriveFileProviderCached, which had it right.
     private val profileDiskCache: DiskCache = DiskCache.Builder()
         .directory(profileDir.toPath())
+        .fileSystem(fileSystem)
         .maxSizeBytes(10L * 1024L * 1024L)
         .build()
 
     private val imageDiskCache: DiskCache = DiskCache.Builder()
         .directory(imageDir.toPath())
+        .fileSystem(fileSystem)
         .maxSizeBytes(200L * 1024L * 1024L)
         .build()
 


### PR DESCRIPTION
Fixes the `(PublicProfileIO) cache-read FAILED … Javascript does not have access to the device's file system` errors flooding production wasm consoles (2026-08-31): the two coil `DiskCache.Builder()`s in `PublicProfileProviderCached` never received the platform `systemFileSystem` the class itself injects, so they defaulted to okio `FileSystem.SYSTEM` — the throwing stub on wasmJs. Every profile cache read errored and fell through to the network (degraded, not broken — but loud and cache-less on web).

`DriveFileProviderCached`, the class this was modeled on, has `.fileSystem(fileSystem)` on all three of its caches — this adds the same missing line to both profile caches, with a comment so it can't be "simplified" away again. On web the cache now lives in the in-memory `FakeFileSystem` (works, page-lifetime persistence); native platforms unchanged (`FileSystem.SYSTEM` is what `systemFileSystem` resolves to there).

Verified: jvm + wasmJs compile, `homebase-api:jvmTest` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ePkqms6AQdGGUWsVrGyzx