### PR TITLE
Show an HD indicator on photos sent at high quality

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/files/PayloadDescriptor.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/files/PayloadDescriptor.kt
@@ -2,6 +2,7 @@ package id.homebase.api.client.drives.files
 
 import androidx.compose.runtime.Immutable
 import co.touchlab.kermit.Logger
+import id.homebase.api.image.MediaQuality
 import id.homebase.api.serialization.OdinSystemSerializer
 import id.homebase.api.video.VideoMetadata
 import kotlinx.serialization.Serializable
@@ -138,11 +139,16 @@ sealed interface DescriptorContent {
      * Additive and backward-compatible: a blank or legacy descriptor parses to
      * `ImageFile(isSticker = false, format = null)` and older receivers ignore [format]
      * (OdinSystemSerializer has ignoreUnknownKeys = true).
+     *
+     * [quality] is the send quality the sender chose. null means "not recorded" — every
+     * image sent before this field shipped, which is why a null must never render as
+     * "not HD": that would mislabel every HD photo sent before it.
      */
     @Serializable
     data class ImageFile(
         val isSticker: Boolean = false,
         val format: String? = null,
+        val quality: MediaQuality? = null,
     ) : DescriptorContent {
         /**
          * Filename extension for a downloaded sticker, derived from [format]. Defaults to
@@ -180,10 +186,15 @@ sealed interface DescriptorContent {
         /**
          * Serialize an [ImageFile] descriptor (e.g. `{"isSticker":true,"format":"image/png"}`)
          * for the wire. [format] is the detected image content type — carried so a receiver
-         * can name a downloaded sticker "StickerFile.<ext>".
+         * can name a downloaded sticker "StickerFile.<ext>". [quality] is the chosen send
+         * quality; leave it null to record nothing.
          */
-        fun descriptorContentFromImage(isSticker: Boolean, format: String? = null): String {
-            return OdinSystemSerializer.serialize(ImageFile(isSticker, format))
+        fun descriptorContentFromImage(
+            isSticker: Boolean,
+            format: String? = null,
+            quality: MediaQuality? = null,
+        ): String {
+            return OdinSystemSerializer.serialize(ImageFile(isSticker, format, quality))
         }
     }
 }

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/image/MediaQuality.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/image/MediaQuality.kt
@@ -1,13 +1,21 @@
 package id.homebase.api.image
 
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
 /**
  * How hard an outgoing photo or video is compressed before upload.
  *
  * [HIGH] is a byte-for-byte contract: the picked file's bytes reach the wire unmodified
  * (bar the EXIF scrub every image already gets).
  */
+@Serializable
 enum class MediaQuality(val code: String) {
+    // Wire names match `code` so a descriptor written by any client reads the same.
+    @SerialName("standard")
     STANDARD("standard"),
+
+    @SerialName("high")
     HIGH("high");
 
     companion object {

--- a/homebase-api/src/jvmTest/kotlin/id/homebase/api/client/drives/files/PayloadDescriptorImageTest.kt
+++ b/homebase-api/src/jvmTest/kotlin/id/homebase/api/client/drives/files/PayloadDescriptorImageTest.kt
@@ -1,5 +1,6 @@
 package id.homebase.api.client.drives.files
 
+import id.homebase.api.image.MediaQuality
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -80,6 +81,62 @@ class PayloadDescriptorImageTest {
         val padded = imageDescriptor("""   [{"url":"https://example.com"}]""").descriptorInfo()
         assertTrue(padded is DescriptorContent.ImageFile, "Expected ImageFile, got $padded")
         assertFalse(padded.isSticker)
+    }
+
+    @Test
+    fun quality_roundTripsThroughTheWire() {
+        val serialized = DescriptorContent.descriptorContentFromImage(
+            isSticker = false,
+            quality = MediaQuality.HIGH,
+        )
+        assertTrue(
+            serialized.contains("\"quality\":\"high\""),
+            "Quality must serialize with its lowercase code, got $serialized",
+        )
+        val info = imageDescriptor(serialized).descriptorInfo()
+        assertTrue(info is DescriptorContent.ImageFile, "Expected ImageFile, got $info")
+        assertEquals(MediaQuality.HIGH, info.quality)
+
+        val standard = DescriptorContent.descriptorContentFromImage(
+            isSticker = false,
+            quality = MediaQuality.STANDARD,
+        )
+        val standardInfo = imageDescriptor(standard).descriptorInfo()
+        assertTrue(standardInfo is DescriptorContent.ImageFile)
+        assertEquals(MediaQuality.STANDARD, standardInfo.quality)
+    }
+
+    @Test
+    fun qualityIsOmittedWhenNotRecorded() {
+        // Absent must stay absent — it is what every pre-flag image reads as, and it must
+        // never be coerced to STANDARD, which would mislabel old HD photos.
+        val serialized = DescriptorContent.descriptorContentFromImage(isSticker = true)
+        assertFalse(serialized.contains("quality"), "Unexpected quality key in $serialized")
+
+        val info = imageDescriptor(serialized).descriptorInfo()
+        assertTrue(info is DescriptorContent.ImageFile)
+        assertNull(info.quality)
+
+        assertNull((imageDescriptor("").descriptorInfo() as DescriptorContent.ImageFile).quality)
+    }
+
+    @Test
+    fun stickerAndQualityCoexist_andQualitySurvivesAnUnknownSibling() {
+        val info = imageDescriptor(
+            """{"isSticker":true,"format":"image/png","quality":"high","futureField":42}"""
+        ).descriptorInfo()
+        assertTrue(info is DescriptorContent.ImageFile)
+        assertTrue(info.isSticker)
+        assertEquals(MediaQuality.HIGH, info.quality)
+    }
+
+    @Test
+    fun unknownQualityValue_coercesToNull_notToAQuality() {
+        // coerceInputValues turns an unrecognised enum into the default (null) rather than
+        // throwing, so a newer sender's vocabulary degrades to "not recorded".
+        val info = imageDescriptor("""{"isSticker":false,"quality":"ultra"}""").descriptorInfo()
+        assertTrue(info is DescriptorContent.ImageFile, "Expected ImageFile, got $info")
+        assertNull(info.quality)
     }
 
     @Test

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/builder/MessageAttachmentBuilder.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/builder/MessageAttachmentBuilder.kt
@@ -70,11 +70,20 @@ object MessageAttachmentBuilder {
                         // as a normal image (issue #854). When it IS a sticker we detect the
                         // real format so the download is named "StickerFile.<ext>"; ordinary
                         // photos keep the legacy "" so nothing changes for them.
+                        //
+                        // Quality is recorded only for a HIGH ordinary photo: STANDARD keeps
+                        // the legacy "" (absent reads as standard), and a sticker's bytes are
+                        // bounded at 512px regardless of the toggle, so "HD" would be a lie.
                         val descriptorContent =
                             if (attachment.forceSticker) {
                                 DescriptorContent.descriptorContentFromImage(
                                     isSticker = true,
                                     format = ImageFormatDetector.detectFormat(thumbs.sourceBytes),
+                                )
+                            } else if (mediaQuality == MediaQuality.HIGH) {
+                                DescriptorContent.descriptorContentFromImage(
+                                    isSticker = false,
+                                    quality = MediaQuality.HIGH,
                                 )
                             } else {
                                 ""

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/FullScreenMediaViewer.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/FullScreenMediaViewer.kt
@@ -68,6 +68,7 @@ import id.homebase.core.util.formatTimestamp
 import id.homebase.resources.MR
 import id.homebase.resources.chat_image_unavailable
 import id.homebase.resources.chat_media_quality_hd
+import id.homebase.resources.chat_message_image_attachment
 import id.homebase.resources.chat_options
 import id.homebase.resources.menu_back
 import id.homebase.resources.share
@@ -160,7 +161,7 @@ fun FullScreenMediaViewer(
                     }
                     ZoomableSubSamplingImage(
                         source = source,
-                        contentDescription = payload.descriptorContent,
+                        contentDescription = stringResource(MR.string.chat_message_image_attachment),
                         onTap = { showUI = !showUI },
                         sharedTransitionScope = if (page == initialPage) sharedTransitionScope else null,
                         animatedVisibilityScope = if (page == initialPage) animatedVisibilityScope else null,
@@ -188,7 +189,7 @@ fun FullScreenMediaViewer(
                     }
                     ZoomableSubSamplingImage(
                         source = source,
-                        contentDescription = payload.descriptorContent,
+                        contentDescription = stringResource(MR.string.chat_message_image_attachment),
                         onTap = { showUI = !showUI },
                         sharedTransitionScope = if (page == initialPage) sharedTransitionScope else null,
                         animatedVisibilityScope = if (page == initialPage) animatedVisibilityScope else null,
@@ -399,7 +400,7 @@ fun FullScreenMediaViewer(
                                     shape = RoundedCornerShape(8.dp)
                                 ),
                             contentScale = ContentScale.Crop,
-                            contentDescription = payload.descriptorContent,
+                            contentDescription = stringResource(MR.string.chat_message_image_attachment),
                             animatedVisibilityScope = animatedVisibilityScope,
                             sharedTransitionScope = null,
                         )

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/FullScreenMediaViewer.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/FullScreenMediaViewer.kt
@@ -19,6 +19,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -26,6 +28,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.BrokenImage
+import androidx.compose.material.icons.filled.Hd
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.material3.CircularProgressIndicator
@@ -66,6 +69,7 @@ import id.homebase.core.media.subsample.SubSamplingImageSource
 import id.homebase.core.media.subsample.ZoomableSubSamplingImage
 import id.homebase.core.util.formatTimestamp
 import id.homebase.resources.MR
+import id.homebase.resources.cd_media_quality_hd_badge
 import id.homebase.resources.chat_image_unavailable
 import id.homebase.resources.chat_options
 import id.homebase.resources.menu_back
@@ -233,10 +237,25 @@ fun FullScreenMediaViewer(
                             style = MaterialTheme.typography.titleMedium,
                             fontWeight = FontWeight.SemiBold
                         )
-                        Text(
-                            text = formatTimestamp(data.userDate),
-                            style = MaterialTheme.typography.labelMedium,
-                        )
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            Text(
+                                text = formatTimestamp(data.userDate),
+                                style = MaterialTheme.typography.labelMedium,
+                            )
+                            val currentIsHighQuality = data.payloads
+                                .firstOrNull { it.key == currentPayloadKey }
+                                ?.isHighQualityImage() == true
+                            if (currentIsHighQuality) {
+                                Spacer(modifier = Modifier.width(6.dp))
+                                Icon(
+                                    imageVector = Icons.Default.Hd,
+                                    contentDescription = stringResource(
+                                        MR.string.cd_media_quality_hd_badge
+                                    ),
+                                    modifier = Modifier.size(18.dp),
+                                )
+                            }
+                        }
                     }
 
                 },

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/FullScreenMediaViewer.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/FullScreenMediaViewer.kt
@@ -19,8 +19,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -28,7 +26,6 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.BrokenImage
-import androidx.compose.material.icons.filled.Hd
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.material3.CircularProgressIndicator
@@ -69,8 +66,8 @@ import id.homebase.core.media.subsample.SubSamplingImageSource
 import id.homebase.core.media.subsample.ZoomableSubSamplingImage
 import id.homebase.core.util.formatTimestamp
 import id.homebase.resources.MR
-import id.homebase.resources.cd_media_quality_hd_badge
 import id.homebase.resources.chat_image_unavailable
+import id.homebase.resources.chat_media_quality_hd
 import id.homebase.resources.chat_options
 import id.homebase.resources.menu_back
 import id.homebase.resources.share
@@ -237,25 +234,15 @@ fun FullScreenMediaViewer(
                             style = MaterialTheme.typography.titleMedium,
                             fontWeight = FontWeight.SemiBold
                         )
-                        Row(verticalAlignment = Alignment.CenterVertically) {
-                            Text(
-                                text = formatTimestamp(data.userDate),
-                                style = MaterialTheme.typography.labelMedium,
-                            )
-                            val currentIsHighQuality = data.payloads
-                                .firstOrNull { it.key == currentPayloadKey }
-                                ?.isHighQualityImage() == true
-                            if (currentIsHighQuality) {
-                                Spacer(modifier = Modifier.width(6.dp))
-                                Icon(
-                                    imageVector = Icons.Default.Hd,
-                                    contentDescription = stringResource(
-                                        MR.string.cd_media_quality_hd_badge
-                                    ),
-                                    modifier = Modifier.size(18.dp),
-                                )
-                            }
-                        }
+                        val currentIsHighQuality = data.payloads
+                            .firstOrNull { it.key == currentPayloadKey }
+                            ?.isHighQualityImage() == true
+                        val hdLabel = stringResource(MR.string.chat_media_quality_hd)
+                        val timestamp = formatTimestamp(data.userDate)
+                        Text(
+                            text = if (currentIsHighQuality) "$timestamp · $hdLabel" else timestamp,
+                            style = MaterialTheme.typography.labelMedium,
+                        )
                     }
 
                 },

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MediaMessage.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MediaMessage.kt
@@ -143,6 +143,10 @@ fun MediaMessage(
         payloads.size == 1 && payloads[0].key == ChatProtocol.PAYLOAD_KEY_LINKS
     }
 
+    val isHighQualitySolo = remember(payloads) {
+        payloads.size == 1 && payloads[0].isHighQualityImage()
+    }
+
     Box(modifier = Modifier.testTag(ChatBubbleTestTags.MEDIA).animateContentSize()) {
         when (payloads.size) {
             1 -> {
@@ -249,6 +253,13 @@ fun MediaMessage(
                 status = uploadStatus,
                 modifier = Modifier.matchParentSize(),
             )
+        }
+
+        // Solo photos only: a gallery cell is too small to carry it, and the fullscreen
+        // viewer badges each item there instead. Top-start keeps it clear of the
+        // bottom timestamp scrim, which is drawn over this Box by the parent bubble.
+        if (isHighQualitySolo) {
+            HdBadge(modifier = Modifier.align(Alignment.TopStart))
         }
     }
 }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MediaQualityBadge.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MediaQualityBadge.kt
@@ -3,14 +3,14 @@ package id.homebase.chat.widget
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Hd
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import id.homebase.api.client.drives.files.DescriptorContent
 import id.homebase.api.client.drives.files.PayloadDescriptor
@@ -18,6 +18,7 @@ import id.homebase.api.image.MediaQuality
 import id.homebase.core.ui.theme.HomebaseTheme
 import id.homebase.resources.MR
 import id.homebase.resources.cd_media_quality_hd_badge
+import id.homebase.resources.chat_media_quality_hd
 import org.jetbrains.compose.resources.stringResource
 
 /**
@@ -31,11 +32,13 @@ fun PayloadDescriptor.isHighQualityImage(): Boolean =
     (descriptorInfo() as? DescriptorContent.ImageFile)?.quality == MediaQuality.HIGH
 
 /**
- * HD marker for a photo overlaid on the image itself. Carries its own scrim because it sits
- * on arbitrary picture content, where no surface role can guarantee contrast.
+ * HD marker overlaid on a photo. Carries its own scrim because it sits on arbitrary picture
+ * content, where no surface role can guarantee contrast.
  */
 @Composable
 fun HdBadge(modifier: Modifier = Modifier) {
+    val label = stringResource(MR.string.chat_media_quality_hd)
+    val description = stringResource(MR.string.cd_media_quality_hd_badge)
     Box(
         modifier = modifier
             .padding(6.dp)
@@ -43,13 +46,14 @@ fun HdBadge(modifier: Modifier = Modifier) {
                 color = MaterialTheme.colorScheme.scrim.copy(alpha = 0.55f),
                 shape = RoundedCornerShape(4.dp),
             )
-            .padding(horizontal = 4.dp, vertical = 2.dp),
+            .padding(horizontal = 4.dp, vertical = 2.dp)
+            .clearAndSetSemantics { contentDescription = description },
     ) {
-        Icon(
-            imageVector = Icons.Default.Hd,
-            contentDescription = stringResource(MR.string.cd_media_quality_hd_badge),
-            tint = HomebaseTheme.extendedColors.bubbleSentOnSurface,
-            modifier = Modifier.size(16.dp),
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelSmall,
+            fontWeight = FontWeight.Bold,
+            color = HomebaseTheme.extendedColors.bubbleSentOnSurface,
         )
     }
 }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MediaQualityBadge.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MediaQualityBadge.kt
@@ -1,0 +1,55 @@
+package id.homebase.chat.widget
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Hd
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import id.homebase.api.client.drives.files.DescriptorContent
+import id.homebase.api.client.drives.files.PayloadDescriptor
+import id.homebase.api.image.MediaQuality
+import id.homebase.core.ui.theme.HomebaseTheme
+import id.homebase.resources.MR
+import id.homebase.resources.cd_media_quality_hd_badge
+import org.jetbrains.compose.resources.stringResource
+
+/**
+ * True only when the payload explicitly records [MediaQuality.HIGH].
+ *
+ * A missing quality is "not recorded", not "standard": every photo sent before the flag
+ * shipped reads that way, and badging those as standard would mislabel the HD ones. Absent
+ * and standard therefore render identically — no badge.
+ */
+fun PayloadDescriptor.isHighQualityImage(): Boolean =
+    (descriptorInfo() as? DescriptorContent.ImageFile)?.quality == MediaQuality.HIGH
+
+/**
+ * HD marker for a photo overlaid on the image itself. Carries its own scrim because it sits
+ * on arbitrary picture content, where no surface role can guarantee contrast.
+ */
+@Composable
+fun HdBadge(modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier
+            .padding(6.dp)
+            .background(
+                color = MaterialTheme.colorScheme.scrim.copy(alpha = 0.55f),
+                shape = RoundedCornerShape(4.dp),
+            )
+            .padding(horizontal = 4.dp, vertical = 2.dp),
+    ) {
+        Icon(
+            imageVector = Icons.Default.Hd,
+            contentDescription = stringResource(MR.string.cd_media_quality_hd_badge),
+            tint = HomebaseTheme.extendedColors.bubbleSentOnSurface,
+            modifier = Modifier.size(16.dp),
+        )
+    }
+}

--- a/homebase-chat/src/commonTest/kotlin/id/homebase/chat/widget/MediaQualityBadgeTest.kt
+++ b/homebase-chat/src/commonTest/kotlin/id/homebase/chat/widget/MediaQualityBadgeTest.kt
@@ -1,0 +1,92 @@
+package id.homebase.chat.widget
+
+import id.homebase.api.client.drives.files.DescriptorContent
+import id.homebase.api.client.drives.files.PayloadDescriptor
+import id.homebase.api.image.MediaQuality
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The badge policy: only an explicitly recorded [MediaQuality.HIGH] shows an HD badge.
+ *
+ * Absent is "not recorded", never "standard" — every photo sent before the flag shipped
+ * reads as absent, and many of those were HD. Absent and standard therefore render
+ * identically (no badge), which is the intended outcome: a badge on the common case is
+ * noise, and a *missing* badge on an old HD photo is far better than a wrong one.
+ */
+class MediaQualityBadgeTest {
+
+    private fun image(descriptorContent: String?, contentType: String = "image/jpeg") =
+        PayloadDescriptor(
+            key = "chat_web0",
+            contentType = contentType,
+            descriptorContent = descriptorContent,
+        )
+
+    @Test
+    fun highQuality_isBadged() {
+        val wire = DescriptorContent.descriptorContentFromImage(
+            isSticker = false,
+            quality = MediaQuality.HIGH,
+        )
+        assertTrue(image(wire).isHighQualityImage())
+    }
+
+    @Test
+    fun explicitStandardQuality_isNotBadged() {
+        val wire = DescriptorContent.descriptorContentFromImage(
+            isSticker = false,
+            quality = MediaQuality.STANDARD,
+        )
+        assertFalse(image(wire).isHighQualityImage())
+    }
+
+    @Test
+    fun legacyBlankDescriptor_isNotBadged() {
+        // Every image sent before the flag shipped.
+        assertFalse(image("").isHighQualityImage())
+    }
+
+    @Test
+    fun nullDescriptor_isNotBadged() {
+        assertFalse(image(null).isHighQualityImage())
+    }
+
+    @Test
+    fun stickerDescriptorWithoutQuality_isNotBadged() {
+        val wire = DescriptorContent.descriptorContentFromImage(
+            isSticker = true,
+            format = "image/png",
+        )
+        assertFalse(image(wire, contentType = "image/png").isHighQualityImage())
+    }
+
+    @Test
+    fun malformedDescriptor_isNotBadged_noThrow() {
+        assertFalse(image("{not json").isHighQualityImage())
+    }
+
+    @Test
+    fun unknownQualityValue_isNotBadged() {
+        // A future client could record a quality this build has never heard of; coercing
+        // it to a badge would be a guess.
+        assertFalse(image("""{"isSticker":false,"quality":"ultra"}""").isHighQualityImage())
+    }
+
+    @Test
+    fun linkPreviewJsonArrayDescriptor_isNotBadged() {
+        // chat_links / chat_loc payloads are image/* but store a JSON array here.
+        assertFalse(image("""[{"url":"https://example.com"}]""").isHighQualityImage())
+    }
+
+    @Test
+    fun videoPayload_isNotBadged() {
+        val descriptor = PayloadDescriptor(
+            key = "chat_vid0",
+            contentType = "video/mp4",
+            descriptorContent = """{"mimeType":"video/mp4","isSegmented":false}""",
+        )
+        assertFalse(descriptor.isHighQualityImage())
+    }
+}

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/builder/MessageAttachmentBuilderQualityTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/builder/MessageAttachmentBuilderQualityTest.kt
@@ -1,0 +1,136 @@
+package id.homebase.chat.services.builder
+
+import id.homebase.api.client.drives.files.DescriptorContent
+import id.homebase.api.client.drives.files.PayloadDescriptor
+import id.homebase.api.file.FileOperationsProvider
+import id.homebase.api.image.MediaQuality
+import id.homebase.chat.widget.isHighQualityImage
+import io.ktor.client.request.forms.InputProvider
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.test.runTest
+import org.jetbrains.skia.ColorAlphaType
+import org.jetbrains.skia.ColorInfo
+import org.jetbrains.skia.ColorSpace
+import org.jetbrains.skia.ColorType
+import org.jetbrains.skia.EncodedImageFormat
+import org.jetbrains.skia.Image
+import org.jetbrains.skia.ImageInfo
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Send-side half of the HD indicator: MessageAttachmentBuilder records
+ * [MediaQuality.HIGH] on an ordinary photo's payload descriptor and records nothing
+ * otherwise, so that only a deliberate HD send is badgeable by the receiver.
+ */
+class MessageAttachmentBuilderQualityTest {
+
+    private fun opaqueJpeg(w: Int = 64, h: Int = 64): ByteArray {
+        val info = ImageInfo(
+            colorInfo = ColorInfo(ColorType.BGRA_8888, ColorAlphaType.UNPREMUL, ColorSpace.sRGB),
+            width = w,
+            height = h,
+        )
+        val bytes = ByteArray(w * h * 4)
+        for (i in bytes.indices step 4) {
+            bytes[i] = 0
+            bytes[i + 1] = (0x80).toByte()
+            bytes[i + 2] = (0xFF).toByte()
+            bytes[i + 3] = (0xFF).toByte()
+        }
+        return Image.makeRaster(info, bytes, w * 4)
+            .encodeToData(EncodedImageFormat.JPEG)?.bytes ?: error("encode failed")
+    }
+
+    private fun fakeFsServing(filePath: String, bytes: ByteArray) =
+        object : FileOperationsProvider {
+            override fun getCacheDirectory(): String = "/tmp/test-cache"
+            override fun openFileInput(path: String): InputProvider = fail("openFileInput")
+            override suspend fun readFileBytes(path: String): ByteArray {
+                assertEquals(filePath, path)
+                return bytes
+            }
+
+            override fun deleteTempFile(path: String): Boolean = false
+            override fun getFileSize(path: String): Long = bytes.size.toLong()
+            override suspend fun writeBytesToTempFile(
+                bytes: ByteArray, prefix: String, suffix: String,
+            ): String = fail("writeBytesToTempFile")
+
+            override suspend fun writeBytesToShareOutboundFile(
+                bytes: ByteArray, suffix: String,
+            ): String = fail("writeBytesToShareOutboundFile")
+
+            override suspend fun writeStream(path: String, data: Flow<ByteArray>) =
+                fail<Unit>("writeStream")
+
+            private fun <T> fail(name: String): T =
+                throw UnsupportedOperationException("$name should not be called from this test")
+        }
+
+    /** Rebuild the descriptor the way a receiver would. */
+    private fun received(descriptorContent: String?): PayloadDescriptor =
+        PayloadDescriptor(
+            key = "chat_web0",
+            contentType = "image/jpeg",
+            descriptorContent = descriptorContent,
+        )
+
+    private suspend fun sendPhoto(
+        quality: MediaQuality,
+        forceSticker: Boolean = false,
+    ): String? {
+        val path = "/tmp/photo-${quality.code}-$forceSticker.jpg"
+        val bundle = MessageAttachmentBuilder.buildSingle(
+            attachment = AttachmentInput(
+                filePath = path,
+                contentType = "image/jpeg",
+                forceSticker = forceSticker,
+            ),
+            fileOperationsProvider = fakeFsServing(path, opaqueJpeg()),
+            payloadKey = "chat_web0",
+            mediaQuality = quality,
+        )
+        return bundle.payloads.single().descriptorContent
+    }
+
+    @Test
+    fun highQualityPhoto_recordsHighOnTheWire() = runTest {
+        val descriptorContent = sendPhoto(MediaQuality.HIGH)
+
+        val info = received(descriptorContent).descriptorInfo()
+        assertTrue(info is DescriptorContent.ImageFile, "Expected ImageFile, got $info")
+        assertEquals(MediaQuality.HIGH, info.quality)
+        assertFalse(info.isSticker, "A photo sent in HD is still not a sticker")
+        assertTrue(received(descriptorContent).isHighQualityImage())
+    }
+
+    @Test
+    fun standardQualityPhoto_recordsNothing_andIsNotBadged() = runTest {
+        val descriptorContent = sendPhoto(MediaQuality.STANDARD)
+
+        // STANDARD keeps the legacy blank descriptor, so it is indistinguishable on the
+        // wire from a photo sent before the flag existed — both render no badge.
+        assertEquals("", descriptorContent)
+        val info = received(descriptorContent).descriptorInfo()
+        assertTrue(info is DescriptorContent.ImageFile)
+        assertNull(info.quality)
+        assertFalse(received(descriptorContent).isHighQualityImage())
+    }
+
+    @Test
+    fun sticker_neverRecordsQuality_evenWhenSentAsHigh() = runTest {
+        // A sticker's bytes are bounded at 512px regardless of the toggle, so "HD" would
+        // be a false claim.
+        val descriptorContent = sendPhoto(MediaQuality.HIGH, forceSticker = true)
+
+        val info = received(descriptorContent).descriptorInfo()
+        assertTrue(info is DescriptorContent.ImageFile)
+        assertTrue(info.isSticker)
+        assertNull(info.quality)
+        assertFalse(received(descriptorContent).isHighQualityImage())
+    }
+}

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/widget/HdBadgeRenderTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/widget/HdBadgeRenderTest.kt
@@ -1,0 +1,72 @@
+package id.homebase.chat.widget
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.onAllNodesWithContentDescription
+import androidx.compose.ui.test.runDesktopComposeUiTest
+import id.homebase.api.client.drives.files.DescriptorContent
+import id.homebase.api.client.drives.files.PayloadDescriptor
+import id.homebase.api.image.MediaQuality
+import id.homebase.core.ui.theme.HomebaseTheme
+import kotlin.test.Test
+
+/**
+ * Render-level lock on the badge policy: a photo carrying no quality must draw NOTHING,
+ * exactly like one that explicitly recorded standard. Only HIGH draws the badge.
+ */
+@OptIn(ExperimentalTestApi::class)
+class HdBadgeRenderTest {
+
+    private val badgeDescription = "Sent in high quality"
+
+    private fun image(descriptorContent: String?) = PayloadDescriptor(
+        key = "chat_web0",
+        contentType = "image/jpeg",
+        descriptorContent = descriptorContent,
+    )
+
+    @Composable
+    private fun BubbleFor(payload: PayloadDescriptor) {
+        HomebaseTheme(darkTheme = false, followsSystemTheme = false) {
+            Box(Modifier.fillMaxSize()) {
+                if (payload.isHighQualityImage()) HdBadge()
+            }
+        }
+    }
+
+    private fun assertBadgeCount(payload: PayloadDescriptor, expected: Int) =
+        runDesktopComposeUiTest(200, 200) {
+            setContent { BubbleFor(payload) }
+            onAllNodesWithContentDescription(badgeDescription).assertCountEquals(expected)
+        }
+
+    @Test
+    fun highQualityPhoto_drawsTheBadge() {
+        val wire = DescriptorContent.descriptorContentFromImage(
+            isSticker = false,
+            quality = MediaQuality.HIGH,
+        )
+        assertBadgeCount(image(wire), 1)
+    }
+
+    @Test
+    fun explicitStandardPhoto_drawsNothing() {
+        val wire = DescriptorContent.descriptorContentFromImage(
+            isSticker = false,
+            quality = MediaQuality.STANDARD,
+        )
+        assertBadgeCount(image(wire), 0)
+    }
+
+    @Test
+    fun photoWithNoQualityRecorded_drawsNothing() {
+        // The pre-flag corpus. Many of these really were HD; a badge here would be a guess
+        // and a "standard" label would be a lie, so the surface stays empty.
+        assertBadgeCount(image(""), 0)
+        assertBadgeCount(image(null), 0)
+    }
+}

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -1427,6 +1427,7 @@
     <string name="chat_media_quality_hd">HD</string>
     <string name="cd_media_quality_high_on">High quality is on. Tap to send smaller photos and videos.</string>
     <string name="cd_media_quality_high_off">High quality is off. Tap to send photos and videos at full quality.</string>
+    <string name="cd_media_quality_hd_badge">Sent in high quality</string>
 
     <!-- Settings hub -->
     <string name="settings_section_preferences">Preferences</string>


### PR DESCRIPTION
Closes #1384.

The composer's HD chip changed the encode but left no trace on the wire, so once a photo
was sent neither end could tell a full-quality photo from a downscaled one. This records
the quality and badges it.

## The wire-format addition

`DescriptorContent.ImageFile` — the per-image descriptor that already rides on
`PayloadDescriptor.descriptorContent` and today carries `isSticker` / `format` — gains an
optional `quality: MediaQuality?`. No new protocol surface, no new payload, no header-budget
pressure: the object is `{"isSticker":false,"quality":"high"}`, ~34 bytes, and only on photos
that actually claim HD. `MediaQuality` becomes `@Serializable` with `@SerialName` values
matching its existing `code` (`"standard"` / `"high"`) so the wire spelling is the same one
the rest of the codebase already persists. `MessageAttachmentBuilder` already had
`mediaQuality` threaded in, so the send side is a three-line change.

**STANDARD writes nothing at all.** It keeps the legacy `""` descriptor, so an ordinary photo
is byte-identical on the wire to what it was before this PR — the same conservatism the
sticker feature used. The descriptor is only emitted when it carries information.

**Stickers never record quality.** A sticker skips `standardQualityImage` and is bounded at
512px by `StickerImageProcessor` regardless of the toggle, so "HD" would be a false claim.

## Absent means unknown, and renders nothing

Absent is **not** treated as "not HD" in the UI. Every photo sent before this ships reads as
absent, and many of those genuinely were HD — rendering them as standard would mislabel the
entire existing corpus. So absent draws nothing.

Standard also draws nothing: a badge on the overwhelmingly common case is noise. That makes
absent and standard render identically, which is the intended outcome — a *missing* badge on
an old HD photo is much cheaper than a *wrong* label on one.

## Where the badge renders, and where it deliberately does not

- **Solo photo bubble — yes.** Top-start, a bold `HD` on a `colorScheme.scrim` chip. Top-start
  rather than bottom: the media-only bubble's timestamp + delivery-status scrim is a 40dp
  bottom gradient drawn by the parent *over* this box, so a bottom badge would be dimmed by
  it, and top-start is also the one position that works identically for captioned bubbles
  (which have no scrim and put the timestamp below the media).
- **Fullscreen viewer — yes.** Appended to the app bar's timestamp line as `12:34 · HD`. This
  is the surface where "should I download or re-share this?" is actually decided, it has room,
  and it needs no overlay on the picture at all. It is per-payload, so it follows the pager.
- **Gallery / album cells — deliberately no.** The three-image layout's cells are ~104×69dp and
  the four-plus layout already overlays a "+N" scrim. Per-cell HD chips in a 4-up album would
  be clutter for a surface whose whole job is "tap to open" — and opening it lands on the
  fullscreen viewer, which does badge. This is the one place the badge is intentionally absent
  on media that qualifies for it.

The badge is text, not `Icons.Default.Hd`. I rendered both to PNG: the filled glyph is a solid
plate with HD knocked out of it, so white-on-scrim comes out as a white blob nested inside the
chip's own rounded rect; `Icons.Outlined.Hd` is two nested outlines. Bold `labelSmall` text is
one shape and legible at bubble-corner size. It also reuses `chat_media_quality_hd` — the
string the issue notes had exactly one consumer — so the marker on the photo is literally the
same word as the control the sender tapped.

## Video is out of scope

Video does **not** ride this descriptor and should not be bolted onto it:

1. Its descriptor is `VideoMetadata`, a different serialized type.
2. `MediaQuality.HIGH` for images is a byte-for-byte contract. For video it is only a
   *requested* encoder target — `VideoPayloadProcessor` can fall back to the input path
   entirely (`skipped=${compressedPath == payload.filePath}`), and a 480p source encoded at
   HIGH is still 480p. Recording the request would badge non-HD video as HD.
3. `VideoMetadata` already records `widthPx`/`heightPx` probed from the delivered output, so if
   a video badge is wanted the honest source is measured height, not the requested enum.

That is a different design and deserves its own issue rather than widening this diff.

## Tests

29 tests, JVM (`homebase-api`, `homebase-chat`), 0 skipped:

- `MessageAttachmentBuilderQualityTest` — a HIGH send records `high`; a STANDARD send records
  nothing and is not badged; a sticker never records quality even when sent as HIGH.
- `MediaQualityBadgeTest` — the badge predicate across HIGH / explicit standard / legacy blank /
  null / malformed / unknown-enum-value / link-preview JSON-array / video payloads.
- `HdBadgeRenderTest` — Compose render assertions: HIGH draws one badge, explicit standard and
  no-recorded-quality draw zero. This pins the absent→nothing decision at the UI layer, not
  just in the predicate.
- `PayloadDescriptorImageTest` — serialize/deserialize round trip, lowercase wire spelling,
  quality omitted when unrecorded, sticker+quality coexistence with an unknown sibling key, and
  an unknown quality value coercing to null rather than to a quality.

**Mutation-checked** (production logic deliberately broken, tests confirmed to fail, then
reverted):

| Mutation | Result |
|---|---|
| `isHighQualityImage()` treats absent as HD (`!= STANDARD`) | 9 tests fail |
| `MessageAttachmentBuilder` records quality for STANDARD too | `standardQualityPhoto_recordsNothing_andIsNotBadged` fails |
| Drop `@SerialName("high")` so the wire says `HIGH` | `quality_roundTripsThroughTheWire` fails |
| Absent-as-HD, checked against the *render* test specifically | `photoWithNoQualityRecorded_drawsNothing` fails |

Compiles on all four targets: JVM, iOS (`compileKotlinIosSimulatorArm64`), Android, wasmJs.

## Verified on an iOS simulator

Run for real on two simulators, one identity each: `frodo.baggins.demo.rocks` sending on an
iPhone 17 Pro Max, `samwise.gamgee.demo.rocks` receiving on an iPhone 17e.

- HD sent bubble, light and dark; badge top-start, legible over a bright sky, clear of the
  timestamp scrim.
- **HD received bubble on the second identity**, light and dark — the flag survives transit,
  which is the whole reason it is on the wire.
- Captioned HD bubble: no scrim, timestamp below the media, badge still top-start.
- Fullscreen viewer app bar reading `1m ago · HD`.
- Standard-quality photo and a pre-existing photo from **Aug 18** — both render no badge.
- 2×2 album of four HD photos — no badge on any cell.

The accessibility tree gives this machine-readably, since the badge sets a contentDescription:
a HD bubble reads `"Image attachment, Sent in high quality, …"`, a standard or pre-existing one
reads only `"Image attachment"`. The descriptor itself was observable on device as
`{"isSticker":false,"quality":"high"}`.

Device testing also turned up a real bug and fixed it: `FullScreenMediaViewer` used
`payload.descriptorContent` as the image's `contentDescription`, which was harmlessly empty
before this branch but now made VoiceOver read the descriptor JSON aloud. It uses the proper
string resource now.

## What was NOT verified

- **Android** — iOS simulator only.
- **Video**, which this PR deliberately leaves alone.
