### PR TITLE
WebDrop: snapshot picked files at pick time, fail loudly when a source dies

### DIFF
--- a/homebase-chat/src/androidMain/kotlin/id/homebase/chat/conversationlist/AttachmentUploadResolve.android.kt
+++ b/homebase-chat/src/androidMain/kotlin/id/homebase/chat/conversationlist/AttachmentUploadResolve.android.kt
@@ -1,26 +1,6 @@
 package id.homebase.chat.conversationlist
 
-import id.homebase.api.file.FileOperationsProvider
-import io.github.vinceglb.filekit.FileKit
 import io.github.vinceglb.filekit.PlatformFile
-import io.github.vinceglb.filekit.cacheDir
-import io.github.vinceglb.filekit.copyTo
-import io.github.vinceglb.filekit.mimeType
-import io.github.vinceglb.filekit.name
-
-// Native PlatformFile carries a real path / content:// URI; the existing path-based send
-// pipeline (and resolveToFilePath for content URIs) already handles it. No copy needed at send time.
-actual suspend fun PlatformFile.toUploadPath(fileOps: FileOperationsProvider): String = toString()
-
-// Copy the picked file into the sandbox cache dir at pick time, mirroring the working Vault upload
-// contract. On Android the picked file is a content:// URI whose read grant can be transient;
-// copying through FileKit's copyTo (which reads the content URI) yields a stable plain file the
-// send path can always read — equivalent to the downstream resolveToFilePath copy, just earlier.
-actual suspend fun PlatformFile.materializeForUpload(fileOps: FileOperationsProvider): PlatformFile {
-    val dest = PlatformFile(FileKit.cacheDir, sandboxCopyName(name, mimeType()?.toString()))
-    copyTo(dest)
-    return dest
-}
 
 // Native: ExoPlayer/MediaMetadataRetriever read the path/content:// URI directly; nothing to revoke.
 actual fun PlatformFile.toPlayableUrl(): String = toString()

--- a/homebase-chat/src/appleMain/kotlin/id/homebase/chat/conversationlist/AttachmentUploadResolve.apple.kt
+++ b/homebase-chat/src/appleMain/kotlin/id/homebase/chat/conversationlist/AttachmentUploadResolve.apple.kt
@@ -1,29 +1,6 @@
 package id.homebase.chat.conversationlist
 
-import id.homebase.api.file.FileOperationsProvider
-import io.github.vinceglb.filekit.FileKit
 import io.github.vinceglb.filekit.PlatformFile
-import io.github.vinceglb.filekit.cacheDir
-import io.github.vinceglb.filekit.copyTo
-import io.github.vinceglb.filekit.mimeType
-import io.github.vinceglb.filekit.name
-
-// iOS PlatformFile carries a real file path; the path-based send pipeline reads it directly.
-// No copy needed at send time — the scoped copy happened at pick time (materializeForUpload).
-actual suspend fun PlatformFile.toUploadPath(fileOps: FileOperationsProvider): String = toString()
-
-// Copy the picked file into the sandbox cache dir WHILE the picker's security scope is still live
-// (this runs in the picker-callback launch before any further suspension). FileKit's copyTo opens
-// the source through its NSURL — which still holds the scope grant here — and writes a plain
-// sandbox file, so the later scope-less path read in the send path always succeeds.
-// Keep the original name (plus a MIME-derived extension when it has none) so the send path's
-// content-type / display-name resolution still works; prefix with a uuid so concurrent picks
-// can't collide. See sandboxCopyName.
-actual suspend fun PlatformFile.materializeForUpload(fileOps: FileOperationsProvider): PlatformFile {
-    val dest = PlatformFile(FileKit.cacheDir, sandboxCopyName(name, mimeType()?.toString()))
-    copyTo(dest)
-    return dest
-}
 
 // Native: AVPlayer/AVAssetImageGenerator read the path directly; nothing to revoke.
 actual fun PlatformFile.toPlayableUrl(): String = toString()

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/AttachmentHandler.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/AttachmentHandler.kt
@@ -39,6 +39,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlin.uuid.Uuid
+import id.homebase.core.files.materializeForUpload
 
 /**
  * Handles attachment-editor and audio-recording action arms (attach / unattach

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/AttachmentUploadResolve.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/AttachmentUploadResolve.kt
@@ -1,67 +1,15 @@
 package id.homebase.chat.conversationlist
 
-import id.homebase.api.file.FileOperationsProvider
-import id.homebase.core.util.contentType
-import id.homebase.core.util.extensionForMimeType
 import io.github.vinceglb.filekit.PlatformFile
-import io.github.vinceglb.filekit.mimeType
-import kotlin.uuid.Uuid
 
-/**
- * Resolves a picked [PlatformFile] to a path that [fileOps] can read for upload.
- *
- * The send pipeline is path-based: it takes `attachment.file.toString()` and later reads the
- * bytes via [FileOperationsProvider]. That works on native, where a picked [PlatformFile] is
- * backed by a real filesystem path (or an Android `content://` URI that `resolveToFilePath`
- * copies downstream) — so the native actuals return [PlatformFile.toString] unchanged, with no
- * extra copy.
- *
- * On the web there is NO path: FileKit's `PlatformFile.path` lives in its non-web source set,
- * and a browser-picked file's bytes are reachable only through `readBytes()`. So `file.toString()`
- * is not an okio path and the upload's `readFileBytes(...)` fails with "file not found". The web
- * actual fixes this by copying the picked bytes into the okio (in-memory) cache via [fileOps] and
- * returning that path, so the rest of the path-based pipeline just works.
- */
-expect suspend fun PlatformFile.toUploadPath(fileOps: FileOperationsProvider): String
-
-/**
- * Copy a freshly-picked [PlatformFile] into the app sandbox **at pick time** and return a
- * sandbox-backed [PlatformFile], or return `this` unchanged when no copy is needed.
- *
- * This exists because an iOS document/Files-app picker vends a **security-scoped** `NSURL`: the
- * read grant is bound to that specific URL object, not to its path string. The chat send path is
- * path-based — it keeps only `file.toString()` and reads the bytes later, inside a separate
- * `scope.launch`, by rebuilding a scope-LESS `NSURL.fileURLWithPath(path)`. By then the original
- * scoped URL is gone, `startAccessingSecurityScopedResource()` on the path-built URL returns false,
- * and `NSData.dataWithContentsOfFile` returns nil → "Unable to read file". Copying into the sandbox
- * **while the picker's scope is still live** (this is called synchronously in the picker callback's
- * launch, before any further suspension) yields a path the send path can always read with no scope.
- *
- * Mirrors the working Vault contract (`VaultViewModel` copies picked files via FileKit `copyTo`
- * before upload). FileKit's `copyTo` is what handles the security scope on apple.
- *
- * - apple/android/jvm: copy into the FileKit cache dir, preserving the original file name (so the
- *   send path's content-type / display-name resolution from `file.name` is unchanged).
- * - web: no-op (`this`). The browser has no path and no security scope; the picked `PlatformFile`
- *   keeps its bytes and [toUploadPath]'s web actual materializes them at send time via `readBytes()`.
- */
-expect suspend fun PlatformFile.materializeForUpload(fileOps: FileOperationsProvider): PlatformFile
-
-/**
- * Name for the pick-time sandbox copy: the original name behind a collision-proof prefix, plus an
- * extension derived from [mimeType] when the picker's name has none. Belt to
- * [PlatformFile.contentType]'s braces — it keeps the copy self-describing for anything that only
- * sees the file (#1149).
- */
-internal fun sandboxCopyName(name: String, mimeType: String?): String {
-    val hasExtension = name.substringAfterLast('.', "").isNotEmpty()
-    val ext = if (hasExtension) null else mimeType?.let(::extensionForMimeType)
-    return "chat_attach_${Uuid.random()}_$name" + if (ext != null) ".$ext" else ""
-}
+// The pick-time/send-time materialization helpers (materializeForUpload, toUploadPath) moved to
+// id.homebase.core.files.UploadMaterialize in homebase-common - they are the platform-wide answer
+// to "I picked a file now and will read it later", not a chat-ism. Only the playback-handle pair
+// below is chat-specific enough to stay.
 
 /**
  * A handle the in-editor video decoder/player can read **immediately**, without the expensive
- * okio materialization [toUploadPath] performs (whole-file read + in-memory copy).
+ * okio materialization `toUploadPath` performs (whole-file read + in-memory copy).
  *
  * - Native (Android/iOS/Desktop): the real filesystem path — identical to [PlatformFile.toString];
  *   the native decoders/players read it directly.
@@ -71,25 +19,10 @@ internal fun sandboxCopyName(name: String, mimeType: String?): String {
  *   from it. Release it with [revokePlayableUrl] once the attachment is gone.
  *
  * This is what gets stored in `AttachmentPendingFile.FileVideo.playablePath`. The upload pipeline
- * still calls [toUploadPath] at send time to materialize bytes into okio for encryption — that is
+ * still calls `toUploadPath` at send time to materialize bytes into okio for encryption — that is
  * unaffected by this handle.
  */
 expect fun PlatformFile.toPlayableUrl(): String
 
 /** Release a [toPlayableUrl] handle. No-op on native and for non-`blob:` strings. */
 expect fun revokePlayableUrl(url: String)
-
-/**
- * Shared materialize step used by the web actual: copy [bytes] into a temp file via [fileOps]
- * and return its path, preserving [fileName]'s extension in the suffix. Extracted to commonMain
- * so the copy-and-readability contract can be unit-tested without a browser.
- */
-internal suspend fun materializeBytesToUploadPath(
-    fileOps: FileOperationsProvider,
-    fileName: String,
-    bytes: ByteArray,
-): String {
-    val ext = fileName.substringAfterLast('.', "")
-    val suffix = if (ext.isNotEmpty()) ".$ext" else ""
-    return fileOps.writeBytesToTempFile(bytes, "attach_", suffix)
-}

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/MessageActionsHandler.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/MessageActionsHandler.kt
@@ -79,6 +79,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlin.time.Instant
 import kotlin.uuid.Uuid
+import id.homebase.core.files.toUploadPath
 
 private const val TAG = "ConversationListViewModel"
 

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/event/EventComposerSheet.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/event/EventComposerSheet.kt
@@ -69,7 +69,7 @@ import id.homebase.api.util.truncateToCodePoints
 import id.homebase.chat.composer.ComposerEditableField
 import id.homebase.chat.composer.ComposerRow
 import id.homebase.chat.composer.ComposerTitleField
-import id.homebase.chat.conversationlist.materializeForUpload
+import id.homebase.core.files.materializeForUpload
 import id.homebase.core.location.rememberCurrentGps
 import id.homebase.core.location.tracking.GpsFixResult
 import id.homebase.chat.services.ChatMessageSenderService

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/builder/ImageAttachmentResolve.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/builder/ImageAttachmentResolve.kt
@@ -2,7 +2,7 @@ package id.homebase.chat.services.builder
 
 import id.homebase.api.file.FileOperationsProvider
 import id.homebase.api.image.convertHeicToJpeg
-import id.homebase.chat.conversationlist.toUploadPath
+import id.homebase.core.files.toUploadPath
 import id.homebase.core.util.contentType
 import io.github.vinceglb.filekit.PlatformFile
 import io.github.vinceglb.filekit.name

--- a/homebase-chat/src/jvmMain/kotlin/id/homebase/chat/conversationlist/AttachmentUploadResolve.jvm.kt
+++ b/homebase-chat/src/jvmMain/kotlin/id/homebase/chat/conversationlist/AttachmentUploadResolve.jvm.kt
@@ -1,25 +1,6 @@
 package id.homebase.chat.conversationlist
 
-import id.homebase.api.file.FileOperationsProvider
-import io.github.vinceglb.filekit.FileKit
 import io.github.vinceglb.filekit.PlatformFile
-import io.github.vinceglb.filekit.cacheDir
-import io.github.vinceglb.filekit.copyTo
-import io.github.vinceglb.filekit.mimeType
-import io.github.vinceglb.filekit.name
-
-// Desktop PlatformFile carries a real filesystem path; the path-based send pipeline reads it
-// directly. No copy needed at send time.
-actual suspend fun PlatformFile.toUploadPath(fileOps: FileOperationsProvider): String = toString()
-
-// Copy the picked file into the sandbox cache dir at pick time, mirroring the working Vault upload
-// contract so all native platforms behave the same. Desktop has no security scope, but copying a
-// real filesystem path is cheap and harmless and keeps the send path reading a sandbox file.
-actual suspend fun PlatformFile.materializeForUpload(fileOps: FileOperationsProvider): PlatformFile {
-    val dest = PlatformFile(FileKit.cacheDir, sandboxCopyName(name, mimeType()?.toString()))
-    copyTo(dest)
-    return dest
-}
 
 // Native: the real path is already okio/VLCJ-readable; no blob URL to mint or revoke.
 actual fun PlatformFile.toPlayableUrl(): String = toString()

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/builder/ImageAttachmentContentTypeTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/builder/ImageAttachmentContentTypeTest.kt
@@ -1,7 +1,6 @@
 package id.homebase.chat.services.builder
 
 import id.homebase.api.file.FileOperationsProvider
-import id.homebase.chat.conversationlist.sandboxCopyName
 import io.github.vinceglb.filekit.PlatformFile
 import io.ktor.client.request.forms.InputProvider
 import kotlinx.coroutines.flow.Flow
@@ -40,19 +39,7 @@ class ImageAttachmentContentTypeTest {
         assertEquals("application/octet-stream", copy.toImageAttachmentInput(NoopFileOps()).contentType)
     }
 
-    @Test
-    fun sandboxCopyName_appendsExtensionWhenPickerNameHasNone() {
-        val name = sandboxCopyName("photopicker-1000022602", "image/jpeg")
 
-        assertTrue(name.endsWith("_photopicker-1000022602.jpg"), "expected .jpg suffix, got: $name")
-    }
-
-    @Test
-    fun sandboxCopyName_keepsAnExistingExtensionAndSurvivesAnUnmappedMime() {
-        assertTrue(sandboxCopyName("IMG_2026.jpeg", "image/jpeg").endsWith("_IMG_2026.jpeg"))
-        assertTrue(sandboxCopyName("raw-shot", "image/x-not-a-real-mime").endsWith("_raw-shot"))
-        assertTrue(sandboxCopyName("raw-shot", null).endsWith("_raw-shot"))
-    }
 }
 
 private class NoopFileOps : FileOperationsProvider {

--- a/homebase-chat/src/wasmJsMain/kotlin/id/homebase/chat/conversationlist/AttachmentUploadResolve.web.kt
+++ b/homebase-chat/src/wasmJsMain/kotlin/id/homebase/chat/conversationlist/AttachmentUploadResolve.web.kt
@@ -2,22 +2,7 @@
 
 package id.homebase.chat.conversationlist
 
-import id.homebase.api.file.FileOperationsProvider
 import io.github.vinceglb.filekit.PlatformFile
-import io.github.vinceglb.filekit.name
-import io.github.vinceglb.filekit.readBytes
-
-// The browser has no filesystem path for a picked PlatformFile (FileKit's PlatformFile.path is
-// non-web-only); its bytes are reachable only via readBytes(). Copy them into the okio in-memory
-// cache so the path-based send pipeline can read them back. Without this, web sends fail because
-// file.toString() isn't an okio path ("file not found").
-actual suspend fun PlatformFile.toUploadPath(fileOps: FileOperationsProvider): String =
-    materializeBytesToUploadPath(fileOps, name, readBytes())
-
-// No-op on web: the browser has no filesystem path to copy to and no security scope to lose. The
-// picked PlatformFile keeps its bytes; toUploadPath() above materializes them at send time via
-// readBytes(). (FileKit's copyTo / cacheDir aren't available on wasmJs.)
-actual suspend fun PlatformFile.materializeForUpload(fileOps: FileOperationsProvider): PlatformFile = this
 
 // Mint a blob: object URL straight from the picked browser File. This is O(1): the browser keeps
 // the File's bytes and the <video>/canvas stream from the URL on demand — no readBytes(), no copy

--- a/homebase-common/src/androidMain/kotlin/id/homebase/core/files/UploadMaterialize.android.kt
+++ b/homebase-common/src/androidMain/kotlin/id/homebase/core/files/UploadMaterialize.android.kt
@@ -1,0 +1,22 @@
+package id.homebase.core.files
+
+import id.homebase.api.file.FileOperationsProvider
+import io.github.vinceglb.filekit.FileKit
+import io.github.vinceglb.filekit.PlatformFile
+import io.github.vinceglb.filekit.cacheDir
+import io.github.vinceglb.filekit.copyTo
+import io.github.vinceglb.filekit.mimeType
+import io.github.vinceglb.filekit.name
+
+// Native PlatformFile carries a real path / content:// URI; the path-based pipelines (and
+// resolveToFilePath for content URIs) already handle it. No copy needed at send time.
+actual suspend fun PlatformFile.toUploadPath(fileOps: FileOperationsProvider): String = toString()
+
+// On Android the picked file is a content:// URI whose read grant can be transient;
+// copying through FileKit's copyTo (which reads the content URI) yields a stable plain file the
+// send path can always read — equivalent to the downstream resolveToFilePath copy, just earlier.
+actual suspend fun PlatformFile.materializeForUpload(fileOps: FileOperationsProvider): PlatformFile {
+    val dest = PlatformFile(FileKit.cacheDir, sandboxCopyName(name, mimeType()?.toString()))
+    copyTo(dest)
+    return dest
+}

--- a/homebase-common/src/appleMain/kotlin/id/homebase/core/files/UploadMaterialize.apple.kt
+++ b/homebase-common/src/appleMain/kotlin/id/homebase/core/files/UploadMaterialize.apple.kt
@@ -1,0 +1,23 @@
+package id.homebase.core.files
+
+import id.homebase.api.file.FileOperationsProvider
+import io.github.vinceglb.filekit.FileKit
+import io.github.vinceglb.filekit.PlatformFile
+import io.github.vinceglb.filekit.cacheDir
+import io.github.vinceglb.filekit.copyTo
+import io.github.vinceglb.filekit.mimeType
+import io.github.vinceglb.filekit.name
+
+// Native PlatformFile carries a real path / content:// URI; the path-based pipelines (and
+// resolveToFilePath for content URIs) already handle it. No copy needed at send time.
+actual suspend fun PlatformFile.toUploadPath(fileOps: FileOperationsProvider): String = toString()
+
+// Copy WHILE the picker's security scope is still live (this runs in the picker-callback
+// launch before any further suspension). FileKit's copyTo opens the source through its NSURL —
+// which still holds the scope grant here — and writes a plain sandbox file, so the later
+// scope-less path read always succeeds.
+actual suspend fun PlatformFile.materializeForUpload(fileOps: FileOperationsProvider): PlatformFile {
+    val dest = PlatformFile(FileKit.cacheDir, sandboxCopyName(name, mimeType()?.toString()))
+    copyTo(dest)
+    return dest
+}

--- a/homebase-common/src/commonMain/composeResources/values-da/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values-da/strings.xml
@@ -1726,5 +1726,6 @@
     <string name="webdrop_revoke_cancel">Annullér</string>
     <string name="webdrop_files_and_age">%1$s &#183; %2$s</string>
     <string name="webdrop_error_create">Kunne ikke oprette drop-linket</string>
+    <string name="webdrop_error_source_unreadable">Kunne ikke læse %1$s — vælg den venligst igen</string>
     <string name="webdrop_error_too_many">Et drop kan højst indeholde %1$d filer</string>
 </resources>

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -2147,5 +2147,6 @@
     <string name="webdrop_revoke_cancel">Cancel</string>
     <string name="webdrop_files_and_age">%1$s &#183; %2$s</string>
     <string name="webdrop_error_create">Couldn't create the drop link</string>
+    <string name="webdrop_error_source_unreadable">Couldn't read %1$s — please pick it again</string>
     <string name="webdrop_error_too_many">A drop can hold at most %1$d files</string>
 </resources>

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/files/UploadMaterialize.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/files/UploadMaterialize.kt
@@ -1,0 +1,79 @@
+package id.homebase.core.files
+
+import id.homebase.api.file.FileOperationsProvider
+import id.homebase.core.util.extensionForMimeType
+import io.github.vinceglb.filekit.PlatformFile
+import kotlin.uuid.Uuid
+
+/**
+ * Resolves a picked [PlatformFile] to a path that [fileOps] can read for upload.
+ *
+ * Path-based upload pipelines keep `file.toString()` and later read the bytes via
+ * [FileOperationsProvider]. That works on native, where a picked [PlatformFile] is backed by a
+ * real filesystem path (or an Android `content://` URI that `resolveToFilePath` copies
+ * downstream) — so the native actuals return [PlatformFile.toString] unchanged, with no extra
+ * copy.
+ *
+ * On the web there is NO path: FileKit's `PlatformFile.path` lives in its non-web source set,
+ * and a browser-picked file's bytes are reachable only through `readBytes()`. So `file.toString()`
+ * is not an okio path and the upload's `readFileBytes(...)` fails with "file not found". The web
+ * actual fixes this by copying the picked bytes into the okio (in-memory) cache via [fileOps] and
+ * returning that path, so the rest of the path-based pipeline just works.
+ */
+expect suspend fun PlatformFile.toUploadPath(fileOps: FileOperationsProvider): String
+
+/**
+ * Copy a freshly-picked [PlatformFile] into the app sandbox **at pick time** and return a
+ * sandbox-backed [PlatformFile], or return `this` unchanged when no copy is needed.
+ *
+ * This is the platform's one answer to "I picked a file now and will read it later" — every
+ * picker that stores a path across time must go through it, because two platforms revoke
+ * access behind your back:
+ *
+ * - Android grants only transient read permission to a picked `content://` URI; keep the raw
+ *   URI and read it later and you get FileNotFoundException when the grant lapses (WebDrop's
+ *   issue #1420 was exactly this).
+ * - An iOS document/Files-app picker vends a **security-scoped** `NSURL`: the read grant is
+ *   bound to that specific URL object, not to its path string. A later scope-LESS
+ *   `NSURL.fileURLWithPath(path)` read returns nil. Copying into the sandbox **while the
+ *   picker's scope is still live** (call this synchronously in the picker callback's launch,
+ *   before any further suspension) yields a path that can always be read with no scope.
+ *
+ * FileKit's `copyTo` is what handles the security scope on apple.
+ *
+ * - apple/android/jvm: copy into the FileKit cache dir, preserving the original file name (so
+ *   content-type / display-name resolution from `file.name` is unchanged).
+ * - web: no-op (`this`). The browser has no path and no security scope; the picked
+ *   [PlatformFile] keeps its bytes and [toUploadPath]'s web actual materializes them at send
+ *   time via `readBytes()`.
+ */
+expect suspend fun PlatformFile.materializeForUpload(fileOps: FileOperationsProvider): PlatformFile
+
+/**
+ * Name for the pick-time sandbox copy: the original name behind a collision-proof prefix, plus an
+ * extension derived from [mimeType] when the picker's name has none. Belt to
+ * `PlatformFile.contentType`'s braces — it keeps the copy self-describing for anything that only
+ * sees the file (#1149). The prefix is historical (the helper grew up in chat) and is deliberately
+ * kept: CacheSweeper reaps it as untracked either way, and a rename would orphan nothing but
+ * grep results.
+ */
+internal fun sandboxCopyName(name: String, mimeType: String?): String {
+    val hasExtension = name.substringAfterLast('.', "").isNotEmpty()
+    val ext = if (hasExtension) null else mimeType?.let(::extensionForMimeType)
+    return "chat_attach_${Uuid.random()}_$name" + if (ext != null) ".$ext" else ""
+}
+
+/**
+ * Shared materialize step used by the web actual: copy [bytes] into a temp file via [fileOps]
+ * and return its path, preserving [fileName]'s extension in the suffix. Extracted to commonMain
+ * so the copy-and-readability contract can be unit-tested without a browser.
+ */
+internal suspend fun materializeBytesToUploadPath(
+    fileOps: FileOperationsProvider,
+    fileName: String,
+    bytes: ByteArray,
+): String {
+    val ext = fileName.substringAfterLast('.', "")
+    val suffix = if (ext.isNotEmpty()) ".$ext" else ""
+    return fileOps.writeBytesToTempFile(bytes, "attach_", suffix)
+}

--- a/homebase-common/src/commonTest/kotlin/id/homebase/core/files/UploadMaterializeTest.kt
+++ b/homebase-common/src/commonTest/kotlin/id/homebase/core/files/UploadMaterializeTest.kt
@@ -1,4 +1,4 @@
-package id.homebase.chat.conversationlist
+package id.homebase.core.files
 
 import id.homebase.api.file.FileOperationsProvider
 import io.ktor.client.request.forms.InputProvider
@@ -11,13 +11,13 @@ import kotlin.test.assertTrue
 /**
  * Guards the contract the web `PlatformFile.toUploadPath` actual relies on: a picked file's
  * bytes, once materialized, must be READABLE BACK through the same [FileOperationsProvider] the
- * send pipeline uses. The web Gallery/image send bug was exactly this contract being skipped —
+ * upload pipelines use. The web Gallery/image send bug was exactly this contract being skipped —
  * the raw browser PlatformFile was never copied into okio, so `readFileBytes` couldn't find it.
  *
  * (The web `readBytes()` interop itself can't run without a browser; this covers the shared
  * copy-and-readability logic, which is the part that was missing.)
  */
-class AttachmentUploadResolveTest {
+class UploadMaterializeTest {
 
     @Test
     fun materializedPathIsReadableBackWithSameProvider() = runTest {
@@ -52,9 +52,22 @@ class AttachmentUploadResolveTest {
         assertEquals(listOf<Byte>(1), fs.readFileBytes(a).toList())
         assertEquals(listOf<Byte>(2), fs.readFileBytes(b).toList())
     }
+
+    @Test
+    fun sandboxCopyNameAppendsExtensionWhenPickerNameHasNone() {
+        val name = sandboxCopyName("photopicker-1000022602", "image/jpeg")
+        assertTrue(name.endsWith(".jpg"), "expected a .jpg suffix, got: $name")
+        assertTrue(name.startsWith("chat_attach_"))
+    }
+
+    @Test
+    fun sandboxCopyNameKeepsAnExistingExtensionAndSurvivesAnUnmappedMime() {
+        assertTrue(sandboxCopyName("IMG_2026.jpeg", "image/jpeg").endsWith("_IMG_2026.jpeg"))
+        assertTrue(sandboxCopyName("raw-shot", "image/x-not-a-real-mime").endsWith("_raw-shot"))
+        assertTrue(sandboxCopyName("raw-shot", null).endsWith("_raw-shot"))
+    }
 }
 
-/** Minimal in-memory [FileOperationsProvider] — only the members the materialize path touches. */
 private class InMemoryFileOps : FileOperationsProvider {
     private val store = mutableMapOf<String, ByteArray>()
     private var counter = 0

--- a/homebase-common/src/jvmMain/kotlin/id/homebase/core/files/UploadMaterialize.jvm.kt
+++ b/homebase-common/src/jvmMain/kotlin/id/homebase/core/files/UploadMaterialize.jvm.kt
@@ -1,0 +1,21 @@
+package id.homebase.core.files
+
+import id.homebase.api.file.FileOperationsProvider
+import io.github.vinceglb.filekit.FileKit
+import io.github.vinceglb.filekit.PlatformFile
+import io.github.vinceglb.filekit.cacheDir
+import io.github.vinceglb.filekit.copyTo
+import io.github.vinceglb.filekit.mimeType
+import io.github.vinceglb.filekit.name
+
+// Native PlatformFile carries a real path / content:// URI; the path-based pipelines (and
+// resolveToFilePath for content URIs) already handle it. No copy needed at send time.
+actual suspend fun PlatformFile.toUploadPath(fileOps: FileOperationsProvider): String = toString()
+
+// Desktop has no security scope, but copying a real filesystem path is cheap and harmless
+// and keeps all native platforms behaving the same.
+actual suspend fun PlatformFile.materializeForUpload(fileOps: FileOperationsProvider): PlatformFile {
+    val dest = PlatformFile(FileKit.cacheDir, sandboxCopyName(name, mimeType()?.toString()))
+    copyTo(dest)
+    return dest
+}

--- a/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/files/UploadMaterialize.web.kt
+++ b/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/files/UploadMaterialize.web.kt
@@ -1,0 +1,18 @@
+package id.homebase.core.files
+
+import id.homebase.api.file.FileOperationsProvider
+import io.github.vinceglb.filekit.PlatformFile
+import io.github.vinceglb.filekit.name
+import io.github.vinceglb.filekit.readBytes
+
+// The browser has no filesystem path for a picked PlatformFile (FileKit's PlatformFile.path is
+// non-web-only); its bytes are reachable only via readBytes(). Copy them into the okio in-memory
+// cache so the path-based pipelines can read them back. Without this, web sends fail because
+// file.toString() isn't an okio path ("file not found").
+actual suspend fun PlatformFile.toUploadPath(fileOps: FileOperationsProvider): String =
+    materializeBytesToUploadPath(fileOps, name, readBytes())
+
+// No-op on web: the browser has no filesystem path to copy to and no security scope to lose. The
+// picked PlatformFile keeps its bytes; toUploadPath() above materializes them at send time via
+// readBytes(). (FileKit's copyTo / cacheDir aren't available on wasmJs.)
+actual suspend fun PlatformFile.materializeForUpload(fileOps: FileOperationsProvider): PlatformFile = this

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/feed/widget/CommentComposer.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/feed/widget/CommentComposer.kt
@@ -44,7 +44,7 @@ import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import id.homebase.api.file.FileOperationsProvider
-import id.homebase.chat.conversationlist.materializeForUpload
+import id.homebase.core.files.materializeForUpload
 import id.homebase.chat.services.builder.AttachmentInput
 import id.homebase.chat.services.builder.toImageAttachmentInput
 import id.homebase.chat.services.sticker.SavedSticker

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/webdrop/WebDropService.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/webdrop/WebDropService.kt
@@ -25,6 +25,7 @@ import id.homebase.core.ui.screens.webdrop.model.WebDropTtlChoice
 import id.homebase.core.webdrop.WebDropDropContent
 import id.homebase.core.webdrop.WebDropIntro
 import id.homebase.core.webdrop.WebDropIntroContent
+import id.homebase.api.file.withResolvedFile
 import id.homebase.core.webdrop.WebDropManifestEntry
 import id.homebase.core.webdrop.WebDropProtocol
 import id.homebase.core.webdrop.WebDropReceiptContent
@@ -70,51 +71,27 @@ class WebDropService(
         val ttl = ttlChoice.toTtl(nowMs)
 
         val ivs = mutableMapOf<String, ByteArray>()
-        val payloads = mutableListOf<PayloadFile>()
-
-        val resolvedPaths = files.map { fileOps.resolveToFilePath(it.path) }
-        val manifest = files.mapIndexed { index, file ->
-            WebDropManifestEntry(
-                key = WebDropProtocol.dataPayloadKey(index),
-                name = file.name,
-                contentType = file.contentType,
-                size = fileOps.getFileSize(resolvedPaths[index]),
-            )
-        }
 
         val manifestIv = ByteArrayUtil.getRndByteArray(16)
         ivs[WebDropProtocol.ManifestPayloadKey] = manifestIv
+
+        val (manifest, dataPayloads) = stageWebDropPayloads(fileOps, files, key, ivs)
+
         val manifestBytes = AesCbc.encrypt(
             OdinSystemSerializer.serialize(manifest).encodeToByteArray(),
             key,
             manifestIv,
         )
         val manifestPath = fileOps.writeBytesToOutboxTempFile(manifestBytes, "wdrmeta", ".bin")
-        payloads += PayloadFile(
-            key = WebDropProtocol.ManifestPayloadKey,
-            filePath = manifestPath,
-            contentType = "application/octet-stream",
-            isPreEncrypted = true,
-        )
-
-        files.forEachIndexed { index, file ->
-            val payloadKey = WebDropProtocol.dataPayloadKey(index)
-            val iv = ByteArrayUtil.getRndByteArray(16)
-            ivs[payloadKey] = iv
-            // Staged (not cache-temp) because the outbox reads payload bytes lazily at drain
-            // time; a reaped temp file would kill the row as PERMANENT.
-            val stagedPath = fileOps.createOutboxStagingPath("wdrdata", ".bin")
-            fileOps.writeStream(
-                stagedPath,
-                AesCbc.streamEncryptWithCbc(fileOps.readFileAsFlow(resolvedPaths[index]), key, iv),
-            )
-            payloads += PayloadFile(
-                key = payloadKey,
-                filePath = stagedPath,
+        val payloads = mutableListOf(
+            PayloadFile(
+                key = WebDropProtocol.ManifestPayloadKey,
+                filePath = manifestPath,
                 contentType = "application/octet-stream",
                 isPreEncrypted = true,
             )
-        }
+        )
+        payloads += dataPayloads
 
         val encryptedIntro = intro?.takeUnless { it.isEmpty() }?.let {
             // Its own IV, never a payload's: reusing an IV under the same key breaks CBC.
@@ -216,4 +193,67 @@ class WebDropService(
             false
         }
     }
+}
+
+/**
+ * A drop source file could not be read. Snapshot-on-pick (materializeForUpload) makes this rare -
+ * the picker copies into the sandbox at selection time - but a cache sweep between pick and
+ * create, or a share-in whose temp was reaped, can still land here. Typed so the UI can name the
+ * file and say "pick it again" instead of a generic failure (#1420).
+ */
+class WebDropSourceReadException(
+    val fileName: String,
+    val filePath: String,
+    cause: Throwable,
+) : Exception("couldn't read drop source '$fileName'", cause)
+
+/**
+ * Sizes and encrypts every picked file into outbox staging, one at a time. Extracted from
+ * [WebDropService.createDrop] so the read-failure contract is unit-testable without the outbox:
+ * any per-file failure aborts the WHOLE drop as [WebDropSourceReadException] - a partial drop
+ * must never reach the recipient - and each resolved content-URI copy is reaped either way
+ * ([withResolvedFile]). [ivs] gains one fresh IV per data payload, keyed by payload key.
+ */
+internal suspend fun stageWebDropPayloads(
+    fileOps: FileOperationsProvider,
+    files: List<PickedDropFile>,
+    key: ByteArray,
+    ivs: MutableMap<String, ByteArray>,
+): Pair<List<WebDropManifestEntry>, List<PayloadFile>> {
+    val manifest = mutableListOf<WebDropManifestEntry>()
+    val payloads = mutableListOf<PayloadFile>()
+    files.forEachIndexed { index, file ->
+        val payloadKey = WebDropProtocol.dataPayloadKey(index)
+        val iv = ByteArrayUtil.getRndByteArray(16)
+        try {
+            fileOps.withResolvedFile(file.path) { resolvedPath ->
+                manifest += WebDropManifestEntry(
+                    key = payloadKey,
+                    name = file.name,
+                    contentType = file.contentType,
+                    size = fileOps.getFileSize(resolvedPath),
+                )
+                // Staged (not cache-temp) because the outbox reads payload bytes lazily at drain
+                // time; a reaped temp file would kill the row as PERMANENT.
+                val stagedPath = fileOps.createOutboxStagingPath("wdrdata", ".bin")
+                fileOps.writeStream(
+                    stagedPath,
+                    AesCbc.streamEncryptWithCbc(fileOps.readFileAsFlow(resolvedPath), key, iv),
+                )
+                payloads += PayloadFile(
+                    key = payloadKey,
+                    filePath = stagedPath,
+                    contentType = "application/octet-stream",
+                    isPreEncrypted = true,
+                )
+            }
+        } catch (e: Exception) {
+            // The source read is what fails in practice (stale URI, swept temp); a staging-write
+            // failure lands here too, and "couldn't read <name>" with a re-pick is still the
+            // honest, actionable message for both.
+            throw WebDropSourceReadException(file.name, file.path, e)
+        }
+        ivs[payloadKey] = iv
+    }
+    return manifest to payloads
 }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/webdrop/WebDropUiState.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/webdrop/WebDropUiState.kt
@@ -55,4 +55,7 @@ sealed interface WebDropUiEvent {
 sealed interface WebDropError {
     data object CreateFailed : WebDropError
     data object TooManyFiles : WebDropError
+
+    /** A picked file could not be read back at create time; it has been removed from the pick list. */
+    data class SourceUnreadable(val fileName: String) : WebDropError
 }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/webdrop/WebDropViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/webdrop/WebDropViewModel.kt
@@ -173,8 +173,20 @@ class WebDropViewModel(
                     webDropStream.loadAll()
                     _events.tryEmit(WebDropUiEvent.ShareLink(created.url))
                 }
-                .onFailure {
-                    _uiState.update { it.copy(isCreating = false, error = WebDropError.CreateFailed) }
+                .onFailure { e ->
+                    if (e is WebDropSourceReadException) {
+                        // Name the file and clear it from the pick list - the path is dead, so
+                        // "pick it again" is the only way forward (#1420).
+                        _uiState.update { state ->
+                            state.copy(
+                                isCreating = false,
+                                error = WebDropError.SourceUnreadable(e.fileName),
+                                pickedFiles = state.pickedFiles.filterNot { it.path == e.filePath },
+                            )
+                        }
+                    } else {
+                        _uiState.update { it.copy(isCreating = false, error = WebDropError.CreateFailed) }
+                    }
                 }
         }
     }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/webdrop/components/WebDropComposeSheet.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/webdrop/components/WebDropComposeSheet.kt
@@ -46,6 +46,7 @@ import id.homebase.resources.webdrop_compose_title
 import id.homebase.resources.webdrop_copy
 import id.homebase.resources.webdrop_create
 import id.homebase.resources.webdrop_error_create
+import id.homebase.resources.webdrop_error_source_unreadable
 import id.homebase.resources.webdrop_error_too_many
 import id.homebase.resources.webdrop_for_someone
 import id.homebase.resources.webdrop_recipient_name
@@ -67,8 +68,15 @@ import io.github.vinceglb.filekit.dialogs.FileKitType
 import io.github.vinceglb.filekit.dialogs.compose.rememberFilePickerLauncher
 import io.github.vinceglb.filekit.name
 import org.jetbrains.compose.resources.stringResource
+import androidx.compose.runtime.rememberCoroutineScope
+import org.koin.compose.koinInject
+import kotlinx.coroutines.launch
+import id.homebase.core.files.materializeForUpload
+import id.homebase.api.file.FileOperationsProvider
+import co.touchlab.kermit.Logger
 
 private const val MAX_NAME_CHARS = 40
+private const val TAG = "WebDropComposeSheet"
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
 @Composable
@@ -76,23 +84,40 @@ fun WebDropComposeSheet(
     uiState: WebDropUiState,
     onAction: (WebDropUiAction) -> Unit,
 ) {
+    val fileOps = koinInject<FileOperationsProvider>()
+    val scope = rememberCoroutineScope()
     val filePicker = rememberFilePickerLauncher(
         type = FileKitType.File(),
         mode = FileKitMode.Multiple(),
     ) { files ->
         if (!files.isNullOrEmpty()) {
-            onAction(
-                WebDropUiAction.FilesPicked(
-                    files.map { file ->
-                        PickedDropFile(
-                            path = file.pathCompat,
-                            name = file.name,
-                            contentType = file.contentType(),
-                            size = 0,
-                        )
-                    }
+            scope.launch {
+                onAction(
+                    WebDropUiAction.FilesPicked(
+                        files.map { file ->
+                            // Content type off the PICKED handle before the copy - the sandbox
+                            // copy's picker-name may lack an extension to derive it from (#1149).
+                            val contentType = file.contentType()
+                            // Snapshot into the sandbox at pick time: Android's content:// grant
+                            // and iOS's security scope are both transient, and createDrop reads
+                            // the path much later (#1420). On failure keep the raw handle - the
+                            // grant is freshest right now, and createDrop reports a typed,
+                            // per-file error if it still cannot read it.
+                            val snapshot = runCatching { file.materializeForUpload(fileOps) }
+                                .getOrElse { e ->
+                                    Logger.w(TAG, e) { "snapshot-on-pick failed for ${file.name}" }
+                                    file
+                                }
+                            PickedDropFile(
+                                path = snapshot.pathCompat,
+                                name = file.name,
+                                contentType = contentType,
+                                size = 0,
+                            )
+                        }
+                    )
                 )
-            )
+            }
         }
     }
 
@@ -209,6 +234,8 @@ fun WebDropComposeSheet(
                         WebDropError.CreateFailed -> stringResource(MR.string.webdrop_error_create)
                         WebDropError.TooManyFiles ->
                             stringResource(MR.string.webdrop_error_too_many, WebDropProtocol.MaxFilesPerDrop)
+                        is WebDropError.SourceUnreadable ->
+                            stringResource(MR.string.webdrop_error_source_unreadable, error.fileName)
                     },
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.error,

--- a/homebase-core/src/commonTest/kotlin/id/homebase/core/ui/screens/webdrop/WebDropStagePayloadsTest.kt
+++ b/homebase-core/src/commonTest/kotlin/id/homebase/core/ui/screens/webdrop/WebDropStagePayloadsTest.kt
@@ -1,0 +1,112 @@
+package id.homebase.core.ui.screens.webdrop
+
+import id.homebase.api.file.FileOperationsProvider
+import id.homebase.core.ui.screens.webdrop.model.PickedDropFile
+import io.ktor.client.request.forms.InputProvider
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The read-failure contract of issue #1420: an unreadable source aborts the WHOLE drop as a
+ * typed [WebDropSourceReadException] naming the file - never a partial drop, never a bare
+ * exception - and resolved content-URI copies are reaped either way.
+ */
+class WebDropStagePayloadsTest {
+
+    private val key = ByteArray(16) { it.toByte() }
+
+    private fun picked(path: String, name: String) =
+        PickedDropFile(path = path, name = name, contentType = "application/pdf", size = 0)
+
+    @Test
+    fun stagesEveryFileAndCollectsOneIvPerPayload() = runTest {
+        val fs = StageFakeFileOps(mutableMapOf("/a.pdf" to ByteArray(40) { 1 }, "/b.pdf" to ByteArray(7) { 2 }))
+        val ivs = mutableMapOf<String, ByteArray>()
+
+        val (manifest, payloads) = stageWebDropPayloads(
+            fs, listOf(picked("/a.pdf", "A.pdf"), picked("/b.pdf", "B.pdf")), key, ivs,
+        )
+
+        assertEquals(listOf("A.pdf", "B.pdf"), manifest.map { it.name })
+        assertEquals(listOf(40L, 7L), manifest.map { it.size })
+        assertEquals(2, payloads.size)
+        assertEquals(manifest.map { it.key }, payloads.map { it.key })
+        assertEquals(manifest.map { it.key }.toSet(), ivs.keys)
+        // Staged bytes are ciphertext, not the source bytes.
+        val staged = fs.files[payloads[0].filePath]!!
+        assertFalse(staged.take(7) == List<Byte>(7) { 1 }, "staged payload must be encrypted")
+        assertTrue(payloads.all { it.isPreEncrypted })
+    }
+
+    @Test
+    fun anUnreadableSourceAbortsTheWholeDropTypedAndNamed() = runTest {
+        val fs = StageFakeFileOps(mutableMapOf("/a.pdf" to ByteArray(3) { 1 }))
+        val ivs = mutableMapOf<String, ByteArray>()
+
+        val e = assertFailsWith<WebDropSourceReadException> {
+            stageWebDropPayloads(
+                fs, listOf(picked("/a.pdf", "A.pdf"), picked("/gone.pdf", "Gone.pdf")), key, ivs,
+            )
+        }
+
+        assertEquals("Gone.pdf", e.fileName)
+        assertEquals("/gone.pdf", e.filePath)
+        // The failed file left no orphan IV behind; the successful one kept its slot.
+        assertEquals(1, ivs.size)
+    }
+
+    @Test
+    fun aResolvedContentUriCopyIsReapedAfterStaging() = runTest {
+        val fs = StageFakeFileOps(
+            files = mutableMapOf("/resolved-copy.pdf" to ByteArray(5) { 3 }),
+            resolveMap = mapOf("content://picked" to "/resolved-copy.pdf"),
+        )
+
+        stageWebDropPayloads(fs, listOf(picked("content://picked", "C.pdf")), key, mutableMapOf())
+
+        assertContentEquals(listOf("/resolved-copy.pdf"), fs.deleted, "the resolve copy must be reaped")
+    }
+}
+
+private class StageFakeFileOps(
+    val files: MutableMap<String, ByteArray>,
+    private val resolveMap: Map<String, String> = emptyMap(),
+) : FileOperationsProvider {
+    val deleted = mutableListOf<String>()
+    private var counter = 0
+
+    override suspend fun resolveToFilePath(path: String): String = resolveMap[path] ?: path
+
+    override suspend fun readFileBytes(path: String): ByteArray =
+        files[path] ?: error("file not found: $path")
+
+    override fun getFileSize(path: String): Long =
+        (files[path] ?: error("file not found: $path")).size.toLong()
+
+    override suspend fun createOutboxStagingPath(prefix: String, suffix: String): String =
+        "/outbox/$prefix${counter++}$suffix"
+
+    override suspend fun writeStream(path: String, data: Flow<ByteArray>) {
+        val chunks = data.toList()
+        files[path] = chunks.fold(ByteArray(0)) { acc, c -> acc + c }
+    }
+
+    override fun deleteTempFile(path: String): Boolean {
+        deleted += path
+        return files.remove(path) != null
+    }
+
+    override fun getCacheDirectory(): String = "/tmp"
+    override fun openFileInput(path: String): InputProvider = throw NotImplementedError()
+    override suspend fun writeBytesToTempFile(bytes: ByteArray, prefix: String, suffix: String): String =
+        throw NotImplementedError()
+    override suspend fun writeBytesToShareOutboundFile(bytes: ByteArray, suffix: String): String =
+        throw NotImplementedError()
+}


### PR DESCRIPTION
Fixes #1420 — the silent first-drop failure on a stale `content://` URI.

## What changed

1. **Snapshot on pick** — the compose sheet runs every picked file through `materializeForUpload` (content type read off the picked handle first, per #1149), so `createDrop` reads sandbox-owned paths that can't go stale. This closes the race on Android (transient content-URI grants) *and* iOS (security-scoped NSURLs — same bug class, confirmed in the helper's own docs).
2. **Common home for the primitive** — answering "we process URIs elsewhere; is there common code?": yes, chat's `AttachmentUploadResolve` was it, and WebDrop was the one picker that skipped it. This PR promotes the upload-side helpers (`materializeForUpload`, `toUploadPath`, `sandboxCopyName`, `materializeBytesToUploadPath`) from `id.homebase.chat.conversationlist` to **`id.homebase.core.files` in homebase-common** — importable by every module, sitting next to what it needs. Chat's call sites updated; the playback-URL pair stays chat-local. Behavior byte-identical (same names, same prefixes, same docs).
3. **Typed, actionable failure** — staging extracted to `stageWebDropPayloads`: any per-file read failure aborts the whole drop as `WebDropSourceReadException` (a partial drop must never reach a recipient), the VM maps it to `WebDropError.SourceUnreadable`, removes the dead file from the pick list, and the sheet shows *"Couldn't read `<name>` — please pick it again"* (EN/DA) instead of a silent no-op.
4. **Resolve-copy leak fixed** — per-file staging goes through `withResolvedFile`, reaping Android content-URI copies instead of stranding `resolved_*` files until the next startup sweep.

## Acceptance criteria from the issue

- [x] Stale-URI drop no longer fails silently — bytes are snapshotted at pick; a still-unreadable source yields a clear, per-file, actionable error.
- [x] Picking copies to a stable local path at selection time.
- [x] `createDrop` read failures reach the UI typed; no unhandled exception.
- [x] Pick → background/foreground → create either succeeds (snapshot) or errors gracefully.

## Testing

- New `WebDropStagePayloadsTest`: staging happy path (one IV per payload, encrypted staging, manifest/payload alignment), typed-and-named abort with no orphan IV, resolve-copy reap.
- `UploadMaterializeTest` (moved + extended): readability contract, extension handling, distinct paths, `sandboxCopyName` cases relocated from chat's jvmTest.
- All four modules' jvmTest suites green (incl. Konsist); wasmJs/android/apple-metadata compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ePkqms6AQdGGUWsVrGyzx