### PR TITLE
Send a Vault entry as one WebDrop

### DIFF
--- a/homebase-common/src/commonMain/composeResources/values-da/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values-da/strings.xml
@@ -1087,6 +1087,9 @@
     <string name="vault_gallery_delete_page_confirm">Slet denne side? Dette kan ikke fortrydes.</string>
     <string name="vault_gallery_delete_last_page_confirm">Dette er den sidste side. Sletter du den, fjernes hele posten.</string>
     <string name="vault_gallery_share_page">Del denne side</string>
+    <string name="vault_gallery_send_webdrop">Send som WebDrop</string>
+    <string name="vault_error_webdrop_prepare">Kunne ikke klargøre filerne til WebDrop</string>
+    <string name="vault_error_webdrop_too_many_files">Denne fil har for mange sider til ét WebDrop (maks. %1$d)</string>
     <string name="vault_gallery_save_page">Gem på enheden</string>
     <string name="vault_gallery_delete_file">Slet fil</string>
     <string name="vault_gallery_delete_all">Slet alle</string>

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -1309,6 +1309,9 @@
     <string name="vault_gallery_delete_page_confirm">Delete this page? This cannot be undone.</string>
     <string name="vault_gallery_delete_last_page_confirm">This is the last page. Deleting it will remove the entire entry.</string>
     <string name="vault_gallery_share_page">Share this page</string>
+    <string name="vault_gallery_send_webdrop">Send as WebDrop</string>
+    <string name="vault_error_webdrop_prepare">Couldn't prepare the files for WebDrop</string>
+    <string name="vault_error_webdrop_too_many_files">This entry has too many files for one WebDrop (max %1$d)</string>
     <string name="vault_gallery_save_page">Save to device</string>
     <string name="vault_gallery_delete_file">Delete file</string>
     <string name="vault_gallery_delete_all">Delete all</string>

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
@@ -1213,6 +1213,7 @@ val appModule = module {
             driveSyncManager = get(),
             cropResultBus = get(),
             drawResultBus = get(),
+            webDropShareFlowState = get(),
         )
     }
     viewModelOf(::VaultSettingsViewModel)

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
@@ -437,6 +437,7 @@ fun AppNavHost(
                 is VaultUiEvent.SaveFileReady,
                 is VaultUiEvent.NavigateToCropper,
                 is VaultUiEvent.NavigateToDrawer,
+                is VaultUiEvent.OpenWebDrop,
                 is VaultUiEvent.Error -> { /* handled by VaultScreen */ }
             }
         }
@@ -1825,6 +1826,7 @@ fun AppNavHost(
                                             onNavigateToNoteEditor = { sectionId, entryId ->
                                                 navController.navigate(Route.VaultNoteEditor(sectionId, entryId))
                                             },
+                                            onNavigateToWebDrop = openWebDrop,
                                             onNavigateToCropper = { requestId ->
                                                 navController.navigate(Route.Crop(requestId.toString()))
                                             },

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultScreen.kt
@@ -94,6 +94,8 @@ import id.homebase.resources.vault_error_download
 import id.homebase.resources.vault_error_download_page
 import id.homebase.resources.vault_error_edit_page
 import id.homebase.resources.vault_error_open_editor
+import id.homebase.resources.vault_error_webdrop_prepare
+import id.homebase.resources.vault_error_webdrop_too_many_files
 import id.homebase.resources.vault_error_outbox_upload
 import id.homebase.resources.vault_error_rename_file
 import id.homebase.resources.vault_error_rename_section
@@ -129,6 +131,7 @@ fun VaultScreen(
     onNavigateToNoteEditor: (sectionId: String, entryId: String?) -> Unit = { _, _ -> },
     onNavigateToCropper: (Uuid) -> Unit = {},
     onNavigateToDrawer: (Uuid) -> Unit = {},
+    onNavigateToWebDrop: () -> Unit = {},
     /** Set by the host when the already-selected Vault tab is re-tapped. */
     scrollToTop: Boolean = false,
     onScrollToTopHandled: () -> Unit = {},
@@ -197,6 +200,7 @@ fun VaultScreen(
                 is VaultUiEvent.Error -> {
                     pendingError = event.error
                 }
+                is VaultUiEvent.OpenWebDrop -> onNavigateToWebDrop()
                 is VaultUiEvent.OpenNoteEditor -> {
                     onNavigateToNoteEditor(
                         event.sectionId.toString(),
@@ -407,6 +411,10 @@ fun VaultScreen(
                             onDismiss = { viewModel.onAction(VaultUiAction.CloseOverlay) },
                             onSharePage = { key ->
                                 viewModel.onAction(VaultUiAction.SharePage(overlay.file, key))
+                            },
+                            webDropEnabled = uiState.webDropActivated,
+                            onSendAsWebDrop = {
+                                viewModel.onAction(VaultUiAction.SendAsWebDrop(overlay.file))
                             },
                             onSavePage = { key ->
                                 viewModel.onAction(VaultUiAction.SavePage(overlay.file, key))
@@ -714,4 +722,7 @@ private fun resolveVaultError(error: VaultError): String = when (error) {
     VaultError.OutboxUploadFailed -> stringResource(MR.string.vault_error_outbox_upload)
     VaultError.EditPageFailed -> stringResource(MR.string.vault_error_edit_page)
     VaultError.OpenEditorFailed -> stringResource(MR.string.vault_error_open_editor)
+    VaultError.WebDropPrepareFailed -> stringResource(MR.string.vault_error_webdrop_prepare)
+    is VaultError.WebDropTooManyFiles ->
+        stringResource(MR.string.vault_error_webdrop_too_many_files, error.max)
 }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultUiState.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultUiState.kt
@@ -26,6 +26,8 @@ data class VaultUiState(
      * survives navigating out to the crop/draw screen and back. Null when the editor is closed.
      */
     val pendingEditor: VaultPendingEditor? = null,
+    /** Gates the gallery's "Send as WebDrop" affordances on the WebDrop drive being activated. */
+    val webDropActivated: Boolean = false,
 )
 
 /** Which editor screen a crop/draw request routes to. */
@@ -141,6 +143,7 @@ sealed interface VaultUiAction {
     data class EntryClicked(val file: VaultEntry) : VaultUiAction
     data class ShareFile(val file: VaultEntry) : VaultUiAction
     data class SharePage(val file: VaultEntry, val payloadKey: String) : VaultUiAction
+    data class SendAsWebDrop(val file: VaultEntry) : VaultUiAction
     data class SavePage(val file: VaultEntry, val payloadKey: String) : VaultUiAction
     data class RenameFile(val file: VaultEntry, val newName: String) : VaultUiAction
     data class DeleteFile(val file: VaultEntry) : VaultUiAction
@@ -161,6 +164,9 @@ sealed interface VaultUiEvent {
         val fileName: String,
     ) : VaultUiEvent
     data class Error(val error: VaultError) : VaultUiEvent
+
+    /** The WebDrop draft is seeded; the screen should navigate to the WebDrop composer. */
+    data object OpenWebDrop : VaultUiEvent
     data class OpenNoteEditor(val sectionId: Uuid, val entryId: Uuid? = null) : VaultUiEvent
     data class NavigateToCropper(val requestId: Uuid) : VaultUiEvent
     data class NavigateToDrawer(val requestId: Uuid) : VaultUiEvent
@@ -179,6 +185,8 @@ sealed interface VaultError {
     data object DeletePageFailed : VaultError
     data object SaveNotesFailed : VaultError
     data class UpdateLabelFailed(val fileName: String) : VaultError
+    data object WebDropPrepareFailed : VaultError
+    data class WebDropTooManyFiles(val max: Int) : VaultError
     data object DownloadPageFailed : VaultError
     data object OutboxUploadFailed : VaultError
     data object EditPageFailed : VaultError

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/VaultViewModel.kt
@@ -20,8 +20,14 @@ import id.homebase.core.pdf.generatePdfThumbnailFromFile
 import id.homebase.core.config.vaultDefaultSections
 import id.homebase.core.config.vaultLabeledDrive
 import id.homebase.core.sync.DriveRegistry
+import id.homebase.core.config.webDropLabeledDrive
 import id.homebase.core.sync.OptionalDriveActivation
+import id.homebase.core.ui.screens.webdrop.WebDropShareFlowState
+import id.homebase.core.ui.screens.webdrop.model.PickedDropFile
+import id.homebase.core.webdrop.WebDropProtocol
 import id.homebase.core.ui.screens.vault.model.VaultEntry
+import id.homebase.core.ui.screens.vault.model.webDropFileNames
+import id.homebase.core.ui.screens.vault.model.webDropGuardKey
 import id.homebase.core.ui.screens.vault.model.VaultSection
 import id.homebase.core.ui.screens.vault.model.VaultSectionContent
 import id.homebase.core.util.contentType
@@ -65,12 +71,14 @@ class VaultViewModel(
     private val driveSyncManager: DriveSyncManager,
     private val cropResultBus: CropResultBus,
     private val drawResultBus: DrawResultBus,
+    private val webDropShareFlowState: WebDropShareFlowState,
 ) : ViewModel() {
 
     private val _overlayState = MutableStateFlow<VaultOverlay?>(null)
     private val _syncingState = MutableStateFlow(false)
     private val _checkingPermissions = MutableStateFlow(false)
     private val _preparingShareKeys = MutableStateFlow<Set<String>>(emptySet())
+    private val _webDropActivated = MutableStateFlow(false)
     private val _pendingEditor = MutableStateFlow<VaultPendingEditor?>(null)
 
     /**
@@ -91,9 +99,9 @@ class VaultViewModel(
         combine(_overlayState, _pendingEditor) { o, p -> o to p },
         _syncingState,
         _checkingPermissions,
-        _preparingShareKeys,
-    ) { (sections, entriesBySection, isLoaded), (overlay, pendingEditor), syncing, checkingPermissions, preparing ->
-        buildUiState(sections, entriesBySection, isLoaded, overlay, pendingEditor, syncing, checkingPermissions, preparing)
+        combine(_preparingShareKeys, _webDropActivated) { p, w -> p to w },
+    ) { (sections, entriesBySection, isLoaded), (overlay, pendingEditor), syncing, checkingPermissions, (preparing, webDrop) ->
+        buildUiState(sections, entriesBySection, isLoaded, overlay, pendingEditor, syncing, checkingPermissions, preparing, webDrop)
     }.stateIn(
         viewModelScope,
         SharingStarted.WhileSubscribed(5_000),
@@ -114,6 +122,7 @@ class VaultViewModel(
             syncing = _syncingState.value,
             checkingPermissions = _checkingPermissions.value,
             preparingShareKeys = _preparingShareKeys.value,
+            webDropActivated = _webDropActivated.value,
         ),
     )
 
@@ -130,6 +139,7 @@ class VaultViewModel(
         syncing: Boolean,
         checkingPermissions: Boolean,
         preparingShareKeys: Set<String>,
+        webDropActivated: Boolean,
     ): VaultUiState {
         val sectionModels = sections.mapIndexed { index, section ->
             section.copy(
@@ -150,6 +160,7 @@ class VaultViewModel(
             fullScreenOverlay = refreshedOverlay ?: overlay,
             preparingShareKeys = preparingShareKeys,
             pendingEditor = pendingEditor,
+            webDropActivated = webDropActivated,
         )
     }
 
@@ -170,6 +181,12 @@ class VaultViewModel(
     }
 
     init {
+        viewModelScope.launch {
+            optionalDriveActivation.isActivatedFlow(webDropLabeledDrive).collect { activated ->
+                _webDropActivated.value = activated
+            }
+        }
+
         // React to VaultStream reset/load cycles (logout → login as different user).
         // When isLoaded flips false (reset) → null out activation so the UI shows
         // loading. When it flips true (loadAll done) → re-check DriveRegistry.
@@ -269,6 +286,7 @@ class VaultViewModel(
             is VaultUiAction.UpdateLabel,
             is VaultUiAction.MoveEntryToSection,
             is VaultUiAction.SharePage,
+            is VaultUiAction.SendAsWebDrop,
             is VaultUiAction.SavePage,
             is VaultUiAction.ShareFile,
             is VaultUiAction.RenameFile,
@@ -318,6 +336,7 @@ class VaultViewModel(
             is VaultUiAction.UpdateLabel -> handleUpdateLabel(action)
             is VaultUiAction.MoveEntryToSection -> handleMoveEntryToSection(action)
             is VaultUiAction.SharePage -> handleSharePage(action)
+            is VaultUiAction.SendAsWebDrop -> handleSendAsWebDrop(action)
             is VaultUiAction.SavePage -> handleSavePage(action)
             is VaultUiAction.EntryClicked -> handleEntryClicked(action)
             is VaultUiAction.ShareFile -> handleShareFile(action)
@@ -914,6 +933,57 @@ class VaultViewModel(
                 }
             } finally {
                 _preparingShareKeys.update { it - action.payloadKey }
+            }
+        }
+    }
+
+    /**
+     * The whole entry leaves as ONE drop: every payload is decrypted to a temp path, the WebDrop
+     * draft is seeded, and the screen navigates to the composer - which opens with the files
+     * already picked (consume-once draft, same hand-off as the OS share sheet). Guards on
+     * payloadDescriptors.size, never pageCount: a 30-page PDF is one payload, one dropped file.
+     */
+    private fun handleSendAsWebDrop(action: VaultUiAction.SendAsWebDrop) {
+        val file = action.file
+        if (file.isPending) return
+        if (file.payloadDescriptors.isEmpty()) return
+        if (file.payloadDescriptors.size > WebDropProtocol.MaxFilesPerDrop) {
+            _events.tryEmit(
+                VaultUiEvent.Error(VaultError.WebDropTooManyFiles(WebDropProtocol.MaxFilesPerDrop)),
+            )
+            return
+        }
+
+        // Same effectively-atomic UI-thread reasoning as handleSharePage (#850); a synthetic
+        // key scopes the guard (and the gallery's spinner) to the entry, not a page.
+        val guardKey = webDropGuardKey(file)
+        if (guardKey in _preparingShareKeys.value) return
+        _preparingShareKeys.update { it + guardKey }
+        viewModelScope.launch {
+            val names = file.webDropFileNames()
+            val staged = mutableListOf<PickedDropFile>()
+            try {
+                file.payloadDescriptors.forEachIndexed { index, descriptor ->
+                    val tempPath = vaultUploaderService.downloadPayload(file, descriptor.key)
+                    if (tempPath == null) {
+                        // No partial drop: reap what was already materialized and abort loudly.
+                        staged.forEach { fileOperationsProvider.deleteTempFile(it.path) }
+                        _events.tryEmit(VaultUiEvent.Error(VaultError.WebDropPrepareFailed))
+                        return@launch
+                    }
+                    staged += PickedDropFile(
+                        path = tempPath,
+                        name = names[index],
+                        contentType = descriptor.contentType ?: file.contentType,
+                        size = 0,
+                    )
+                }
+                // Seed strictly BEFORE navigating: WebDropViewModel consumes the draft in its
+                // init, which runs the moment Route.WebDrop composes.
+                webDropShareFlowState.setDraft(staged)
+                _events.tryEmit(VaultUiEvent.OpenWebDrop)
+            } finally {
+                _preparingShareKeys.update { it - guardKey }
             }
         }
     }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/components/VaultFileIcon.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/components/VaultFileIcon.kt
@@ -63,6 +63,8 @@ import kotlin.time.Instant
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 import org.jetbrains.compose.resources.stringResource
+import id.homebase.resources.vault_gallery_send_webdrop
+import androidx.compose.material.icons.outlined.Redeem
 
 /**
  * Returns the appropriate icon for a given MIME content type.
@@ -122,6 +124,8 @@ fun formatFileInfo(sizeBytes: Long, createdAt: Long): String {
 fun VaultFileDropdownMenu(
     file: VaultEntry,
     onShare: (VaultEntry) -> Unit,
+    /** Entry-scoped: the whole entry leaves as one WebDrop. Null hides the item (drive not activated). */
+    onSendAsWebDrop: ((VaultEntry) -> Unit)? = null,
     onDelete: (VaultEntry) -> Unit,
     onDeletePage: (() -> Unit)? = null,
     sections: List<VaultSection> = emptyList(),
@@ -153,6 +157,22 @@ fun VaultFileDropdownMenu(
                     onClick = {
                         expanded = false
                         onShare(file)
+                    },
+                )
+            }
+            if (onSendAsWebDrop != null) {
+                DropdownMenuItem(
+                    text = { Text(stringResource(MR.string.vault_gallery_send_webdrop)) },
+                    leadingIcon = {
+                        Icon(
+                            imageVector = Icons.Outlined.Redeem,
+                            contentDescription = null,
+                            tint = iconTint,
+                        )
+                    },
+                    onClick = {
+                        expanded = false
+                        onSendAsWebDrop(file)
                     },
                 )
             }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/gallery/VaultGalleryScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/gallery/VaultGalleryScreen.kt
@@ -81,6 +81,9 @@ import kotlin.uuid.Uuid
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.koinInject
+import id.homebase.resources.vault_gallery_send_webdrop
+import id.homebase.core.ui.screens.vault.model.webDropGuardKey
+import androidx.compose.material.icons.outlined.Redeem
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -90,6 +93,9 @@ fun VaultGalleryScreen(
     onDismiss: () -> Unit,
     onSharePage: (payloadKey: String) -> Unit,
     onSavePage: (payloadKey: String) -> Unit,
+    /** Entry-scoped: the WHOLE entry leaves as one self-destructing WebDrop link. */
+    onSendAsWebDrop: () -> Unit = {},
+    webDropEnabled: Boolean = false,
     onDeletePage: (payloadKey: String) -> Unit,
     onAppendPages: () -> Unit,
     onUpdateLabel: (String?) -> Unit,
@@ -314,9 +320,35 @@ fun VaultGalleryScreen(
                                     )
                                 }
                             }
+                            // Entry-scoped, unlike its page-scoped neighbours: the whole entry
+                            // (all pages) leaves as ONE drop - the point of a WebDrop bundle.
+                            if (webDropEnabled) {
+                                val isPreparingWebDrop = webDropGuardKey(file) in preparingShareKeys
+                                IconButton(
+                                    onClick = onSendAsWebDrop,
+                                    enabled = !isPreparingWebDrop,
+                                ) {
+                                    if (isPreparingWebDrop) {
+                                        CircularProgressIndicator(
+                                            modifier = Modifier.size(20.dp),
+                                            strokeWidth = 2.dp,
+                                        )
+                                    } else {
+                                        Icon(
+                                            imageVector = Icons.Outlined.Redeem,
+                                            contentDescription = stringResource(MR.string.vault_gallery_send_webdrop),
+                                        )
+                                    }
+                                }
+                            }
                             VaultFileDropdownMenu(
                                 file = file,
                                 onShare = { currentDescriptor?.let { onSharePage(it.key) } },
+                                onSendAsWebDrop = if (webDropEnabled) {
+                                    { onSendAsWebDrop() }
+                                } else {
+                                    null
+                                },
                                 onDelete = { showDeleteEntryConfirm = true },
                                 onDeletePage = { currentDescriptor?.let { pageToDelete = it.key } },
                                 sections = sections,

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/model/VaultWebDropNaming.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/model/VaultWebDropNaming.kt
@@ -1,0 +1,43 @@
+package id.homebase.core.ui.screens.vault.model
+
+/**
+ * Names for a Vault entry's pages when they leave as one WebDrop: a single payload keeps the
+ * entry's name (`Passport.jpg`), a bundle numbers its pages 1-based in page order
+ * (`Insurance card-1.png`, `-2.png`, ...). The recipient sees these names in the drop manifest
+ * and as download filenames, so they must look like files, not like `vlt_pg_00`.
+ */
+internal fun VaultEntry.webDropFileNames(): List<String> =
+    webDropFileNamesFor(fileName, payloadDescriptors.map { it.contentType ?: contentType })
+
+/**
+ * Extension rule byte-identical to [VaultUploaderService.downloadPayload]'s temp-file suffix
+ * (`substringAfter("/", "bin")`, `jpeg` -> `jpg`) so the PickedDropFile name always agrees with
+ * the materialized file's extension.
+ */
+internal fun webDropExtensionFor(contentType: String?): String =
+    (contentType ?: "").substringAfter("/", "bin").let { if (it == "jpeg") "jpg" else it }
+        .ifEmpty { "bin" }
+
+internal fun webDropFileNamesFor(entryName: String, contentTypes: List<String?>): List<String> {
+    val total = contentTypes.size
+    return contentTypes.mapIndexed { index, contentType ->
+        val ext = webDropExtensionFor(contentType)
+        // Strip a MATCHING extension case-insensitively so "scan.pdf" doesn't become
+        // "scan.pdf-1.pdf" - but never blind-substringBeforeLast: a dotted name with no real
+        // extension ("v2.final") must survive untouched.
+        val base = if (entryName.length > ext.length + 1 &&
+            entryName.endsWith(".$ext", ignoreCase = true)
+        ) {
+            entryName.dropLast(ext.length + 1)
+        } else {
+            entryName
+        }
+        if (total == 1) "$base.$ext" else "$base-${index + 1}.$ext"
+    }
+}
+
+/**
+ * Synthetic [VaultUiState.preparingShareKeys] key for the entry-scoped WebDrop preparation:
+ * page keys guard per-page share/save; this guards (and spins) the whole entry.
+ */
+internal fun webDropGuardKey(file: VaultEntry): String = "webdrop:${file.uniqueId}"

--- a/homebase-core/src/commonTest/kotlin/id/homebase/core/ui/screens/vault/model/VaultWebDropNamingTest.kt
+++ b/homebase-core/src/commonTest/kotlin/id/homebase/core/ui/screens/vault/model/VaultWebDropNamingTest.kt
@@ -1,0 +1,74 @@
+package id.homebase.core.ui.screens.vault.model
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * The names a Vault entry's pages carry into a WebDrop manifest - what the recipient sees and
+ * downloads. Single payload keeps the entry name; bundles number pages 1-based; extensions are
+ * byte-identical to downloadPayload's temp-file rule so name and file always agree.
+ */
+class VaultWebDropNamingTest {
+
+    @Test
+    fun singlePayloadKeepsTheEntryNameAndGainsItsExtension() {
+        assertEquals(listOf("Passport.jpg"), webDropFileNamesFor("Passport", listOf("image/jpeg")))
+    }
+
+    @Test
+    fun aMatchingExtensionIsNotDoubled() {
+        assertEquals(listOf("scan.pdf"), webDropFileNamesFor("scan.pdf", listOf("application/pdf")))
+    }
+
+    @Test
+    fun theMatchingExtensionStripIsCaseInsensitive() {
+        assertEquals(listOf("Scan.pdf"), webDropFileNamesFor("Scan.PDF", listOf("application/pdf")))
+    }
+
+    @Test
+    fun bundlesNumberPagesOneBasedInPageOrder() {
+        assertEquals(
+            listOf("Insurance card-1.png", "Insurance card-2.png", "Insurance card-3.png"),
+            webDropFileNamesFor("Insurance card", listOf("image/png", "image/png", "image/png")),
+        )
+    }
+
+    @Test
+    fun mixedPageTypesEachGetTheirOwnExtension() {
+        assertEquals(
+            listOf("Trip-1.png", "Trip-2.jpg"),
+            webDropFileNamesFor("Trip", listOf("image/png", "image/jpeg")),
+        )
+    }
+
+    @Test
+    fun aNullPageTypeFallsBackToBin() {
+        // The caller resolves descriptor ?: entry; a null reaching the helper means neither knew.
+        assertEquals(listOf("Mystery.bin"), webDropFileNamesFor("Mystery", listOf(null)))
+    }
+
+    @Test
+    fun jpegBecomesJpgExactlyLikeTheDownloadTempRule() {
+        assertEquals(listOf("Photo.jpg"), webDropFileNamesFor("Photo", listOf("image/jpeg")))
+        assertEquals("jpg", webDropExtensionFor("image/jpeg"))
+        assertEquals("bin", webDropExtensionFor("weird"))
+        assertEquals("bin", webDropExtensionFor(null))
+    }
+
+    @Test
+    fun aDottedNameWithNoRealExtensionIsNotMangled() {
+        assertEquals(
+            listOf("v2.final-1.pdf", "v2.final-2.pdf"),
+            webDropFileNamesFor("v2.final", listOf("application/pdf", "application/pdf")),
+        )
+    }
+
+    @Test
+    fun strippingAppliesPerPageInMixedBundles() {
+        // Page 1's pdf matches the entry name's extension and strips; page 2's png does not.
+        assertEquals(
+            listOf("report-1.pdf", "report.pdf-2.png"),
+            webDropFileNamesFor("report.pdf", listOf("application/pdf", "image/png")),
+        )
+    }
+}


### PR DESCRIPTION
The Vault gallery gains a **Send as WebDrop** action (Redeem icon next to Share, plus an overflow-menu item) — and it's **per-entry**, answering the "2 images in a bundle, I don't want to send each individually" problem: the entry *is* the bundle, a drop carries up to 24 files, so the whole thing leaves as **one** self-destructing link with one countdown and one consent screen. Per-page Share/Save are untouched; per-page WebDrop is deliberately out of v1.

## How it works

- Reuses the share-sheet hand-off wholesale: decrypt each payload to a temp path via the existing `downloadPayload` (per-descriptor IVs respected), seed `WebDropShareFlowState`, navigate to `Route.WebDrop` — the composer opens with the files picked; TTL/recipient/terms/theme live there as usual.
- **Guards**: `payloadDescriptors.size`, never `pageCount` (a 30-page PDF is ONE payload → one dropped file); > `MaxFilesPerDrop` → parameterized toast; entry-scoped re-entrancy + spinner via a synthetic `preparingShareKeys` key; any failed page reaps already-materialized temps and aborts loudly — **no partial drop**.
- Affordances gated on `OptionalDriveActivation(webDropLabeledDrive)` — no icon until the drive is activated.
- Recipient-facing names from a pure helper: `Passport.jpg`; `scan.pdf` not doubled (case-insensitive match, dotted-but-extensionless names untouched); bundles as `Insurance card-1.png`… in page order; extension rule byte-identical to `downloadPayload`'s temp suffix so name and file always agree.

## Accepted behaviors (from the reviewed plan)

- Navigating to WebDrop closes the gallery overlay; back lands on the vault grid (matches Settings/note nav).
- Activation drift between tap and nav → WebDrop onboarding; the consume-once draft can't resurface stale.
- Temps: composer owns them on success (share-sheet convention); reaped on abort; swept scratch regardless.

## Testing

- New `VaultWebDropNamingTest` (9 cases): single/multi naming, case-insensitive strip, mixed per-page types, null-type fallback, `jpeg→jpg`, unknown → `.bin`, dotted-name safety, per-page stripping.
- All four modules' jvmTest suites green (incl. Konsist), wasmJs + Android compiles, strings EN/DA.
- Manual pass pending: multi-image entry → Redeem → composer prefilled → create → both files decrypt in the browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ePkqms6AQdGGUWsVrGyzx