### PR TITLE
Show the unread total on the desktop app icon

### DIFF
--- a/desktopApp/src/jvmMain/kotlin/id/homebase/app/Main.kt
+++ b/desktopApp/src/jvmMain/kotlin/id/homebase/app/Main.kt
@@ -35,6 +35,7 @@ import id.homebase.api.youauth.YouAuthState
 import id.homebase.app.lifecycle.rememberDesktopLifecycleOwner
 import id.homebase.core.App
 import id.homebase.core.auth.AuthConnectionCoordinator
+import id.homebase.core.desktop.AppIconBadge
 import id.homebase.core.di.allModules
 import id.homebase.core.diagnostics.MainThreadWatchdog
 import id.homebase.api.client.isRecoverablePermissionFailure
@@ -333,6 +334,8 @@ fun main() {
 
             DesktopAppFocusManager.registerWindowProvider { window }
             window.minimumSize = java.awt.Dimension(minWidth, minHeight)
+
+            LaunchedEffect(window) { AppIconBadge.start(window) }
 
             if (isMacOs) {
                 LaunchedEffect(Unit) {

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
@@ -35,11 +35,14 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlin.time.Clock
 import kotlin.time.Instant
@@ -100,6 +103,11 @@ class ConversationStream(
     val conversations: StateFlow<ConversationsData> = _conversations.asStateFlow()
     val shareableConversations: StateFlow<List<ShareableConversation>> =
         _shareableConversations.asStateFlow()
+
+    // Archived / left / removed threads are counted, matching the per-row unread badge.
+    val totalUnreadCount: Flow<Int> = conversations
+        .map { data -> data.items.sumOf { it.unreadCount } }
+        .distinctUntilChanged()
 
     // region Recovery: missing or deleted conversation file
     /** Hook for explicit (non-sync) conversation recovery.

--- a/homebase-core/src/jvmMain/kotlin/id/homebase/core/desktop/AppIconBadge.kt
+++ b/homebase-core/src/jvmMain/kotlin/id/homebase/core/desktop/AppIconBadge.kt
@@ -1,0 +1,134 @@
+package id.homebase.core.desktop
+
+import co.touchlab.kermit.Logger
+import id.homebase.chat.services.convo.ConversationStream
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import org.koin.core.context.GlobalContext
+import java.awt.Color
+import java.awt.EventQueue
+import java.awt.Font
+import java.awt.Graphics2D
+import java.awt.Image
+import java.awt.RenderingHints
+import java.awt.Taskbar
+import java.awt.Window
+import java.awt.image.BufferedImage
+
+private const val TAG = "AppIconBadge"
+private const val OVERLAY_CAP = 99
+private const val OVERLAY_PX = 32
+private const val OVERLAY_TEXT_PX = 24
+private const val OVERLAY_FONT_MAX_PT = 22
+private const val OVERLAY_FONT_MIN_PT = 8
+
+// The overlay is painted by AWT outside any composition, so MaterialTheme is unreachable here.
+private val OVERLAY_BACKGROUND = Color(0xD3, 0x2F, 0x2F)
+
+/**
+ * Total unread count on the app's task-area icon: a text badge on the macOS Dock (and on a
+ * Unity launcher), an overlay image on the Windows taskbar button. Desktops that report
+ * neither feature are left untouched.
+ */
+object AppIconBadge {
+
+    @Volatile
+    private var window: Window? = null
+
+    @Volatile
+    private var lastCount: Int = 0
+
+    private var collecting = false
+    private var loggedSupport = false
+
+    /** Call once the Compose window exists; the Windows overlay is per-window. */
+    fun start(window: Window) {
+        this.window = window
+        if (collecting) {
+            apply(lastCount)
+            return
+        }
+        collecting = true
+        val koin = GlobalContext.get()
+        koin.get<CoroutineScope>().launch {
+            koin.get<ConversationStream>().totalUnreadCount.collect { count ->
+                lastCount = count
+                apply(count)
+            }
+        }
+    }
+
+    private fun apply(unreadCount: Int) {
+        val taskbar = if (Taskbar.isTaskbarSupported()) Taskbar.getTaskbar() else return
+        EventQueue.invokeLater {
+            val supportsText = taskbar.isSupported(Taskbar.Feature.ICON_BADGE_NUMBER)
+            val supportsOverlay = taskbar.isSupported(Taskbar.Feature.ICON_BADGE_IMAGE_WINDOW)
+            if (!loggedSupport) {
+                loggedSupport = true
+                Logger.i(tag = TAG) {
+                    "taskbar badge support: text=$supportsText overlay=$supportsOverlay"
+                }
+            }
+            if (supportsText) taskbar.setIconBadge(dockBadgeText(unreadCount))
+            val frame = window
+            if (supportsOverlay && frame != null) {
+                taskbar.setWindowIconBadge(
+                    frame,
+                    overlayBadgeText(unreadCount)?.let(::renderOverlay),
+                )
+            }
+        }
+    }
+}
+
+internal fun dockBadgeText(unreadCount: Int): String? =
+    if (unreadCount <= 0) null else unreadCount.toString()
+
+internal fun overlayBadgeText(unreadCount: Int): String? = when {
+    unreadCount <= 0 -> null
+    unreadCount > OVERLAY_CAP -> "$OVERLAY_CAP+"
+    else -> unreadCount.toString()
+}
+
+private fun renderOverlay(text: String): Image {
+    val image = BufferedImage(OVERLAY_PX, OVERLAY_PX, BufferedImage.TYPE_INT_ARGB)
+    val graphics = image.createGraphics()
+    try {
+        graphics.setRenderingHint(
+            RenderingHints.KEY_ANTIALIASING,
+            RenderingHints.VALUE_ANTIALIAS_ON,
+        )
+        graphics.setRenderingHint(
+            RenderingHints.KEY_TEXT_ANTIALIASING,
+            RenderingHints.VALUE_TEXT_ANTIALIAS_ON,
+        )
+        graphics.color = OVERLAY_BACKGROUND
+        graphics.fillOval(0, 0, OVERLAY_PX, OVERLAY_PX)
+        graphics.color = Color.WHITE
+        graphics.font = fittedFont(graphics, text)
+        val metrics = graphics.fontMetrics
+        graphics.drawString(
+            text,
+            (OVERLAY_PX - metrics.stringWidth(text)) / 2,
+            (OVERLAY_PX - metrics.height) / 2 + metrics.ascent,
+        )
+    } finally {
+        graphics.dispose()
+    }
+    return image
+}
+
+// Windows and macOS resolve SANS_SERIF to different faces, so the size has to be measured
+// against the real metrics rather than tabulated per digit count.
+private fun fittedFont(graphics: Graphics2D, text: String): Font {
+    for (points in OVERLAY_FONT_MAX_PT downTo OVERLAY_FONT_MIN_PT) {
+        val font = Font(Font.SANS_SERIF, Font.BOLD, points)
+        val metrics = graphics.getFontMetrics(font)
+        if (metrics.stringWidth(text) <= OVERLAY_TEXT_PX &&
+            metrics.ascent + metrics.descent <= OVERLAY_TEXT_PX
+        ) {
+            return font
+        }
+    }
+    return Font(Font.SANS_SERIF, Font.BOLD, OVERLAY_FONT_MIN_PT)
+}

--- a/homebase-core/src/jvmTest/kotlin/id/homebase/core/desktop/AppIconBadgeTest.kt
+++ b/homebase-core/src/jvmTest/kotlin/id/homebase/core/desktop/AppIconBadgeTest.kt
@@ -1,0 +1,31 @@
+package id.homebase.core.desktop
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class AppIconBadgeTest {
+
+    @Test
+    fun `nothing is shown when there is nothing unread`() {
+        assertNull(dockBadgeText(0))
+        assertNull(overlayBadgeText(0))
+        assertNull(dockBadgeText(-1))
+        assertNull(overlayBadgeText(-1))
+    }
+
+    @Test
+    fun `dock badge carries the exact total`() {
+        assertEquals("1", dockBadgeText(1))
+        assertEquals("126", dockBadgeText(126))
+        assertEquals("12345", dockBadgeText(12345))
+    }
+
+    @Test
+    fun `overlay badge caps once it stops fitting the icon`() {
+        assertEquals("1", overlayBadgeText(1))
+        assertEquals("99", overlayBadgeText(99))
+        assertEquals("99+", overlayBadgeText(100))
+        assertEquals("99+", overlayBadgeText(12345))
+    }
+}


### PR DESCRIPTION
The desktop app icon carries no unread indicator. The Dock icon looks identical whether there are zero unread messages or a hundred.

## There was no app-wide unread total to read

The per-conversation counts already exist. `ChatReadCount.sq`'s `selectAllUnreadCount` returns them `GROUP BY d.groupId`, read via `ChatReadCountWrapper.selectAllUnreadCount`, merged into the live list by `ConversationStream.enrichAllConversationsWithUnreadCounts`, and surfaced per row as `ConversationUiModel.unreadCount`. Nothing sums them.

`BadgeManager` in `homebase-common` looks like the app total but is not. It is an increment-per-notification counter — `increment()` / `resetCount()` — and its JVM actual is a no-op on every method. It was left alone.

So the total is derived at the layer that already owns the counts. Three lines in `ConversationStream`:

```kotlin
val totalUnreadCount: Flow<Int> = conversations
    .map { data -> data.items.sumOf { it.unreadCount } }
    .distinctUntilChanged()
```

## The unread rule is inherited, not invented

Whatever `selectAllUnreadCount` counts, the badge counts. That query is: chat messages (`fileType = 7878`, `dataType = 0`) newer than `ChatReadCount.lastReadTime`, authored by someone other than self (`originalAuthor IS NOT NULL AND originalAuthor != ?`), excluding soft-deleted rows on both markers (`fileState != 0`, `archivalStatus != 2`).

**Archived, left and removed threads are counted.** `ConversationItem.kt` renders the per-row unread badge with no conversation-state gate, so summing all items matches the in-app indicator exactly. There is no per-conversation mute feature in this codebase, so there is nothing to exclude on that axis either.

Whether the *icon* badge specifically should drop archived threads is a real open question, not an oversight — WhatsApp excludes archived from its icon count, Signal does not. This PR takes the position that the icon and the list should not disagree. Changing that means deciding the icon is a different surface with its own rule, and is worth its own change.

## Live and self-clearing

`_conversations` emits on every message arrival and every mark-as-read, so the badge tracks both directions without its own invalidation path. `SessionEnded` calls `ConversationStream.reset()`, which sets `_conversations.value = ConversationsData(dataReady = false)` — an empty `items` — so logging out drops the badge. Zero renders no badge at all rather than a literal `"0"`.

## Cost

The `sumOf` is O(n) over the conversation list, run once per list emission on `Dispatchers.Default`, behind `distinctUntilChanged()` on the resulting `Int`. Only a changed total hops to the EDT, via a single `EventQueue.invokeLater`.

Nothing here reads the conversation list from a composable. That matters: `CLAUDE.md` documents two prior main-thread stalls in this repo (builds 1394 and 1419) caused by exactly that pattern, and a per-emission O(n) sum on the UI dispatcher would have been a third.

## Platform matrix

Every AWT call is feature-checked — `Taskbar.isTaskbarSupported()`, then `isSupported(...)`. Nothing is wrapped in a swallowing `try`/`catch`.

| Platform | Path | Result |
|---|---|---|
| macOS | `ICON_BADGE_NUMBER` -> `setIconBadge("126")` | Dock badge, uncapped |
| Windows | `ICON_BADGE_IMAGE_WINDOW` -> `setWindowIconBadge` | 32x32 red disc, capped `99+` |
| Linux (Unity) | `ICON_BADGE_NUMBER` | launcher count, uncapped |
| everything else | neither feature | clean return, no exception |

`setIconBadge` internally checks `ICON_BADGE_NUMBER`, not `ICON_BADGE_TEXT` (JDK 21, `Taskbar.java:376`), so `ICON_BADGE_NUMBER` is the gate used. Gating on `ICON_BADGE_TEXT` would have thrown `UnsupportedOperationException` on a platform that reports one but not the other.

The cap is deliberately asymmetric. macOS and Unity render the real total, matching both macOS's own conventions and the uncapped in-app row badge. Only the 32px Windows overlay caps at `99+`, because a five-digit number is illegible inside it. The overlay font size is measured against real `FontMetrics` rather than tabulated per digit count, since Windows and macOS resolve `SANS_SERIF` to different faces.

## Why `GlobalContext`

`desktopApp` deliberately excludes `homebase-chat` from its compile classpath (`desktopApp/build.gradle.kts:69`), so `Main.kt` cannot name any chat type. `AppIconBadge` lives in `homebase-core`, which can, and its public surface is JDK-only: `start(java.awt.Window)`. The `ConversationStream` dependency is resolved through `GlobalContext` inside that call.

It is deliberately **not** registered as a `createdAtStart` Koin singleton. That would force eager `ConversationStream` construction during `startKoin`, which `Main.kt:120` explicitly warns against — eager creation there resolves `DatabaseManager.appDb` and throws `UninitializedPropertyAccessException` if the DB is not up yet.

## Test

`AppIconBadgeTest` covers the pure text and cap rules — nothing shown at zero or negative, the exact total on the Dock, `99+` on the overlay. Three tests. AWT is not mocked; the rendering and feature-gate paths are not unit-tested.

## Limitations

- **The badge appearing on the real macOS Dock is unverified by eye.** There is no Screen Recording permission on the machine this was written on.
- **The Windows taskbar overlay is entirely unverified.** Only its rendered bitmap and its feature gate were inspected, and that was done on macOS.
- What *was* verified non-visually: a standalone JDK 21 probe against this machine's real AWT taskbar peer reported `isTaskbarSupported=true`, `ICON_BADGE_NUMBER=true`, `ICON_BADGE_IMAGE_WINDOW=false`, and both `setIconBadge("126")` and `setIconBadge(null)` returned without throwing.
- `AppIconBadge` logs one `taskbar badge support: text=... overlay=...` line to `homebase.log` on first apply, so the path the live app actually chose is checkable from `~/Library/Application Support/HomebaseChatDev/logs/homebase.log` without a screenshot.

## Verification

- `:desktopApp:compileKotlinJvm` — BUILD SUCCESSFUL.
- `:homebase-core:jvmTest --tests '*AppIconBadgeTest*' --rerun-tasks` — 3 tests, 0 failures.
- `:homebase-common:jvmTest --tests '*ArchitectureTest*' --rerun-tasks` — 6 tests, 0 failures.
- `ConversationStream.kt` is `commonMain`, so all four targets were compiled: `:homebase-chat:compileKotlinJvm`, `:homebase-chat:compileKotlinIosSimulatorArm64`, `:homebase-chat:compileAndroidMain`, `:homebase-chat:compileKotlinWasmJs` — all BUILD SUCCESSFUL. `:homebase-chat:jvmTest` green.
