### PR TITLE
Open desktop settings as a floating pane, and fix the sidebar indicator and single-choice rows

### DIFF
--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -1426,7 +1426,9 @@
     <string name="settings_media_quality_header">Quality for photos and videos you send</string>
     <string name="settings_media_quality_standard">Standard</string>
     <string name="settings_media_quality_high">High</string>
-    <string name="settings_media_quality_footer">Standard sends photos up to 1600 pixels and video at 720p, so they upload faster and use far less data. High sends your photos exactly as they are and video at 1080p. Either way, what you save to your device is the version that was sent.</string>
+    <string name="settings_media_quality_standard_description">Photos up to 1600 pixels and video at 720p. Uploads faster and uses far less data.</string>
+    <string name="settings_media_quality_high_description">Photos exactly as they are and video at 1080p.</string>
+    <string name="settings_media_quality_footer">Either way, what you save to your device is the version that was sent.</string>
     <string name="chat_media_quality_hd">HD</string>
     <string name="cd_media_quality_high_on">High quality is on. Tap to send smaller photos and videos.</string>
     <string name="cd_media_quality_high_off">High quality is off. Tap to send photos and videos at full quality.</string>

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -1433,6 +1433,7 @@
     <string name="cd_media_quality_hd_badge">Sent in high quality</string>
 
     <!-- Settings hub -->
+    <string name="settings_category_general">General</string>
     <string name="settings_section_preferences">Preferences</string>
     <string name="settings_section_apps">Apps</string>
     <string name="settings_section_device">Device</string>

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/ui/theme/Shapes.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/ui/theme/Shapes.kt
@@ -1,0 +1,9 @@
+package id.homebase.core.ui.theme
+
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.unit.dp
+
+// Shared by the desktop navigation rail and the settings pane's sidebar. Both are navigation
+// surfaces sitting side by side, so a selected item shaped differently in each reads as a bug.
+val NavigationIndicatorShape: Shape = RoundedCornerShape(14.dp)

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/widget/SettingsOptionRow.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/widget/SettingsOptionRow.kt
@@ -1,29 +1,23 @@
 package id.homebase.core.widget
 
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.selection.selectable
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Check
-import androidx.compose.material3.Icon
 import androidx.compose.material3.ListItem
-import androidx.compose.material3.ListItemDefaults
-import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.unit.dp
 
-// One choice under a [SettingsRowAction.Expand] row. The empty leading slot lines the label up
-// with its parent's, and `selectable` announces the selection instead of the check mark.
+// The radio occupies the same 24.dp leading slot as SettingsRow's icon, so an option nested under
+// a [SettingsRowAction.Expand] row still lines up with its parent's label.
 @Composable
 fun SettingsOptionRow(
     label: String,
     selected: Boolean,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
+    supportingText: String? = null,
 ) {
     ListItem(
         modifier = modifier.selectable(
@@ -34,25 +28,11 @@ fun SettingsOptionRow(
         headlineContent = {
             Text(text = label, maxLines = 2, overflow = TextOverflow.Ellipsis)
         },
-        leadingContent = { Spacer(modifier = Modifier.size(24.dp)) },
-        trailingContent = if (selected) {
-            {
-                Icon(
-                    imageVector = Icons.Filled.Check,
-                    contentDescription = null,
-                    modifier = Modifier.size(24.dp),
-                )
-            }
-        } else {
-            null
+        supportingContent = supportingText?.let { supporting ->
+            { Text(text = supporting) }
         },
-        colors = ListItemDefaults.colors(
-            headlineColor = if (selected) {
-                MaterialTheme.colorScheme.primary
-            } else {
-                MaterialTheme.colorScheme.onSurface
-            },
-            trailingIconColor = MaterialTheme.colorScheme.primary,
-        ),
+        leadingContent = {
+            RadioButton(selected = selected, onClick = null)
+        },
     )
 }

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/widget/SettingsTopBar.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/widget/SettingsTopBar.kt
@@ -1,0 +1,58 @@
+package id.homebase.core.widget
+
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarScrollBehavior
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.ProvidableCompositionLocal
+import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.ui.Modifier
+import id.homebase.resources.MR
+import id.homebase.resources.menu_back
+import org.jetbrains.compose.resources.stringResource
+
+// True while a settings screen renders inside the desktop settings pane, whose own header owns
+// both the page title and dismissal — so the screen's bar would be a second title and a back
+// arrow pointing nowhere.
+internal val LocalSettingsPaneEmbedded: ProvidableCompositionLocal<Boolean> =
+    compositionLocalOf { false }
+
+@Composable
+fun ProvideSettingsChrome(embedded: Boolean, content: @Composable () -> Unit) {
+    CompositionLocalProvider(LocalSettingsPaneEmbedded provides embedded, content = content)
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SettingsTopBar(
+    title: String,
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+    titleModifier: Modifier = Modifier,
+    navigationIconModifier: Modifier = Modifier,
+    scrollBehavior: TopAppBarScrollBehavior? = null,
+    actions: @Composable RowScope.() -> Unit = {},
+) {
+    if (LocalSettingsPaneEmbedded.current) return
+    TopAppBar(
+        title = { Text(title, modifier = titleModifier) },
+        modifier = modifier,
+        navigationIcon = {
+            IconButton(onClick = onBack, modifier = navigationIconModifier) {
+                Icon(
+                    imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                    contentDescription = stringResource(MR.string.menu_back),
+                )
+            }
+        },
+        actions = actions,
+        scrollBehavior = scrollBehavior,
+    )
+}

--- a/homebase-common/src/commonTest/kotlin/id/homebase/core/widget/SettingsOptionRowTest.kt
+++ b/homebase-common/src/commonTest/kotlin/id/homebase/core/widget/SettingsOptionRowTest.kt
@@ -1,8 +1,13 @@
 package id.homebase.core.widget
 
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotSelected
 import androidx.compose.ui.test.assertIsSelected
 import androidx.compose.ui.test.isToggleable
@@ -16,7 +21,7 @@ import kotlin.test.assertEquals
 class SettingsOptionRowTest {
 
     @Test
-    fun reportsSelectionInsteadOfLeavingItToTheCheckMark() = runComposeUiTest {
+    fun reportsSelectionOnTheRow() = runComposeUiTest {
         setContent {
             MaterialTheme {
                 SettingsOptionRow(label = "Dark", selected = true, onClick = {})
@@ -48,5 +53,32 @@ class SettingsOptionRowTest {
             }
         }
         onAllNodes(isToggleable()).assertCountEquals(0)
+    }
+
+    /** The announced role has to match the control that is actually rendered. */
+    @Test
+    fun announcesTheRadioButtonRole() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                SettingsOptionRow(label = "Dark", selected = true, onClick = {})
+            }
+        }
+        onNodeWithText("Dark")
+            .assert(SemanticsMatcher.expectValue(SemanticsProperties.Role, Role.RadioButton))
+    }
+
+    @Test
+    fun rendersSupportingTextWhenGiven() = runComposeUiTest {
+        setContent {
+            MaterialTheme {
+                SettingsOptionRow(
+                    label = "High",
+                    selected = false,
+                    onClick = {},
+                    supportingText = "Photos exactly as they are",
+                )
+            }
+        }
+        onNodeWithText("Photos exactly as they are").assertIsDisplayed()
     }
 }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
@@ -77,9 +77,11 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.repeatOnLifecycle
+import androidx.navigation.FloatingWindow
 import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavDestination
 import androidx.navigation.NavDestination.Companion.hasRoute
+import androidx.navigation.NavGraph
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -147,6 +149,8 @@ import id.homebase.core.ui.screens.notifications.NotificationSettingsScreen
 import id.homebase.core.ui.screens.profile.ProfileAvatarEditScreen
 import id.homebase.core.ui.screens.profile.ProfileEditScreen
 import id.homebase.core.ui.screens.settings.SettingsActions
+import id.homebase.core.ui.screens.settings.SettingsPaneActions
+import id.homebase.core.ui.screens.settings.SettingsPaneHost
 import id.homebase.core.ui.screens.settings.SettingsScreen
 import androidx.compose.material3.CircularProgressIndicator
 import id.homebase.core.ui.screens.vault.VaultScreen
@@ -190,8 +194,8 @@ import id.homebase.resources.vault_label
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.koinInject
 import id.homebase.core.util.getUriHandler
-import id.homebase.core.util.isExpandedLayout
 import id.homebase.core.util.isDesktopOrWeb
+import id.homebase.core.util.isExpandedLayout
 import id.homebase.chat.conversationlist.ConversationListUiAction
 import id.homebase.resources.chat_archived_chats
 import id.homebase.resources.settings
@@ -261,6 +265,16 @@ fun AppNavHost(
     val isAuthenticated = authState is YouAuthState.Authenticated && identityScope != null
     val navBackStackEntry by navController.currentBackStackEntryAsState()
     val currentDestination = navBackStackEntry?.destination
+    // A settings pane floats over the screen beneath it, which stays mounted. The rail and bottom
+    // bar must keep tracking that screen or they vanish (and reflow it) the moment a pane opens.
+    val chromeDestination = if (isDesktopOrWeb()) {
+        val backStack by navController.currentBackStack.collectAsStateWithLifecycle()
+        backStack.lastOrNull {
+            it.destination !is FloatingWindow && it.destination !is NavGraph
+        }?.destination
+    } else {
+        currentDestination
+    }
     val momentsPreferences = koinInject<MomentsPreferences>()
     val momentsIconVisible by momentsPreferences.iconVisible.collectAsStateWithLifecycle()
     val momentsFeedService = koinInject<MomentsFeedService>()
@@ -367,9 +381,9 @@ fun AppNavHost(
     // check (not topLevelRoutes) so the bottom nav still shows on the Vault screen even
     // when the user has hidden the Vault icon from the nav bar.
     val isTopLevelRoute =
-        currentDestination.isTopLevelRoute() ||
+        chromeDestination.isTopLevelRoute() ||
                 topLevelRoutes.any { topLevelRoute ->
-                    currentDestination?.hasRoute(topLevelRoute.route::class) == true
+                    chromeDestination?.hasRoute(topLevelRoute.route::class) == true
                 }
 
     // Only show bottom nav if on a top-level route AND not showing only detail pane
@@ -706,7 +720,7 @@ fun AppNavHost(
                 NavigationBar {
                     topLevelRoutes.forEach { topLevelRoute ->
                         val isSelected =
-                            currentDestination?.hasRoute(topLevelRoute.route::class) == true
+                            chromeDestination?.hasRoute(topLevelRoute.route::class) == true
                         NavigationBarItem(
                             icon = {
                                 TopLevelNavIcon(
@@ -761,7 +775,7 @@ fun AppNavHost(
                     ) {
                         topLevelRoutes.forEach { topLevelRoute ->
                             val isSelected =
-                                currentDestination?.hasRoute(topLevelRoute.route::class) == true
+                                chromeDestination?.hasRoute(topLevelRoute.route::class) == true
                             RailItem(
                                 topLevelRoute = topLevelRoute,
                                 selected = isSelected,
@@ -1495,7 +1509,39 @@ fun AppNavHost(
                             }
                         }
 
-                        composable<Route.Settings> {
+                        settingsDestination<Route.Settings>(
+                            onDismiss = { navController.popBackStack() },
+                            paneContent = {
+                                if (isAuthenticated) {
+                                    SettingsPaneHost(
+                                        showDeveloperMenu = showDeveloperMenu,
+                                        onDismiss = { navController.popBackStack() },
+                                        actions = SettingsPaneActions(
+                                            onOpenWebDrop = openWebDrop,
+                                            onLocation = openLocation,
+                                            onOpenMoments = openMoments,
+                                            onOpenVault = openVault,
+                                            onOpenEmail = openEmail,
+                                            onOpenContacts = openContactBook,
+                                            onNavigateToCropper = { requestId ->
+                                                navController.navigate(
+                                                    Route.Crop(
+                                                        requestId.toString(),
+                                                        lockedAspect = "square",
+                                                    )
+                                                )
+                                            },
+                                            onNavigateToDeveloperMenu = {
+                                                navController.navigate(Route.DeveloperMenu)
+                                            },
+                                            onNavigateToDefragmenter = {
+                                                navController.navigate(Route.Defragmenter)
+                                            },
+                                        ),
+                                    )
+                                }
+                            },
+                        ) {
                             if (isAuthenticated) {
                                 SettingsScreen(
                                     viewModel = koinViewModel(),

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
@@ -59,7 +59,6 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.selection.selectable
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
@@ -193,6 +192,7 @@ import id.homebase.resources.location_locate_fetch_failed
 import id.homebase.resources.vault_label
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.koinInject
+import id.homebase.core.ui.theme.NavigationIndicatorShape
 import id.homebase.core.util.getUriHandler
 import id.homebase.core.util.isDesktopOrWeb
 import id.homebase.core.util.isExpandedLayout
@@ -244,7 +244,6 @@ private const val SHOW_ARCHIVED_KEY = "showArchived"
 // Material's 80dp rail is tuned for touch; desktop chat clients sit at 64dp.
 private val NavigationRailWidth = 64.dp
 private val RailIndicatorSize = 48.dp
-private val RailIndicatorShape = RoundedCornerShape(14.dp)
 private val RailIconSize = 20.dp
 
 @Composable
@@ -2219,7 +2218,7 @@ private fun RailItem(
     onClick: () -> Unit,
 ) {
     Box(
-        modifier = Modifier.size(RailIndicatorSize).clip(RailIndicatorShape).background(
+        modifier = Modifier.size(RailIndicatorSize).clip(NavigationIndicatorShape).background(
             if (selected) MaterialTheme.colorScheme.primaryContainer else Color.Transparent
         ).selectable(selected = selected, role = Role.Tab, onClick = onClick),
         contentAlignment = Alignment.Center,
@@ -2243,7 +2242,7 @@ private fun RailActionItem(
     onClick: () -> Unit,
 ) {
     Box(
-        modifier = Modifier.size(RailIndicatorSize).clip(RailIndicatorShape)
+        modifier = Modifier.size(RailIndicatorSize).clip(NavigationIndicatorShape)
             .clickable(role = Role.Button, onClick = onClick),
         contentAlignment = Alignment.Center,
     ) {

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/SettingsPaneDestination.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/SettingsPaneDestination.kt
@@ -1,0 +1,121 @@
+package id.homebase.core.ui.navigation
+
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.DialogProperties
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.dialog
+import id.homebase.core.util.isDesktopOrWeb
+import id.homebase.core.util.isExpandedLayout
+
+private val PaneMaxWidth = 980.dp
+private val PaneMaxHeight = 800.dp
+private const val PaneWidthFraction = 0.92f
+private const val PaneHeightFraction = 0.9f
+
+/**
+ * Registers [T] as a dialog destination on desktop/web — which is what keeps the screen underneath
+ * mounted and visible — and as an ordinary full-screen destination everywhere else.
+ *
+ * Gated on the platform, not the window width, because `NavHost` rebuilds its graph when the
+ * builder lambda changes and that resets the back stack; width is decided inside
+ * [SettingsPaneContainer], which falls back to [content] below the expanded breakpoint.
+ *
+ * [paneContent] must host its own sub-pages rather than pushing routes: a second dialog layer
+ * stacks a second platform scrim (`Color.Black` @ 0.6 each, not settable from commonMain) and the
+ * app behind goes near-black, which is the thing this pane exists to avoid.
+ */
+internal inline fun <reified T : Any> NavGraphBuilder.settingsDestination(
+    noinline onDismiss: () -> Unit,
+    noinline paneContent: @Composable () -> Unit,
+    noinline content: @Composable () -> Unit,
+) {
+    if (isDesktopOrWeb()) {
+        dialog<T>(dialogProperties = DialogProperties(usePlatformDefaultWidth = false)) {
+            SettingsPaneContainer(
+                onDismiss = onDismiss,
+                paneContent = paneContent,
+                content = content,
+            )
+        }
+    } else {
+        composable<T> { content() }
+    }
+}
+
+@Composable
+internal fun SettingsPaneContainer(
+    onDismiss: () -> Unit,
+    paneContent: @Composable () -> Unit,
+    content: @Composable () -> Unit,
+) {
+    val floating = isExpandedLayout()
+    val focusRequester = remember { FocusRequester() }
+    var dismissRequested by remember { mutableStateOf(false) }
+
+    LaunchedEffect(focusRequester) { focusRequester.requestFocus() }
+
+    // Sizing the surface (rather than a full-bleed wrapper) is what leaves a margin the dialog
+    // layer can report as an outside click; a fillMaxSize child would swallow the scrim tap.
+    // widthIn must stay OUTSIDE fillMaxWidth: fill reports its own size upward, so an inner
+    // widthIn constrains the child and is then ignored. The fraction is what leaves the margin.
+    val sizing = if (floating) {
+        Modifier
+            .widthIn(max = PaneMaxWidth)
+            .fillMaxWidth(PaneWidthFraction)
+            .heightIn(max = PaneMaxHeight)
+            .fillMaxHeight(PaneHeightFraction)
+    } else {
+        Modifier.fillMaxSize()
+    }
+
+    Surface(
+        modifier = sizing
+            .focusRequester(focusRequester)
+            .focusable()
+            .onPreviewKeyEvent { event ->
+                if (event.key == Key.Escape && event.type == KeyEventType.KeyDown) {
+                    if (!dismissRequested) {
+                        dismissRequested = true
+                        onDismiss()
+                    }
+                    true
+                } else {
+                    false
+                }
+            },
+        shape = if (floating) MaterialTheme.shapes.extraLarge else RectangleShape,
+        color = if (floating) {
+            MaterialTheme.colorScheme.surface
+        } else {
+            MaterialTheme.colorScheme.background
+        },
+        tonalElevation = if (floating) 6.dp else 0.dp,
+        shadowElevation = if (floating) 6.dp else 0.dp,
+    ) {
+        if (floating) paneContent() else content()
+    }
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/appearance/AppearanceSettingsScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/appearance/AppearanceSettingsScreen.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Brightness6
 import androidx.compose.material.icons.filled.DarkMode
 import androidx.compose.material.icons.filled.LightMode
@@ -40,13 +39,13 @@ import id.homebase.core.settings.setPlatformSystemLocale
 import id.homebase.core.widget.SettingsOptionRow
 import id.homebase.core.widget.SettingsRow
 import id.homebase.core.widget.SettingsRowAction
+import id.homebase.core.widget.SettingsTopBar
 import id.homebase.resources.MR
 import id.homebase.resources.language
 import id.homebase.resources.language_danish
 import id.homebase.resources.language_english_gb
 import id.homebase.resources.language_english_us
 import id.homebase.resources.language_system
-import id.homebase.resources.menu_back
 import id.homebase.resources.settings_appearance
 import id.homebase.resources.settings_haptic_feedback
 import id.homebase.resources.theme
@@ -92,16 +91,9 @@ fun AppearanceSettingsUi(
 
     Scaffold(
         topBar = {
-            TopAppBar(
-                title = { Text(stringResource(MR.string.settings_appearance)) },
-                navigationIcon = {
-                    IconButton(onClick = onBackClick) {
-                        Icon(
-                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = stringResource(MR.string.menu_back)
-                        )
-                    }
-                },
+            SettingsTopBar(
+                title = stringResource(MR.string.settings_appearance),
+                onBack = onBackClick,
             )
         },
     ) { innerPadding ->

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/appearance/AppearanceSettingsScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/appearance/AppearanceSettingsScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Brightness6
@@ -120,7 +121,7 @@ fun AppearanceSettingsUi(
                 ),
             )
             AnimatedVisibility(visible = languageExpanded) {
-                Column {
+                Column(modifier = Modifier.selectableGroup()) {
                     uiState.availableLanguages.forEach { language ->
                         SettingsOptionRow(
                             label = stringResource(getStringResourceForLanguage(language)),
@@ -145,7 +146,7 @@ fun AppearanceSettingsUi(
                 ),
             )
             AnimatedVisibility(visible = themeExpanded) {
-                Column {
+                Column(modifier = Modifier.selectableGroup()) {
                     ThemeState.entries.forEach { theme ->
                         SettingsOptionRow(
                             label = theme.getStringResourceForTheme(),

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/settings/ContactBookSettingsScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/contactbook/settings/ContactBookSettingsScreen.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.outlined.People
 import androidx.compose.material.icons.outlined.Visibility
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -26,11 +25,11 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import id.homebase.core.widget.SettingsRow
 import id.homebase.core.widget.SettingsRowAction
+import id.homebase.core.widget.SettingsTopBar
 import id.homebase.resources.MR
 import id.homebase.resources.contactbook_settings_open
 import id.homebase.resources.contactbook_settings_section
 import id.homebase.resources.contactbook_settings_show_icon
-import id.homebase.resources.menu_back
 import org.jetbrains.compose.resources.stringResource
 
 @Composable
@@ -62,16 +61,9 @@ fun ContactBookSettingsUi(
 ) {
     Scaffold(
         topBar = {
-            TopAppBar(
-                title = { Text(stringResource(MR.string.contactbook_settings_section)) },
-                navigationIcon = {
-                    IconButton(onClick = onBackClick) {
-                        Icon(
-                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = stringResource(MR.string.menu_back),
-                        )
-                    }
-                },
+            SettingsTopBar(
+                title = stringResource(MR.string.contactbook_settings_section),
+                onBack = onBackClick,
             )
         },
     ) { innerPadding ->

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/email/settings/EmailSettingsScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/email/settings/EmailSettingsScreen.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.outlined.Fingerprint
 import androidx.compose.material.icons.outlined.MailOutline
 import androidx.compose.material.icons.outlined.Visibility
@@ -27,12 +26,12 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import id.homebase.core.widget.SettingsRow
 import id.homebase.core.widget.SettingsRowAction
+import id.homebase.core.widget.SettingsTopBar
 import id.homebase.resources.MR
 import id.homebase.resources.email_settings_biometrics
 import id.homebase.resources.email_settings_open
 import id.homebase.resources.email_settings_section
 import id.homebase.resources.email_settings_show_icon
-import id.homebase.resources.menu_back
 import org.jetbrains.compose.resources.stringResource
 
 @Composable
@@ -65,16 +64,9 @@ fun EmailSettingsUi(
     val scrollState = rememberScrollState()
     Scaffold(
         topBar = {
-            TopAppBar(
-                title = { Text(stringResource(MR.string.email_settings_section)) },
-                navigationIcon = {
-                    IconButton(onClick = onBackClick) {
-                        Icon(
-                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = stringResource(MR.string.menu_back),
-                        )
-                    }
-                },
+            SettingsTopBar(
+                title = stringResource(MR.string.email_settings_section),
+                onBack = onBackClick,
             )
         },
     ) { innerPadding ->

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/help/HelpScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/help/HelpScreen.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.outlined.HelpOutline
 import androidx.compose.material.icons.outlined.BugReport
 import androidx.compose.material.icons.outlined.Code
@@ -45,6 +44,7 @@ import id.homebase.core.util.getUriHandler
 import id.homebase.core.widget.SettingsRow
 import id.homebase.core.widget.SettingsRowAction
 import id.homebase.core.widget.SettingsSectionHeader
+import id.homebase.core.widget.SettingsTopBar
 import id.homebase.resources.MR
 import id.homebase.resources.about_homebase
 import id.homebase.resources.dev_menu_title
@@ -60,7 +60,6 @@ import id.homebase.resources.help_support_center
 import id.homebase.resources.help_terms_privacy
 import id.homebase.resources.help_version
 import id.homebase.resources.logging
-import id.homebase.resources.menu_back
 import id.homebase.resources.settings_help
 import id.homebase.resources.update_available
 import id.homebase.resources.update_check_now
@@ -140,24 +139,11 @@ fun HelpUi(
     Scaffold(
         snackbarHost = { SnackbarHost(snackbarHostState) },
         topBar = {
-            TopAppBar(
-                title = {
-                    Text(
-                        stringResource(MR.string.settings_help),
-                        modifier = Modifier.testTag("helpTitle"),
-                    )
-                },
-                navigationIcon = {
-                    IconButton(
-                        onClick = onBackClick,
-                        modifier = Modifier.testTag("helpBackButton"),
-                    ) {
-                        Icon(
-                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = stringResource(MR.string.menu_back)
-                        )
-                    }
-                }
+            SettingsTopBar(
+                title = stringResource(MR.string.settings_help),
+                titleModifier = Modifier.testTag("helpTitle"),
+                navigationIconModifier = Modifier.testTag("helpBackButton"),
+                onBack = onBackClick,
             )
         }
     ) { innerPadding ->

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentsSettingsScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/MomentsSettingsScreen.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.outlined.AutoAwesome
 import androidx.compose.material.icons.outlined.Visibility
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -26,8 +25,8 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import id.homebase.core.widget.SettingsRow
 import id.homebase.core.widget.SettingsRowAction
+import id.homebase.core.widget.SettingsTopBar
 import id.homebase.resources.MR
-import id.homebase.resources.menu_back
 import id.homebase.resources.moments_settings_open
 import id.homebase.resources.moments_settings_section
 import id.homebase.resources.moments_settings_show_icon
@@ -60,16 +59,9 @@ fun MomentsSettingsUi(
     val scrollState = rememberScrollState()
     Scaffold(
         topBar = {
-            TopAppBar(
-                title = { Text(stringResource(MR.string.moments_settings_section)) },
-                navigationIcon = {
-                    IconButton(onClick = onBackClick) {
-                        Icon(
-                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = stringResource(MR.string.menu_back),
-                        )
-                    }
-                },
+            SettingsTopBar(
+                title = stringResource(MR.string.moments_settings_section),
+                onBack = onBackClick,
             )
         },
     ) { innerPadding ->

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/notifications/NotificationSettingsScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/notifications/NotificationSettingsScreen.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.outlined.VolumeUp
 import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.outlined.MusicNote
@@ -53,8 +52,8 @@ import id.homebase.core.widget.SettingsOptionRow
 import id.homebase.core.widget.SettingsRow
 import id.homebase.core.widget.SettingsRowAction
 import id.homebase.core.widget.SettingsSectionHeader
+import id.homebase.core.widget.SettingsTopBar
 import id.homebase.resources.MR
-import id.homebase.resources.menu_back
 import id.homebase.resources.not_available
 import id.homebase.resources.settings_badge_count
 import id.homebase.resources.settings_copy_token
@@ -139,16 +138,11 @@ fun NotificationSettingsUi(
 
     Scaffold(
         topBar = {
-            TopAppBar(
-                title = { Text(stringResource(MR.string.settings_notifications), modifier = Modifier.testTag("notificationsTitle")) },
-                navigationIcon = {
-                    IconButton(onClick = onBackClick) {
-                        Icon(
-                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = stringResource(MR.string.menu_back)
-                        )
-                    }
-                })
+            SettingsTopBar(
+                title = stringResource(MR.string.settings_notifications),
+                titleModifier = Modifier.testTag("notificationsTitle"),
+                onBack = onBackClick,
+            )
         }) { innerPadding ->
         Column(
             modifier = Modifier

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/notifications/NotificationSettingsScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/notifications/NotificationSettingsScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
@@ -230,14 +231,16 @@ fun NotificationSettingsUi(
                 ),
             )
             if (uiState.showContentLevelPicker) {
-                NotificationContentLevel.entries.forEach { level ->
-                    SettingsOptionRow(
-                        label = stringResource(level.label),
-                        selected = level == uiState.notificationContentLevel,
-                        onClick = {
-                            onAction(NotificationSettingsUiAction.SetContentLevel(level))
-                        },
-                    )
+                Column(modifier = Modifier.fillMaxWidth().selectableGroup()) {
+                    NotificationContentLevel.entries.forEach { level ->
+                        SettingsOptionRow(
+                            label = stringResource(level.label),
+                            selected = level == uiState.notificationContentLevel,
+                            onClick = {
+                                onAction(NotificationSettingsUiAction.SetContentLevel(level))
+                            },
+                        )
+                    }
                 }
             }
             Text(

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/profile/ProfileAvatarEditScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/profile/ProfileAvatarEditScreen.kt
@@ -16,7 +16,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.PhotoCamera
 import androidx.compose.material.icons.outlined.Person
 import androidx.compose.material3.Button
@@ -47,9 +46,9 @@ import coil3.compose.AsyncImage
 import id.homebase.api.client.profile.ProfileAttribute
 import id.homebase.api.client.profile.ProfileVisibility
 import id.homebase.core.image.HomebaseImage
+import id.homebase.core.widget.SettingsTopBar
 import id.homebase.resources.MR
 import id.homebase.resources.cd_profile_avatar_change_photo
-import id.homebase.resources.menu_back
 import id.homebase.resources.profile_avatar_edit_acl_anonymous
 import id.homebase.resources.profile_avatar_edit_acl_connected
 import id.homebase.resources.profile_avatar_edit_anonymous_desc
@@ -99,16 +98,9 @@ fun ProfileAvatarEditScreen(
 
     Scaffold(
         topBar = {
-            TopAppBar(
-                title = { Text(stringResource(MR.string.profile_avatar_edit_title)) },
-                navigationIcon = {
-                    IconButton(onClick = { viewModel.onAction(ProfileAvatarEditAction.BackClicked) }) {
-                        Icon(
-                            Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = stringResource(MR.string.menu_back),
-                        )
-                    }
-                },
+            SettingsTopBar(
+                title = stringResource(MR.string.profile_avatar_edit_title),
+                onBack = { viewModel.onAction(ProfileAvatarEditAction.BackClicked) },
             )
         },
         snackbarHost = { SnackbarHost(snackbarHostState) },

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/profile/ProfileEditScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/profile/ProfileEditScreen.kt
@@ -20,7 +20,6 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.outlined.AlternateEmail
 import androidx.compose.material.icons.outlined.Badge
@@ -74,6 +73,7 @@ import id.homebase.core.ui.screens.contactbook.ContactFieldValidation
 import id.homebase.core.widget.AdaptiveSheet
 import id.homebase.core.ui.screens.contactbook.components.PhoneNumberField
 import id.homebase.core.ui.screens.contactbook.components.formatPhoneForDisplay
+import id.homebase.core.widget.SettingsTopBar
 import id.homebase.resources.MR
 import id.homebase.resources.cancel
 import id.homebase.resources.contactbook_detail_location
@@ -81,7 +81,6 @@ import id.homebase.resources.contactbook_detail_name
 import id.homebase.resources.contactbook_error_birthday
 import id.homebase.resources.contactbook_error_email
 import id.homebase.resources.contactbook_error_phone
-import id.homebase.resources.menu_back
 import id.homebase.resources.profile_edit_add_attribute
 import id.homebase.resources.profile_edit_add_attribute_title
 import id.homebase.resources.profile_edit_additional_name
@@ -186,16 +185,9 @@ fun ProfileEditScreen(
 
     Scaffold(
         topBar = {
-            TopAppBar(
-                title = { Text(stringResource(MR.string.profile_edit_title)) },
-                navigationIcon = {
-                    IconButton(onClick = { viewModel.onAction(ProfileEditAction.BackClicked) }) {
-                        Icon(
-                            Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = stringResource(MR.string.menu_back),
-                        )
-                    }
-                },
+            SettingsTopBar(
+                title = stringResource(MR.string.profile_edit_title),
+                onBack = { viewModel.onAction(ProfileEditAction.BackClicked) },
                 actions = {
                     if (!uiState.isLoading && !uiState.loadFailed) {
                         IconButton(onClick = { previewMode = !previewMode }) {

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/settings/SettingsPaneCategory.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/settings/SettingsPaneCategory.kt
@@ -17,6 +17,7 @@ import androidx.compose.material.icons.outlined.People
 import androidx.compose.material.icons.outlined.Storage
 import androidx.compose.material.icons.outlined.Tune
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.NavigationDrawerItem
 import androidx.compose.material3.NavigationDrawerItemDefaults
 import androidx.compose.material3.Text
@@ -25,6 +26,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.dp
 import id.homebase.core.ui.theme.Dimens
+import id.homebase.core.ui.theme.NavigationIndicatorShape
 import id.homebase.resources.MR
 import id.homebase.resources.contactbook_settings_section
 import id.homebase.resources.email_settings_section
@@ -77,7 +79,12 @@ internal fun SettingsSidebar(
                     selected = category == selected,
                     onClick = { onSelect(category) },
                     modifier = Modifier.padding(horizontal = Dimens.Spacing.item),
-                    colors = NavigationDrawerItemDefaults.colors(),
+                    shape = NavigationIndicatorShape,
+                    colors = NavigationDrawerItemDefaults.colors(
+                        selectedContainerColor = MaterialTheme.colorScheme.primaryContainer,
+                        selectedIconColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                        selectedTextColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                    ),
                 )
             }
         }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/settings/SettingsPaneCategory.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/settings/SettingsPaneCategory.kt
@@ -1,0 +1,85 @@
+package id.homebase.core.ui.screens.settings
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.HelpOutline
+import androidx.compose.material.icons.outlined.AutoAwesome
+import androidx.compose.material.icons.outlined.Brightness6
+import androidx.compose.material.icons.outlined.Lock
+import androidx.compose.material.icons.outlined.MailOutline
+import androidx.compose.material.icons.outlined.Notifications
+import androidx.compose.material.icons.outlined.People
+import androidx.compose.material.icons.outlined.Storage
+import androidx.compose.material.icons.outlined.Tune
+import androidx.compose.material3.Icon
+import androidx.compose.material3.NavigationDrawerItem
+import androidx.compose.material3.NavigationDrawerItemDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.dp
+import id.homebase.core.ui.theme.Dimens
+import id.homebase.resources.MR
+import id.homebase.resources.contactbook_settings_section
+import id.homebase.resources.email_settings_section
+import id.homebase.resources.moments_settings_section
+import id.homebase.resources.settings_appearance
+import id.homebase.resources.settings_category_general
+import id.homebase.resources.settings_data_storage
+import id.homebase.resources.settings_help
+import id.homebase.resources.settings_notifications
+import id.homebase.resources.vault_settings_section
+import org.jetbrains.compose.resources.StringResource
+import org.jetbrains.compose.resources.stringResource
+
+internal val SettingsSidebarWidth = 220.dp
+
+internal enum class SettingsCategory(
+    val label: StringResource,
+    val icon: ImageVector,
+) {
+    General(MR.string.settings_category_general, Icons.Outlined.Tune),
+    Notifications(MR.string.settings_notifications, Icons.Outlined.Notifications),
+    Appearance(MR.string.settings_appearance, Icons.Outlined.Brightness6),
+    Moments(MR.string.moments_settings_section, Icons.Outlined.AutoAwesome),
+    Vault(MR.string.vault_settings_section, Icons.Outlined.Lock),
+    Email(MR.string.email_settings_section, Icons.Outlined.MailOutline),
+    Contacts(MR.string.contactbook_settings_section, Icons.Outlined.People),
+    Storage(MR.string.settings_data_storage, Icons.Outlined.Storage),
+    Help(MR.string.settings_help, Icons.AutoMirrored.Outlined.HelpOutline),
+}
+
+@Composable
+internal fun SettingsSidebar(
+    selected: SettingsCategory,
+    showEmail: Boolean,
+    onSelect: (SettingsCategory) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .width(SettingsSidebarWidth)
+            .fillMaxHeight()
+            .verticalScroll(rememberScrollState())
+            .padding(vertical = Dimens.Spacing.item),
+    ) {
+        SettingsCategory.entries.forEach { category ->
+            if (category != SettingsCategory.Email || showEmail) {
+                NavigationDrawerItem(
+                    label = { Text(stringResource(category.label)) },
+                    icon = { Icon(category.icon, contentDescription = null) },
+                    selected = category == selected,
+                    onClick = { onSelect(category) },
+                    modifier = Modifier.padding(horizontal = Dimens.Spacing.item),
+                    colors = NavigationDrawerItemDefaults.colors(),
+                )
+            }
+        }
+    }
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/settings/SettingsPaneHost.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/settings/SettingsPaneHost.kt
@@ -1,0 +1,224 @@
+@file:OptIn(ExperimentalUuidApi::class)
+
+package id.homebase.core.ui.screens.settings
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.VerticalDivider
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import id.homebase.core.ui.theme.Dimens
+import id.homebase.core.ui.screens.appearance.AppearanceSettingsScreen
+import id.homebase.core.ui.screens.contactbook.settings.ContactBookSettingsScreen
+import id.homebase.core.ui.screens.email.settings.EmailSettingsScreen
+import id.homebase.core.ui.screens.help.HelpScreen
+import id.homebase.core.ui.screens.moments.MomentsSettingsScreen
+import id.homebase.core.ui.screens.notifications.NotificationSettingsScreen
+import id.homebase.core.ui.screens.profile.ProfileAvatarEditScreen
+import id.homebase.core.ui.screens.profile.ProfileEditScreen
+import id.homebase.core.ui.screens.storage.StorageSettingsScreen
+import id.homebase.core.ui.screens.vault.settings.VaultSettingsScreen
+import id.homebase.core.widget.ProvideSettingsChrome
+import id.homebase.resources.MR
+import id.homebase.resources.close
+import id.homebase.resources.settings
+import org.jetbrains.compose.resources.stringResource
+import org.koin.compose.viewmodel.koinViewModel
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+internal data class SettingsPaneActions(
+    val onOpenWebDrop: () -> Unit,
+    val onLocation: () -> Unit,
+    val onOpenMoments: () -> Unit,
+    val onOpenVault: () -> Unit,
+    val onOpenEmail: () -> Unit,
+    val onOpenContacts: () -> Unit,
+    val onNavigateToCropper: (Uuid) -> Unit,
+    val onNavigateToDeveloperMenu: () -> Unit,
+    val onNavigateToDefragmenter: () -> Unit,
+)
+
+private enum class ProfilePage { Edit, Avatar }
+
+@Composable
+internal fun SettingsPaneHost(
+    showDeveloperMenu: Boolean,
+    onDismiss: () -> Unit,
+    actions: SettingsPaneActions,
+) {
+    // Plain remember, not rememberSaveable: the pane exists only on desktop/web, which have no
+    // configuration change or process death to restore across.
+    var category by remember { mutableStateOf(SettingsCategory.General) }
+    var profilePage by remember { mutableStateOf<ProfilePage?>(null) }
+
+    Column(modifier = Modifier.fillMaxSize()) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(
+                    start = Dimens.Spacing.gutter,
+                    end = Dimens.Spacing.item,
+                    top = Dimens.Spacing.item,
+                    bottom = Dimens.Spacing.item,
+                ),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = stringResource(MR.string.settings),
+                style = MaterialTheme.typography.titleLarge,
+                modifier = Modifier.weight(1f),
+            )
+            IconButton(onClick = onDismiss) {
+                Icon(
+                    imageVector = Icons.Default.Close,
+                    contentDescription = stringResource(MR.string.close),
+                )
+            }
+        }
+        HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+
+        Row(modifier = Modifier.fillMaxWidth().weight(1f)) {
+            SettingsSidebar(
+                selected = category,
+                showEmail = showDeveloperMenu,
+                onSelect = {
+                    category = it
+                    profilePage = null
+                },
+            )
+            VerticalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+            Box(modifier = Modifier.weight(1f).fillMaxHeight()) {
+                val profile = profilePage
+                if (profile == null) {
+                    ProvideSettingsChrome(embedded = true) {
+                        CategoryPage(
+                            category = category,
+                            showDeveloperMenu = showDeveloperMenu,
+                            onDismiss = onDismiss,
+                            onSelectCategory = { category = it },
+                            onProfileEdit = { profilePage = ProfilePage.Edit },
+                            onProfileAvatarEdit = { profilePage = ProfilePage.Avatar },
+                            actions = actions,
+                        )
+                    }
+                } else {
+                    // The profile pages are a drill-down inside the detail column, so their own
+                    // back arrow is correct here and returns to the category rather than closing.
+                    ProvideSettingsChrome(embedded = false) {
+                        when (profile) {
+                            ProfilePage.Edit -> ProfileEditScreen(
+                                viewModel = koinViewModel(),
+                                avatarViewModel = koinViewModel(),
+                                onBack = { profilePage = null },
+                                onNavigateToCropper = actions.onNavigateToCropper,
+                            )
+
+                            ProfilePage.Avatar -> ProfileAvatarEditScreen(
+                                viewModel = koinViewModel(),
+                                onBack = { profilePage = null },
+                                onNavigateToCropper = actions.onNavigateToCropper,
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun CategoryPage(
+    category: SettingsCategory,
+    showDeveloperMenu: Boolean,
+    onDismiss: () -> Unit,
+    onSelectCategory: (SettingsCategory) -> Unit,
+    onProfileEdit: () -> Unit,
+    onProfileAvatarEdit: () -> Unit,
+    actions: SettingsPaneActions,
+) {
+    when (category) {
+        SettingsCategory.General -> SettingsScreen(
+            viewModel = koinViewModel(),
+            showDeveloperMenu = showDeveloperMenu,
+            actions = SettingsActions(
+                onBack = onDismiss,
+                onNotifications = { onSelectCategory(SettingsCategory.Notifications) },
+                onAppearance = { onSelectCategory(SettingsCategory.Appearance) },
+                onStorage = { onSelectCategory(SettingsCategory.Storage) },
+                onHelp = { onSelectCategory(SettingsCategory.Help) },
+                onMomentsSettings = { onSelectCategory(SettingsCategory.Moments) },
+                onVaultSettings = { onSelectCategory(SettingsCategory.Vault) },
+                onEmailSettings = { onSelectCategory(SettingsCategory.Email) },
+                onOpenWebDrop = actions.onOpenWebDrop,
+                onLocation = actions.onLocation,
+                onContactBookSettings = { onSelectCategory(SettingsCategory.Contacts) },
+                onProfileEdit = onProfileEdit,
+                onProfileAvatarEdit = onProfileAvatarEdit,
+            ),
+        )
+
+        SettingsCategory.Notifications -> NotificationSettingsScreen(
+            viewModel = koinViewModel(),
+            onBackClick = onDismiss,
+        )
+
+        SettingsCategory.Appearance -> AppearanceSettingsScreen(
+            viewModel = koinViewModel(),
+            onBackClick = onDismiss,
+        )
+
+        SettingsCategory.Moments -> MomentsSettingsScreen(
+            viewModel = koinViewModel(),
+            onBackClick = onDismiss,
+            onOpenMoments = actions.onOpenMoments,
+        )
+
+        SettingsCategory.Vault -> VaultSettingsScreen(
+            viewModel = koinViewModel(),
+            onBackClick = onDismiss,
+            onOpenVault = actions.onOpenVault,
+        )
+
+        SettingsCategory.Email -> EmailSettingsScreen(
+            viewModel = koinViewModel(),
+            onBackClick = onDismiss,
+            onOpenEmail = actions.onOpenEmail,
+        )
+
+        SettingsCategory.Contacts -> ContactBookSettingsScreen(
+            viewModel = koinViewModel(),
+            onBackClick = onDismiss,
+            onOpenContacts = actions.onOpenContacts,
+        )
+
+        SettingsCategory.Storage -> StorageSettingsScreen(
+            viewModel = koinViewModel(),
+            onBackClick = onDismiss,
+            onNavigateToDefragmenter = actions.onNavigateToDefragmenter,
+        )
+
+        SettingsCategory.Help -> HelpScreen(
+            viewModel = koinViewModel(),
+            onBackClick = onDismiss,
+            onNavigateToDeveloperMenu = actions.onNavigateToDeveloperMenu,
+        )
+    }
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/settings/SettingsScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/settings/SettingsScreen.kt
@@ -20,7 +20,6 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.ui.backhandler.BackHandler
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.automirrored.outlined.HelpOutline
 import androidx.compose.material.icons.automirrored.outlined.Logout
@@ -81,6 +80,7 @@ import id.homebase.core.widget.DialogTitle
 import id.homebase.core.widget.SettingsRow
 import id.homebase.core.widget.SettingsRowAction
 import id.homebase.core.widget.SettingsSectionHeader
+import id.homebase.core.widget.SettingsTopBar
 import id.homebase.resources.MR
 import id.homebase.resources.webdrop_home_subtitle
 import id.homebase.resources.webdrop_label
@@ -90,7 +90,6 @@ import id.homebase.resources.cancel
 import id.homebase.resources.cd_profile_avatar_change_photo
 import id.homebase.resources.contactbook_settings_section
 import id.homebase.resources.location_settings_section
-import id.homebase.resources.menu_back
 import id.homebase.resources.moments_settings_section
 import id.homebase.resources.settings
 import id.homebase.resources.settings_appearance
@@ -258,24 +257,11 @@ fun SettingsUi(
     Scaffold(
         modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
         topBar = {
-            TopAppBar(
-                title = {
-                    Text(
-                        stringResource(MR.string.settings),
-                        modifier = Modifier.testTag("settingsTitle")
-                    )
-                },
-                navigationIcon = {
-                    IconButton(
-                        onClick = actions.onBack,
-                        modifier = Modifier.testTag("settingsBackButton"),
-                    ) {
-                        Icon(
-                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = stringResource(MR.string.menu_back)
-                        )
-                    }
-                },
+            SettingsTopBar(
+                title = stringResource(MR.string.settings),
+                titleModifier = Modifier.testTag("settingsTitle"),
+                navigationIconModifier = Modifier.testTag("settingsBackButton"),
+                onBack = actions.onBack,
                 scrollBehavior = scrollBehavior,
             )
         }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/storage/StorageSettingsScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/storage/StorageSettingsScreen.kt
@@ -19,7 +19,6 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
@@ -51,11 +50,11 @@ import id.homebase.core.diagnostics.DiagnosticsCrashTrigger
 import id.homebase.core.diagnostics.NoOpDiagnosticsCrashTrigger
 import id.homebase.core.widget.SettingsOptionRow
 import id.homebase.core.widget.SettingsSectionHeader
+import id.homebase.core.widget.SettingsTopBar
 import id.homebase.resources.MR
 import id.homebase.resources.settings_media_quality_footer
 import id.homebase.resources.settings_media_quality
 import id.homebase.resources.settings_data_storage
-import id.homebase.resources.menu_back
 import id.homebase.resources.settings_storage
 import id.homebase.resources.storage_orphan_coil_body
 import id.homebase.resources.storage_orphan_coil_title
@@ -134,16 +133,9 @@ fun StorageSettingsUi(
 
     Scaffold(
         topBar = {
-            TopAppBar(
-                title = { Text(stringResource(MR.string.settings_data_storage)) },
-                navigationIcon = {
-                    IconButton(onClick = onBackClick) {
-                        Icon(
-                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = stringResource(MR.string.menu_back)
-                        )
-                    }
-                },
+            SettingsTopBar(
+                title = stringResource(MR.string.settings_data_storage),
+                onBack = onBackClick,
             )
         },
         snackbarHost = { SnackbarHost(snackbarHostState) },

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/storage/StorageSettingsScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/storage/StorageSettingsScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
@@ -154,13 +155,16 @@ fun StorageSettingsUi(
                 modifier = Modifier.padding(horizontal = 4.dp),
             )
             Column {
-                MediaQuality.entries.forEach { quality ->
-                    SettingsOptionRow(
-                        modifier = Modifier.testTag(quality.code),
-                        label = stringResource(quality.label),
-                        selected = quality == uiState.mediaQuality,
-                        onClick = { onAction(StorageSettingsUiAction.SetMediaQuality(quality)) },
-                    )
+                Column(modifier = Modifier.selectableGroup()) {
+                    MediaQuality.entries.forEach { quality ->
+                        SettingsOptionRow(
+                            modifier = Modifier.testTag(quality.code),
+                            label = stringResource(quality.label),
+                            supportingText = stringResource(quality.description),
+                            selected = quality == uiState.mediaQuality,
+                            onClick = { onAction(StorageSettingsUiAction.SetMediaQuality(quality)) },
+                        )
+                    }
                 }
                 Text(
                     text = stringResource(MR.string.settings_media_quality_footer),

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/storage/StorageSettingsUiState.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/storage/StorageSettingsUiState.kt
@@ -3,7 +3,9 @@ package id.homebase.core.ui.screens.storage
 import id.homebase.api.image.MediaQuality
 import id.homebase.resources.MR
 import id.homebase.resources.settings_media_quality_high
+import id.homebase.resources.settings_media_quality_high_description
 import id.homebase.resources.settings_media_quality_standard
+import id.homebase.resources.settings_media_quality_standard_description
 import org.jetbrains.compose.resources.StringResource
 import kotlin.uuid.Uuid
 
@@ -55,6 +57,12 @@ val MediaQuality.label: StringResource
     get() = when (this) {
         MediaQuality.STANDARD -> MR.string.settings_media_quality_standard
         MediaQuality.HIGH -> MR.string.settings_media_quality_high
+    }
+
+val MediaQuality.description: StringResource
+    get() = when (this) {
+        MediaQuality.STANDARD -> MR.string.settings_media_quality_standard_description
+        MediaQuality.HIGH -> MR.string.settings_media_quality_high_description
     }
 
 sealed interface StorageSettingsUiEvent {

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/settings/VaultSettingsScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/vault/settings/VaultSettingsScreen.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.outlined.Fingerprint
 import androidx.compose.material.icons.outlined.Lock
 import androidx.compose.material.icons.outlined.Visibility
@@ -27,8 +26,8 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import id.homebase.core.widget.SettingsRow
 import id.homebase.core.widget.SettingsRowAction
+import id.homebase.core.widget.SettingsTopBar
 import id.homebase.resources.MR
-import id.homebase.resources.menu_back
 import id.homebase.resources.vault_settings_biometrics
 import id.homebase.resources.vault_settings_open
 import id.homebase.resources.vault_settings_section
@@ -65,16 +64,9 @@ fun VaultSettingsUi(
     val scrollState = rememberScrollState()
     Scaffold(
         topBar = {
-            TopAppBar(
-                title = { Text(stringResource(MR.string.vault_settings_section)) },
-                navigationIcon = {
-                    IconButton(onClick = onBackClick) {
-                        Icon(
-                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = stringResource(MR.string.menu_back),
-                        )
-                    }
-                },
+            SettingsTopBar(
+                title = stringResource(MR.string.vault_settings_section),
+                onBack = onBackClick,
             )
         },
     ) { innerPadding ->


### PR DESCRIPTION
Three changes, all in the desktop settings surface. The pane is the feature; the other two are M3 defects it put side by side with the nav rail and so made visible.

1. **Settings opens as a floating pane** on desktop/web instead of a full-screen route takeover.
2. **The pane's sidebar now matches the nav rail** — it was a capsule in `secondaryContainer`, next to the rail's rounded rect in `primaryContainer`.
3. **Settings single-choice groups get a real radio control**, fixing a ragged left edge and a double selection signal on Media quality.

---

# 1. Settings as a floating pane

Settings opened as a full-screen route takeover on every surface. That is the mobile idiom; on a wide desktop or web window it throws away the whole app to show a preferences list.

## The mechanism is a dialog *destination*, not a Dialog inside a destination

`Route.Settings` is registered as a Navigation Compose **`dialog<T>` destination** on desktop/web — not wrapped in a `Dialog` inside `composable<T>`. That distinction is the whole design. `NavHost` renders only the current destination, so a `Dialog` inside `composable<Route.Settings>` would scrim an empty screen. A dialog destination keeps the entry beneath at `STARTED`, so the conversation list stays mounted and painted behind, and back / scrim / Esc all pop the same entry.

## Two predicates, deliberately

| gate | predicate | why |
|---|---|---|
| graph shape | `isDesktopOrWeb()` | `NavHost` does `remember(route, startDestination, typeMap, builder) { createGraph(...) }` |
| presentation | `isExpandedLayout()` | plain composable state; safe to change per frame |

Width cannot gate the graph. A builder that changed identity on a width-class crossing would rebuild the graph and reset the back stack — dragging a window across 840dp would dump the user's navigation.

Below the expanded breakpoint the container collapses to full-bleed with square corners and no elevation, i.e. today's takeover. **Consequence worth stating: an Android/iOS tablet at expanded width keeps the takeover.** This is desktop/web-only, not wide-only.

## Sidebar, not stacked dialogs

The pane holds a category list (General, Notifications, Appearance, Moments, Vault, Email — dev-gated as before —, Contacts, Data and storage, Help) beside the selected page: the Signal Desktop / macOS System Settings model.

This is not a style preference. An earlier attempt pushed each sub-screen as its own dialog destination, and skiko hardcodes the dialog scrim at `Color.Black` 60% with `scrimColor` unavailable from commonMain — verified by compiling it, which passes JVM and fails Android with `No parameter with name 'scrimColor' found`. Two stacked layers give 0.84 alpha and the app behind goes near-black, which is the thing this pane exists to avoid.

Selecting a category is plain composable state, never a back-stack entry, so nothing stacks and nothing leaks into the app back stack.

## Width was measured, not chosen

The widest settings page (`StorageSettingsUi` — stacked cache bar, three-column legend, four `SpaceBetween` rows) was rendered in the detail column at three pane widths:

| pane width | result |
|---|---|
| 760dp | media-quality paragraph wraps to four lines, legend crowds |
| 900dp | correct |
| 1040dp | label to value gaps stretch until rows read as disconnected |

Final: `PaneMaxWidth = 980.dp` x `PaneWidthFraction = 0.92f`, sidebar fixed at `220.dp`. The fraction guarantees a scrim margin at every window width — at an 840dp window the pane is 773dp, leaving ~34dp per side, so the outside-click target still exists.

Rendering also caught a bug review had missed: `.fillMaxWidth(0.92f).widthIn(max = ...)` renders identically at 960 and 820, because `fillMaxWidth` reports its own size upward and the inner `widthIn` is discarded — the cap was silently dead. Correct order is `widthIn(max).fillMaxWidth(fraction)`.

## Top bar consolidation

The ten settings screens each duplicated the same `TopAppBar` + `navigationIcon` + back-arrow block character-for-character. They now share `SettingsTopBar` (58 lines, `homebase-common`), which returns early when `LocalSettingsPaneEmbedded` is true — so inside the pane the per-screen bar disappears entirely and the pane header owns the title and dismissal.

One substitution per file. No signature changes, no `Scaffold` restructuring. **Net across the eleven settings screens: 50 insertions, 148 deletions.**

Variation is absorbed by parameters rather than by leaving screens out:

- `scrollBehavior` — `SettingsScreen`'s pinned behavior
- `actions` — `ProfileEditScreen`'s preview toggle
- `titleModifier` / `navigationIconModifier` — preserving the five existing bar testTags across three screens (`settingsTitle`, `settingsBackButton`, `helpTitle`, `helpBackButton`, `notificationsTitle`)

## Mobile is unchanged, and that was proven

The collapsed 480x800 settings screen was rendered before and after the eleven-file extraction and the decompressed PNG pixel data diffed: **0 differing bytes of 1,536,800.**

On Android/iOS `settingsDestination<T>` reduces to `composable<T> { content() }`, the ten sub-routes stay untouched `composable<>` destinations, and `chromeDestination` is `currentDestination` verbatim.

## App chrome fix, required by the pane

`Route.Settings` is not a top-level route, so opening it set `isOnTopLevelScreen = false` and hid the rail — which, with the conversation list now *visible* behind the pane, would reflow it 64dp the instant the pane opened.

`chromeDestination` resolves the topmost non-`FloatingWindow`, non-`NavGraph` entry from `navController.currentBackStack` (plain public API) and feeds `isTopLevelRoute` and both nav-item selections.

## Dismissal, three ways

1. The pane header's close control.
2. Scrim click via `DialogProperties(dismissOnClickOutside = true)` — which is why the size constraints sit on the `Surface` rather than a full-bleed wrapper, since the skiko dialog derives "outside" from measured content bounds.
3. Esc via an explicit `onPreviewKeyEvent`, guarded by a one-shot flag against auto-repeat double-popping.

The only other Escape handler in the app is scoped to the message composer's focused editor and cannot hold focus behind the dialog layer.

## Strings

One new resource, `settings_category_general`. Everything else reuses existing resources.

## Limitations

- **The General category duplicates the sidebar.** General renders the existing root settings list, which repeats the eight category rows now in the sidebar. It works as a table of contents but is redundant. Removing it means hiding rows *and* re-sectioning the list — the "Preferences" section empties entirely, "Device" is left holding only a version string. That is a redesign of that screen rather than a container change, so it is deliberately out of scope here.
- **Eight of the ten pages were not seen inside the pane.** They need Koin ViewModels a bare UI test cannot supply. Their bar suppression is correct by construction — all eleven share `SettingsTopBar` — but only General and Storage were verified by eye.
- **The real scrim was never composited.** `captureToImage()` on the root excludes the `ComposeSceneLayer` the dialog lives in, so the scrim was reproduced from the bytecode constant rather than captured. It is the app's existing desktop dialog scrim, shared with every `AlertDialog`.
- **Esc, focus and scrim-click are unexercised on a live build**, desktop or web. They are reasoned from library semantics and bytecode, not run.
- **wasmJs compiles only** — nothing was run there.
- Sidebar label wrapping was checked in English only. "Data and storage" already wraps to two lines at 220dp.
- Three deep-navigations still leave the pane by design, because they are genuinely other screens: Storage to Defragmenter, Help to DeveloperMenu, Profile to Crop.

---

# 2. The sidebar's selected item now matches the rail indicator

The sidebar's `NavigationDrawerItem` passed no `shape`, so it fell through to M3's default `CircleShape` — a full pill, visibly rounder than the rail's selected indicator sitting immediately to its left.

`RoundedCornerShape(14.dp)` is hoisted out of `AppNavHost.kt` (where it was `private val RailIndicatorShape`) into a new `homebase-common` `Shapes.kt` as `NavigationIndicatorShape`, read by both. **The navigation indicator's 14dp radius is now defined once.** (Two unrelated `RoundedCornerShape(14.dp)` remain, on `EventDetailDialog` and `GroodleDetailDialog` — different surfaces, not navigation indicators, and deliberately left alone.)

`RailIndicatorSize` (48dp) and `RailIconSize` (20dp) deliberately stay private in `AppNavHost.kt`. Neither is meaningful to a full-width drawer row, and 20dp is a compaction choice for a 64dp rail that would be wrong to import into a 220dp sidebar.

## The same pass found a second mismatch

`NavigationDrawerItemDefaults.colors()` defaults to `secondaryContainer` / `onSecondaryContainer`, while the rail uses `primaryContainer` / `onPrimaryContainer`. Pixel-sampled:

| theme | before | after |
|---|---|---|
| light | `#DCE5F9` | `#D2DFFB` |
| dark | `#414659` | `#464B5C` |

Now an exact match to the rail in both themes. The unselected state already agreed and was left alone.

Corner inset measured **21px → 9px**, confirming the row is now the rail's rounded rect and no longer a capsule.

---

# 3. A radio control for the settings single-choice groups

The Media quality options rendered with a ragged left edge, signalled selection twice (a primary-coloured label **and** a trailing check mark), and never explained what "Standard" or "High" actually means.

## Root cause

`SettingsOptionRow`'s `leadingContent` was an empty `Spacer(24.dp)`. Its only purpose was indenting a **nested** option under a `SettingsRow(SettingsRowAction.Expand)` parent — and Storage used the row standalone, with no parent, orphaning the indent.

A per-call-site audit found **3 of the 4 call sites are genuinely nested** (Appearance languages at `:124`, Appearance themes at `:149`, Notifications content levels at `:234`), so simply removing the indent would have broken them. The indent was never the bug — the *empty* indent was.

## Fix

Replacing the `Spacer(24.dp)` with a real `RadioButton(selected, onClick = null)` fills exactly that slot: M3 renders a 20dp icon plus 2dp padding = 24dp, and `minimumInteractiveComponentSize` is skipped when `onClick == null`. Nested alignment is therefore pixel-identical, while Storage's orphaned gap now holds a control. One change, correct at all four sites.

Also:

- Dropped the trailing `Icons.Filled.Check` and the `headlineColor = primary` override, so selection is expressed **once**, by the control. This makes the pre-existing `role = Role.RadioButton` honest instead of contradicting the pixels.
- Added an optional `supportingText` and per-option descriptions.
- Split the overloaded `settings_media_quality_footer`: its two per-option clauses moved onto the options, and the footer keeps only the genuinely shared sentence. `values-da` has no `media_quality` keys, so there is no translation drift.
- Added `selectableGroup()` to all four groups so the choice announces as a radio group.

## Why not `SingleChoiceSegmentedButtonRow`

- Segments have no `supportingContent` slot — and the meaninglessness of a bare "Standard" / "High" was the actual complaint.
- Language has far too many entries to ever be segmented, so Storage would have become the only differing "pick one" idiom in settings.
- Segments degrade past ~5 options.

A third `MediaQuality` value just adds a row, and `MediaQuality.description` being an exhaustive `when` means it fails to compile until it supplies a description, rather than rendering blank.

## Tests

`SettingsOptionRowTest` keeps all three original tests (one renamed off the now-gone check mark) and adds `announcesTheRadioButtonRole` and `rendersSupportingTextWhenGiven` — **5 total, nothing deleted.**

---

## Rebase note

The pane was authored against `6af12b9b4`, before #1434 and #1435 merged, and reconstructed onto `origin/main` as a three-way merge. The branch is now rebased onto `3fbf7d527` (#1436). Three things came out of that and are folded in here:

- `Dimens.Spacing` did not exist in the authoring base. `SettingsPaneHost.kt` and `SettingsPaneCategory.kt` use `Dimens.Spacing.gutter` / `Dimens.Spacing.item` instead of raw `16.dp` / `8.dp`. The geometry caps (220dp sidebar, 980dp/800dp pane maxima, and the fractions) stay literals — they are not spacing.
- `AppNavHost.kt` is the only file both sides touched. #1435's rail Archive/Settings group and its private `RailActionItem` sit right beside the `isSelected` lines this change rewrites to `chromeDestination`; both survive.
- **#1435's `RailActionItem` referenced `RailIndicatorShape`**, which change 2 deletes. The text merge is clean — git does not flag it — but it would leave a dangling symbol, so `RailActionItem` is repointed to `NavigationIndicatorShape` as part of this branch. `grep -rn "RailIndicatorShape"` across the repo returns zero hits.

## Follow-ups, not changed here

#1435's rail Settings action calls `navController.navigate(Route.Settings)` without `launchSingleTop`. Not currently reachable as a bug — while the pane is open the scrim intercepts the click — but `launchSingleTop = true` there is cheap insurance against a second pane layer. The tray / cmd-, path is already safe (`App.kt:76` wraps that navigator with it).

Two more, both surfaced by change 3 and both deliberately out of scope:

- **`SettingsSectionHeader`'s blue `primary` colour is off-spec** for M3 list subheaders, which should use `onSurfaceVariant`. It is app-wide, so restyling it is its own change.
- **Media quality is the only group on that screen without a `Card`.** Giving it one would need a container-colour parameter on the shared component for a single call site.

## Verification

Re-run on the rebased base, `origin/main` (`3fbf7d527`):

```
./gradlew :homebase-common:compileKotlinJvm :homebase-chat:compileKotlinJvm :homebase-core:compileKotlinJvm
./gradlew :homebase-common:jvmTest --tests '*ArchitectureTest*' --tests '*SettingsOptionRow*' --rerun
./gradlew :homebase-chat:jvmTest --rerun
```

Plus, from the original pane work: `:homebase-core:compileAndroidMain`, `:compileKotlinWasmJs` and `:compileKotlinIosSimulatorArm64` all BUILD SUCCESSFUL, and the collapsed 480x800 mobile settings screen rendered before/after the eleven-file `SettingsTopBar` extraction with **0 differing bytes of 1,536,800**.
