### PR TITLE
Show archived chats as a mode of the list pane, restoring the pane divider

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/archivedconversations/ArchivedConversationsScreen.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/archivedconversations/ArchivedConversationsScreen.kt
@@ -103,7 +103,6 @@ fun ArchivedConversationsScreen(
 fun ArchivedConversationsUi(
     snackbarHostState: SnackbarHostState,
     uiState: ArchivedConversationsUiState,
-    selectedConversationId: Uuid? = null,
     onUiAction: (ArchivedConversationsUiAction) -> Unit,
 ) {
     val listState = rememberLazyListState()
@@ -166,7 +165,7 @@ fun ArchivedConversationsUi(
                                         onArchiveClick = {
                                             onUiAction(ArchivedConversationsUiAction.UnarchiveConversation(conversation.conversation.id))
                                         },
-                                        isSelected = selectedConversationId == conversation.conversation.id,
+                                        isSelected = false,
                                     )
                                 }
                             }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListScreen.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListScreen.kt
@@ -58,8 +58,6 @@ import androidx.compose.ui.window.Dialog
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import co.touchlab.kermit.Logger
 import com.mohamedrejeb.richeditor.model.RichTextState
-import id.homebase.chat.archivedconversations.ArchivedConversationsUi
-import id.homebase.chat.archivedconversations.ArchivedConversationsUiAction
 import id.homebase.chat.archivedconversations.ArchivedConversationsUiState
 import id.homebase.chat.archivedconversations.ArchivedConversationsViewModel
 import id.homebase.chat.contactcard.ContactCardDescriptor
@@ -882,61 +880,23 @@ fun ConversationListUi(
             scaffoldState = scaffoldNavigator.scaffoldState,
             listPane = {
                 AnimatedPane(modifier = Modifier) {
-                    if (uiState.showArchived) {
-                        ArchivedConversationsUi(
-                            snackbarHostState = snackbarHostState,
-                            uiState = archivedConversationsUiState,
-                            selectedConversationId = uiState.selectedConversationId,
-                            onUiAction = { action ->
-                                when (action) {
-                                    is ArchivedConversationsUiAction.BackClicked -> {
-                                        onUiAction(ConversationListUiAction.ArchiveBackClicked)
-                                    }
-                                    is ArchivedConversationsUiAction.ShowConversation -> {
-                                        onUiAction(ConversationListUiAction.ConversationClicked(action.conversationId, null))
-                                        Logger.i(tag = "ConversationListUi") { "Navigating to detail for ${action.conversationId} from archived" }
-                                        scope.launch {
-                                            scaffoldNavigator.navigateTo(
-                                                ListDetailPaneScaffoldRole.Detail,
-                                                action.conversationId
-                                            )
-                                        }
-                                    }
-                                    is ArchivedConversationsUiAction.ShowConversationSettings -> {
-                                        onUiAction(ConversationListUiAction.ShowConversationSettings(action.conversation))
-                                    }
-                                    is ArchivedConversationsUiAction.UnarchiveConversation -> {
-                                        onUiAction(ConversationListUiAction.UnarchiveConversation(action.conversationId))
-                                    }
-                                    is ArchivedConversationsUiAction.ArchiveConversation -> {
-                                        onUiAction(
-                                            ConversationListUiAction.ArchiveConversation(
-                                                conversationId = action.conversationId,
-                                                isUndo = true,
-                                            )
-                                        )
-                                    }
-                                }
-                            },
-                        )
-                    } else {
-                        ConversationListPane(
-                            uiState = uiState,
-                            selectedConversationId = scaffoldNavigator.currentDestination?.contentKey,
-                            searchTextState = conversationSearchTextFieldState,
-                            onProfileClick = onNavigateToSettingsScreen,
-                            onUiAction = onUiAction,
-                            onConversationSelected = {
-                                Logger.i(tag = "ConversationListUi") { "Navigating to detail for $it" }
-                                scope.launch {
-                                    scaffoldNavigator.navigateTo(
-                                        ListDetailPaneScaffoldRole.Detail,
-                                        it
-                                    )
-                                }
+                    ConversationListPane(
+                        uiState = uiState,
+                        selectedConversationId = scaffoldNavigator.currentDestination?.contentKey,
+                        searchTextState = conversationSearchTextFieldState,
+                        archivedUiState = archivedConversationsUiState,
+                        onProfileClick = onNavigateToSettingsScreen,
+                        onUiAction = onUiAction,
+                        onConversationSelected = {
+                            Logger.i(tag = "ConversationListUi") { "Navigating to detail for $it" }
+                            scope.launch {
+                                scaffoldNavigator.navigateTo(
+                                    ListDetailPaneScaffoldRole.Detail,
+                                    it
+                                )
                             }
-                        )
-                    }
+                        }
+                    )
                 }
             },
             detailPane = {

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationListPane.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationListPane.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.text.TextAutoSize
@@ -73,6 +74,7 @@ import androidx.compose.ui.unit.sp
 import id.homebase.api.client.auth.initials
 import id.homebase.chat.conversationlist.ConversationListContentModel
 import id.homebase.chat.conversationlist.ConversationListContentState
+import id.homebase.chat.archivedconversations.ArchivedConversationsUiState
 import id.homebase.chat.conversationlist.ConversationListUiAction
 import id.homebase.chat.conversationlist.ConversationListUiState
 import id.homebase.chat.data.ConversationState
@@ -85,6 +87,7 @@ import id.homebase.core.widget.MinimalSearchTextField
 import id.homebase.resources.MR
 import id.homebase.resources.app_name
 import id.homebase.resources.chat_archived_chats
+import id.homebase.resources.chat_archived_chats_empty
 import id.homebase.resources.chat_filter_by_unread_clear_button
 import id.homebase.resources.chat_filter_by_unread_description
 import id.homebase.resources.chat_new_conversation
@@ -105,6 +108,7 @@ fun ConversationListPane(
     uiState: ConversationListUiState,
     selectedConversationId: Uuid? = null,
     searchTextState: TextFieldState,
+    archivedUiState: ArchivedConversationsUiState = ArchivedConversationsUiState(),
     onProfileClick: () -> Unit,
     onUiAction: (ConversationListUiAction) -> Unit,
     onConversationSelected: (conversationId: Uuid) -> Unit,
@@ -371,7 +375,7 @@ fun ConversationListPane(
                 }
             },
             floatingActionButton = {
-                if (!iconOnlyMode && !twoPaneWindow) {
+                if (!iconOnlyMode && !twoPaneWindow && !uiState.showArchived) {
                     FloatingActionButton(
                         onClick = {
                             onUiAction(ConversationListUiAction.NewConversationClicked)
@@ -391,6 +395,16 @@ fun ConversationListPane(
                         .consumeWindowInsets(innerPadding),
                     state = listState,
                 ) {
+                    if (uiState.showArchived) {
+                        archivedConversationItems(
+                            archivedUiState = archivedUiState,
+                            selectedConversationId = selectedConversationId,
+                            iconOnlyMode = iconOnlyMode,
+                            onUiAction = onUiAction,
+                            onConversationSelected = onConversationSelected,
+                        )
+                        return@LazyColumn
+                    }
                     if (uiState.filterByUnread) {
                         item {
                             Row(
@@ -569,6 +583,56 @@ fun ConversationListPane(
                     state = listState
                 )
             }
+        }
+    }
+}
+
+private fun LazyListScope.archivedConversationItems(
+    archivedUiState: ArchivedConversationsUiState,
+    selectedConversationId: Uuid?,
+    iconOnlyMode: Boolean,
+    onUiAction: (ConversationListUiAction) -> Unit,
+    onConversationSelected: (conversationId: Uuid) -> Unit,
+) {
+    if (archivedUiState.isLoading) {
+        item {
+            Column(
+                modifier = Modifier.fillMaxWidth().padding(top = 24.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                CircularProgressIndicator()
+            }
+        }
+        return
+    }
+    if (archivedUiState.conversations.isEmpty()) {
+        item {
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(top = 24.dp),
+                horizontalArrangement = Arrangement.Center,
+            ) {
+                Text(
+                    text = stringResource(MR.string.chat_archived_chats_empty),
+                    modifier = Modifier.padding(24.dp),
+                )
+            }
+        }
+        return
+    }
+    items(
+        archivedUiState.conversations,
+        key = { it.conversation.id },
+        contentType = { "conversation" },
+    ) { conversation ->
+        Box(modifier = Modifier.animateItem()) {
+            ConversationLisContentItem(
+                listItem = ConversationListContentModel.Conversation(conversation),
+                selectedConversationId = selectedConversationId,
+                iconOnlyMode = iconOnlyMode,
+                searchQuery = "",
+                onUiAction = onUiAction,
+                onConversationSelected = onConversationSelected,
+            )
         }
     }
 }


### PR DESCRIPTION
The archived-conversations view lost the vertical hairline between the list column and the detail pane.

## Root cause

`ConversationListPane` owns that boundary. It draws it itself — a 1dp `outlineVariant` line down its own trailing edge inside `drawWithContent`, gated on `isExpandedLayout()`. (The `VerticalDivider` at `AppNavHost.kt:790` is the *rail's* divider and is unrelated.)

`ConversationListScreen.kt:885` was replacing the whole pane with `ArchivedConversationsUi` — the standalone full-screen surface written for the unused `Route.ArchivedConversations` — inside the scaffold's `listPane` slot. A full-screen surface has no pane edge, so there was nothing to draw the hairline.

Adding a divider inside `ArchivedConversationsUi` would have been a symptom patch: it would paint a second line that happens to land in the same place, leaving the real defect (a pane slot filled with something that isn't a pane) in place to lose the next piece of pane chrome.

## Fix

Archived becomes a **mode** of the list pane rather than a replacement for it, so no pane chrome can be lost.

- `ConversationListPane` gains an `archivedUiState` parameter (defaulted, for the existing preview); its LazyColumn branches to a private `archivedConversationItems(...)` when `showArchived`.
- The new-conversation FAB is suppressed in archived mode.
- Archived rows go through the same `ConversationLisContentItem` as normal rows, which already dispatches `UnarchiveConversation` when `conversationState == Archived` — so unarchive and its undo snackbar are unchanged.
- `ConversationListScreen` drops the swap and its whole action-remapping block (−49 lines).
- `ArchivedConversationsScreen` loses a now-dead `selectedConversationId` parameter.

### This also makes dead code live

`ConversationListPane.kt:169` was unreachable — a half-built archived mode of the pane (an "Archived conversations" top bar with a back arrow, and no list body) whose only call site sat in the `else` of that same `if (uiState.showArchived)`. The condition was therefore always false when the pane composed. The fix completes it and makes it live.

## Regression dating

| commit | date | what it did |
|---|---|---|
| `4348a2b1a` | 2026-04-16 | introduced the pane swap |
| `98cef5aa6` (#1363) | 2026-08-26 | moved the hairline *inside* `ConversationListPane` — the moment the archived view began losing it |
| `967f4ab4c` (#1435) | 2026-09-01 | only added a reliable entry point |

Before #1435, archived was reachable only via a button that renders when `archivedCount > 0`, which is why this went unnoticed for a week.

## The missing navigation rail is NOT fixed by this

The rail missing from the reported screenshot was never in this code path.

`railVisible = showNavigationRail && isAuthenticated && isOnTopLevelScreen` has no dependency on `showArchived`. The route never changes when archived opens, and at expanded width `showingOnlyDetail` is necessarily false. Renders showed the rail intact **even in the broken state**, with the archived back arrow at x≈92 rather than flush at 0.

If it reproduces it needs its own investigation — most likely a stale `showingOnlyDetailPane` surviving a collapsed-width session.

## Evidence

Scanning row y=600 for a non-background pixel between x=70 and x=600, across eight renders (narrow/wide × normal/archived × light/dark):

- **wide-archived had no divider at all** before this change.
- It now has the hairline at **x=424**, with the identical `outlineVariant` value as the normal list — `(207,212,222)` light, `(62,65,74)` dark. That is the existing hairline, not a new one.

SHA-256 over the eight renders: only `wide-archived-light` and `wide-archived-dark` changed. `narrow-normal`, `narrow-archived` and `wide-normal` are byte-identical in both themes, so the phone / collapsed layout is provably untouched.

## Note on spacing literals

This was authored at `6af12b9b4`, where `Dimens.Spacing` does not exist; it arrives in `578531a21`. Two new padding values are therefore raw `24.dp`, matching their sibling content states in the same file. 24dp is not one of the scale steps (4/8/12/16), so those literals are deliberately left alone rather than given an invented token.

## Verification

Run on `origin/main` (`3fbf7d527`):

```
:homebase-common:compileKotlinJvm :homebase-chat:compileKotlinJvm :homebase-core:compileKotlinJvm
:homebase-common:jvmTest --tests '*ArchitectureTest*' --tests '*SettingsOptionRow*' --rerun
:homebase-chat:jvmTest --rerun
```
