### PR TITLE
Show a persistent search field under the list bar on desktop and web

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListScreen.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListScreen.kt
@@ -52,6 +52,14 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.backhandler.BackHandler
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.isCtrlPressed
+import androidx.compose.ui.input.key.isMetaPressed
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
@@ -793,6 +801,7 @@ fun ConversationListUi(
     var scaffoldLeft by remember { mutableFloatStateOf(0f) }
     var scaffoldWidth by remember { mutableFloatStateOf(0f) }
     var splitterCenter by remember { mutableFloatStateOf(0f) }
+    val conversationSearchFocusRequester = remember { FocusRequester() }
 
     // closeDetailPaneRequest handler — has to live inside ConversationListUi (not
     // the outer screen) because scaffoldNavigator + backNavigationBehavior are in
@@ -875,6 +884,18 @@ fun ConversationListUi(
             modifier = Modifier.fillMaxSize().onGloballyPositioned {
                 scaffoldLeft = it.positionInRoot().x
                 scaffoldWidth = it.size.width.toFloat()
+            }.onPreviewKeyEvent { keyEvent ->
+                if (isDesktopOrWeb() &&
+                    keyEvent.type == KeyEventType.KeyDown &&
+                    keyEvent.key == Key.F &&
+                    (keyEvent.isCtrlPressed || keyEvent.isMetaPressed)
+                ) {
+                    // The field is absent in the archived and icon-only list modes.
+                    runCatching { conversationSearchFocusRequester.requestFocus() }
+                    true
+                } else {
+                    false
+                }
             },
             directive = scaffoldNavigator.scaffoldDirective,
             scaffoldState = scaffoldNavigator.scaffoldState,
@@ -884,6 +905,7 @@ fun ConversationListUi(
                         uiState = uiState,
                         selectedConversationId = scaffoldNavigator.currentDestination?.contentKey,
                         searchTextState = conversationSearchTextFieldState,
+                        searchFocusRequester = conversationSearchFocusRequester,
                         archivedUiState = archivedConversationsUiState,
                         onProfileClick = onNavigateToSettingsScreen,
                         onUiAction = onUiAction,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationListPane.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationListPane.kt
@@ -81,6 +81,8 @@ import id.homebase.chat.data.ConversationState
 import id.homebase.core.avatars.AvatarOptions
 import id.homebase.core.avatars.OwnerAvatar
 import id.homebase.core.ui.assets.FeatherEdit
+import id.homebase.core.ui.theme.Dimens
+import id.homebase.core.util.isDesktopOrWeb
 import id.homebase.core.util.isExpandedLayout
 import id.homebase.core.widget.HomebaseVerticalScrollbar
 import id.homebase.core.widget.MinimalSearchTextField
@@ -114,6 +116,9 @@ fun ConversationListPane(
     onConversationSelected: (conversationId: Uuid) -> Unit,
 ) {
     val twoPaneWindow = isExpandedLayout()
+    val persistentSearch = isDesktopOrWeb() && !uiState.showArchived
+    val searchTyping by remember(searchTextState) { derivedStateOf { searchTextState.text.isNotEmpty() } }
+    val searchActive = uiState.isSearchActive || (persistentSearch && searchTyping)
     val paneContainerColor = MaterialTheme.colorScheme.surfaceContainerLowest
     val paneEdgeColor = MaterialTheme.colorScheme.outlineVariant
     val topBarState = rememberTopAppBarState()
@@ -191,170 +196,189 @@ fun ConversationListPane(
                         ),
                     )
                 } else if (!iconOnlyMode) {
-                    TopAppBar(title = {
-                        Box(modifier = Modifier.fillMaxWidth()) {
-                            // Title row - keep it in place but fade out
-                            Row(
-                                verticalAlignment = Alignment.CenterVertically,
-                                modifier = Modifier.fillMaxWidth()
-                            ) {
-                                AnimatedVisibility(
-                                    visible = !uiState.isSearchActive,
-                                    enter = fadeIn(animationSpec = tween(300, delayMillis = 200)),
-                                    exit = fadeOut(animationSpec = tween(150))
+                    Column(modifier = barUnderline) {
+                        TopAppBar(title = {
+                            Box(modifier = Modifier.fillMaxWidth()) {
+                                // Title row - keep it in place but fade out
+                                Row(
+                                    verticalAlignment = Alignment.CenterVertically,
+                                    modifier = Modifier.fillMaxWidth()
                                 ) {
-                                    Row(
-                                        verticalAlignment = Alignment.CenterVertically
+                                    AnimatedVisibility(
+                                        visible = !uiState.isSearchActive,
+                                        enter = fadeIn(animationSpec = tween(300, delayMillis = 200)),
+                                        exit = fadeOut(animationSpec = tween(150))
                                     ) {
-                                        uiState.ownerSession?.let { session ->
-                                            OwnerAvatar(
-                                                odinId = session.odinId,
-                                                profileImageData = null,
-                                                initials = session.initials(),
-                                                connectionStatus = uiState.connectionStatus,
-                                                driveIsSyncing = uiState.driveIsSyncing,
-                                                hasDriveError = uiState.hasDriveError,
-                                                options = AvatarOptions(
-                                                    size = 32.dp, fontSize = 12.sp, onClick = {
-                                                        onProfileClick()
-                                                    }),
-                                                animatedVisibilityScope = this@AnimatedVisibility,
-                                                sharedTransitionScope = null,
-                                                cacheBustKey = session.profileImageLastModified,
+                                        Row(
+                                            verticalAlignment = Alignment.CenterVertically
+                                        ) {
+                                            uiState.ownerSession?.let { session ->
+                                                OwnerAvatar(
+                                                    odinId = session.odinId,
+                                                    profileImageData = null,
+                                                    initials = session.initials(),
+                                                    connectionStatus = uiState.connectionStatus,
+                                                    driveIsSyncing = uiState.driveIsSyncing,
+                                                    hasDriveError = uiState.hasDriveError,
+                                                    options = AvatarOptions(
+                                                        size = 32.dp, fontSize = 12.sp, onClick = {
+                                                            onProfileClick()
+                                                        }),
+                                                    animatedVisibilityScope = this@AnimatedVisibility,
+                                                    sharedTransitionScope = null,
+                                                    cacheBustKey = session.profileImageLastModified,
+                                                )
+                                            }
+
+                                            Spacer(modifier = Modifier.width(16.dp))
+
+                                            Text(
+                                                text = stringResource(MR.string.app_name),
+                                                style = MaterialTheme.typography.titleLarge,
+                                                fontWeight = FontWeight.Bold,
+                                                maxLines = 1,
+                                                modifier = Modifier.weight(1f, fill = false),
+                                                autoSize = TextAutoSize.StepBased(
+                                                    minFontSize = 14.sp,
+                                                    maxFontSize = 22.sp,
+                                                )
                                             )
+                                            Spacer(modifier = Modifier.width(8.dp))
                                         }
-
-                                        Spacer(modifier = Modifier.width(16.dp))
-
-                                        Text(
-                                            text = stringResource(MR.string.app_name),
-                                            style = MaterialTheme.typography.titleLarge,
-                                            fontWeight = FontWeight.Bold,
-                                            maxLines = 1,
-                                            modifier = Modifier.weight(1f, fill = false),
-                                            autoSize = TextAutoSize.StepBased(
-                                                minFontSize = 14.sp,
-                                                maxFontSize = 22.sp,
-                                            )
-                                        )
-                                        Spacer(modifier = Modifier.width(8.dp))
                                     }
                                 }
-                            }
-                            // Search field - positioned absolutely on top
-                            AnimatedVisibility(
-                                modifier = Modifier.align(Alignment.CenterEnd).fillMaxWidth()
-                                    .padding(end = 16.dp),
-                                visible = uiState.isSearchActive,
-                                enter = fadeIn(animationSpec = tween(200)) + expandHorizontally(
-                                    animationSpec = tween(300), expandFrom = Alignment.End
-                                ),
-                                exit = fadeOut(animationSpec = tween(150)) + shrinkHorizontally(
-                                    animationSpec = tween(250), shrinkTowards = Alignment.End
-                                )
-                            ) {
-                                MinimalSearchTextField(
-                                    textFieldState = searchTextState,
-                                    modifier = Modifier.fillMaxWidth()
-                                        .focusRequester(focusRequesterSearch),
-                                    placeHolderText = stringResource(
-                                        MR.string.chat_search_placeholder
+                                // Search field - positioned absolutely on top
+                                // Qualified: the wrapping Column's overload would otherwise win
+                                // here, and @LayoutScopeMarker then rejects the outer receiver.
+                                androidx.compose.animation.AnimatedVisibility(
+                                    modifier = Modifier.align(Alignment.CenterEnd).fillMaxWidth()
+                                        .padding(end = 16.dp),
+                                    visible = uiState.isSearchActive,
+                                    enter = fadeIn(animationSpec = tween(200)) + expandHorizontally(
+                                        animationSpec = tween(300), expandFrom = Alignment.End
                                     ),
-                                    showBackButton = true,
-                                    onBackButtonClick = {
+                                    exit = fadeOut(animationSpec = tween(150)) + shrinkHorizontally(
+                                        animationSpec = tween(250), shrinkTowards = Alignment.End
+                                    )
+                                ) {
+                                    MinimalSearchTextField(
+                                        textFieldState = searchTextState,
+                                        modifier = Modifier.fillMaxWidth()
+                                            .focusRequester(focusRequesterSearch),
+                                        placeHolderText = stringResource(
+                                            MR.string.chat_search_placeholder
+                                        ),
+                                        showBackButton = true,
+                                        onBackButtonClick = {
+                                            onUiAction(
+                                                ConversationListUiAction.SearchBackClicked
+                                            )
+                                            searchTextState.clearText()
+                                        })
+                                }
+                            }
+                        }, actions = {
+                            if (twoPaneWindow) {
+                                FilledTonalIconButton(
+                                    onClick = {
                                         onUiAction(
-                                            ConversationListUiAction.SearchBackClicked
+                                            ConversationListUiAction.NewConversationClicked
                                         )
-                                        searchTextState.clearText()
-                                    })
-                            }
-                        }
-                    }, actions = {
-                        if (twoPaneWindow) {
-                            FilledTonalIconButton(
-                                onClick = {
-                                    onUiAction(
-                                        ConversationListUiAction.NewConversationClicked
-                                    )
-                                },
-                                colors = IconButtonDefaults.filledTonalIconButtonColors(
-                                    containerColor = MaterialTheme.colorScheme.primaryContainer,
-                                    contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
-                                ),
-                            ) {
-                                Icon(
-                                    imageVector = FeatherEdit,
-                                    contentDescription = stringResource(
-                                        MR.string.chat_new_conversation
+                                    },
+                                    colors = IconButtonDefaults.filledTonalIconButtonColors(
+                                        containerColor = MaterialTheme.colorScheme.primaryContainer,
+                                        contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
                                     ),
-                                    // Feather artwork runs to the edge of its 24dp viewport;
-                                    // Material glyphs keep a keyline, so match their ink, not
-                                    // their nominal size.
-                                    modifier = Modifier.size(20.dp),
-                                )
-                            }
-                        }
-                        if (!uiState.isSearchActive) {
-                            // One pin, either direction (#1012): I'm sharing with anyone OR anyone
-                            // is sharing with me. Tapping opens the live map.
-                            LiveShareIndicator(
-                                untilMs = uiState.liveSharePinAnyUntilMs,
-                                onClick = {
-                                    onUiAction(ConversationListUiAction.OpenLiveLocationMap)
-                                },
-                            )
-                            IconButton(
-                                onClick = {
-                                    onUiAction(
-                                        ConversationListUiAction.SearchClicked
-                                    )
-                                },
-                            ) {
-                                Icon(
-                                    imageVector = Icons.Default.Search,
-                                    contentDescription = stringResource(MR.string.search),
-                                )
-                            }
-                            Box {
-                                IconButton(onClick = { showMenu = true }) {
+                                ) {
                                     Icon(
-                                        imageVector = Icons.Default.MoreVert,
+                                        imageVector = FeatherEdit,
                                         contentDescription = stringResource(
-                                            MR.string.chat_options
-                                        )
+                                            MR.string.chat_new_conversation
+                                        ),
+                                        // Feather artwork runs to the edge of its 24dp viewport;
+                                        // Material glyphs keep a keyline, so match their ink, not
+                                        // their nominal size.
+                                        modifier = Modifier.size(20.dp),
                                     )
                                 }
-                                ConversationListMenu(
-                                    showMenu = showMenu,
-                                    dismissMenu = { showMenu = false },
-                                    isFilteringUnread = uiState.filterByUnread,
-                                    onMarkAllAsRead = {
-                                        // TODO
-                                        showMenu = false
-                                    },
-                                    onFilterUnread = {
-                                        onUiAction(
-                                            ConversationListUiAction.FilterByUnreadClicked
-                                        )
-                                        showMenu = false
-                                    },
-                                    onClearFilterUnread = {
-                                        onUiAction(
-                                            ConversationListUiAction.ClearFilterByUnreadClicked
-                                        )
-                                        showMenu = false
-                                    },
-                                    onSettings = {
-                                        onProfileClick()
-                                        showMenu = false
-                                    })
                             }
+                            if (!uiState.isSearchActive) {
+                                // One pin, either direction (#1012): I'm sharing with anyone OR anyone
+                                // is sharing with me. Tapping opens the live map.
+                                LiveShareIndicator(
+                                    untilMs = uiState.liveSharePinAnyUntilMs,
+                                    onClick = {
+                                        onUiAction(ConversationListUiAction.OpenLiveLocationMap)
+                                    },
+                                )
+                                if (!persistentSearch) {
+                                    IconButton(
+                                        onClick = {
+                                            onUiAction(
+                                                ConversationListUiAction.SearchClicked
+                                            )
+                                        },
+                                    ) {
+                                        Icon(
+                                            imageVector = Icons.Default.Search,
+                                            contentDescription = stringResource(MR.string.search),
+                                        )
+                                    }
+                                }
+                                Box {
+                                    IconButton(onClick = { showMenu = true }) {
+                                        Icon(
+                                            imageVector = Icons.Default.MoreVert,
+                                            contentDescription = stringResource(
+                                                MR.string.chat_options
+                                            )
+                                        )
+                                    }
+                                    ConversationListMenu(
+                                        showMenu = showMenu,
+                                        dismissMenu = { showMenu = false },
+                                        isFilteringUnread = uiState.filterByUnread,
+                                        onMarkAllAsRead = {
+                                            // TODO
+                                            showMenu = false
+                                        },
+                                        onFilterUnread = {
+                                            onUiAction(
+                                                ConversationListUiAction.FilterByUnreadClicked
+                                            )
+                                            showMenu = false
+                                        },
+                                        onClearFilterUnread = {
+                                            onUiAction(
+                                                ConversationListUiAction.ClearFilterByUnreadClicked
+                                            )
+                                            showMenu = false
+                                        },
+                                        onSettings = {
+                                            onProfileClick()
+                                            showMenu = false
+                                        })
+                                }
+                            }
+                        }, scrollBehavior = scrollBehavior,
+                            colors = TopAppBarDefaults.topAppBarColors(
+                                containerColor = paneContainerColor,
+                                scrolledContainerColor = paneContainerColor,
+                            ))
+                        if (persistentSearch) {
+                            MinimalSearchTextField(
+                                textFieldState = searchTextState,
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(
+                                        start = Dimens.Spacing.gutter,
+                                        end = Dimens.Spacing.gutter,
+                                        bottom = Dimens.Spacing.item,
+                                    ),
+                                placeHolderText = stringResource(MR.string.chat_search_placeholder),
+                            )
                         }
-                    }, modifier = barUnderline, scrollBehavior = scrollBehavior,
-                        colors = TopAppBarDefaults.topAppBarColors(
-                            containerColor = paneContainerColor,
-                            scrolledContainerColor = paneContainerColor,
-                        ))
+                    }
                 } else {
                     Column(
                         modifier = Modifier.fillMaxWidth(),
@@ -520,10 +544,10 @@ fun ConversationListPane(
                                         selectedConversationId = selectedConversationId,
                                         iconOnlyMode = iconOnlyMode,
                                         // Search results are a tap target, not a swipe target.
-                                        allowSwipeActions = !uiState.isSearchActive,
+                                        allowSwipeActions = !searchActive,
                                         // Live search text drives the highlight in
                                         // message-search rows; empty when not searching.
-                                        searchQuery = if (uiState.isSearchActive)
+                                        searchQuery = if (searchActive)
                                             searchTextState.text.toString()
                                         else "",
                                         onUiAction = onUiAction,
@@ -534,7 +558,7 @@ fun ConversationListPane(
                         }
                     }
 
-                    if (uiState.archivedCount > 0 && !uiState.isSearchActive) {
+                    if (uiState.archivedCount > 0 && !searchActive) {
                         item {
                             Row(
                                 modifier = Modifier.fillMaxWidth().padding(top = 24.dp),

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationListPane.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationListPane.kt
@@ -66,6 +66,11 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.LayoutDirection
@@ -110,6 +115,7 @@ fun ConversationListPane(
     uiState: ConversationListUiState,
     selectedConversationId: Uuid? = null,
     searchTextState: TextFieldState,
+    searchFocusRequester: FocusRequester? = null,
     archivedUiState: ArchivedConversationsUiState = ArchivedConversationsUiState(),
     onProfileClick: () -> Unit,
     onUiAction: (ConversationListUiAction) -> Unit,
@@ -374,7 +380,22 @@ fun ConversationListPane(
                                         start = Dimens.Spacing.gutter,
                                         end = Dimens.Spacing.gutter,
                                         bottom = Dimens.Spacing.item,
-                                    ),
+                                    )
+                                    .then(
+                                        searchFocusRequester?.let { Modifier.focusRequester(it) }
+                                            ?: Modifier
+                                    )
+                                    .onPreviewKeyEvent { keyEvent ->
+                                        if (keyEvent.type == KeyEventType.KeyDown &&
+                                            keyEvent.key == Key.Escape &&
+                                            searchTextState.text.isNotEmpty()
+                                        ) {
+                                            searchTextState.clearText()
+                                            true
+                                        } else {
+                                            false
+                                        }
+                                    },
                                 placeHolderText = stringResource(MR.string.chat_search_placeholder),
                             )
                         }


### PR DESCRIPTION
Search in the conversation list is currently a magnifier button that swaps the
title row for a text field. That is the right trade on a phone — the field
needs the full bar width, so something has to give — but on desktop and web the
window has width to spare, and hiding search behind a toggle costs a click on
every use.

WhatsApp Desktop and Signal Desktop both keep the field on screen permanently,
directly under the title. This does the same, on desktop and web only.

## What changed

`ConversationListPane.kt`, one file:

- The main top-bar branch is wrapped in a `Column`; a `MinimalSearchTextField`
  renders under the `TopAppBar` when `isDesktopOrWeb()`.
- The magnifier action is hidden in that same case — it would toggle a field
  that is already visible. `LiveShareIndicator` and the overflow menu stay.
- `barUnderline` moves from the `TopAppBar` to the `Column`, so the scrolled
  hairline is drawn under the whole header rather than between the bar and the
  field.
- The three content-side reads of `isSearchActive` (`allowSwipeActions`, the
  match-highlight query, the archived-row gate) now read a `searchActive` that
  is also true when the persistent field has text.

Android and iOS are untouched — `persistentSearch` is false there, so every
branch behaves exactly as before.

The archived view and the collapsed icon-only pane keep their own top bars and
get no search field.

## Why the ViewModel didn't change

`updateListContent()` already derives its results purely from
`conversationSearchTextState.text`, driven by a debounced `snapshotFlow`. The
overlay field and the persistent field write to the same `TextFieldState`, so
filtering, the empty-search state and the message-search hits all work through
the existing path. `isSearchActive` turned out to drive nothing but pane-local
chrome: the title/field animated swap, the back handler, the autofocus effect,
and the three content reads listed above. The first three are still keyed on
`uiState.isSearchActive` and stay dormant on desktop.

## Gotcha worth a look in review

Wrapping the bar in a `Column` put `ColumnScope` into lexical scope, and the
pre-existing search-overlay `AnimatedVisibility` — which had been resolving to
the receiver-less overload — silently started resolving to the `ColumnScope`
one. `@LayoutScopeMarker` then rejects that outer receiver from inside
`BoxScope`, so the file stopped compiling. It is now called as
`androidx.compose.animation.AnimatedVisibility(...)` to pin the top-level
overload, with a comment, since otherwise the qualification reads as a typo and
a future cleanup would re-break the build. Behaviour is identical: the two
overloads differ only in their default `enter`/`exit`, and both are passed
explicitly here. An import alias does not help — Kotlin aliases the name, so
every overload comes with it.

## Diff size

`+171/-147`, but `git diff -w` is `+29/-5`; the rest is the reindent the
`Column` wrap forced on the 165-line `TopAppBar` block. Review with `-w`.

## Verification

`./gradlew :homebase-chat:compileKotlinJvm` clean (only pre-existing warnings in
untouched files). Verified visually on a running desktop build.

## Keyboard

- **Escape** clears a non-empty field. It does not consume Escape on an empty
  field and never drops focus, so it stays out of the way of anything else
  listening for it.
- **Cmd/Ctrl+F** focuses the field from anywhere in the chat screen. The handler
  sits on the `ListDetailPaneScaffold` modifier, not on the list pane: preview
  key events run root-to-leaf, so it beats the message composer's own handler
  and therefore works while you are typing a message — the case that matters. A
  pane-scoped handler would only fire once focus was already in the list.

The field is absent in the archived and icon-only list modes, where
`requestFocus()` on an unattached requester would throw; that call is guarded
and the accelerator is still consumed there rather than falling through.
