### PR TITLE
Redesign the empty detail pane with a drawn halo and M3 hierarchy

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListScreen.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListScreen.kt
@@ -120,7 +120,7 @@ import id.homebase.resources.chat_leave_and_delete
 import id.homebase.resources.chat_leave_and_delete_conversation_text
 import id.homebase.resources.chat_leave_and_delete_conversation_title
 import id.homebase.resources.chat_select_a_conversation
-import id.homebase.resources.chat_select_a_conversation_subtitle
+import id.homebase.resources.chat_select_a_conversation_hint
 import id.homebase.resources.discard
 import id.homebase.resources.error_unknown
 import id.homebase.resources.file_save_failed
@@ -933,7 +933,7 @@ fun ConversationListUi(
                             title = stringResource(
                                 MR.string.chat_select_a_conversation
                             ), subtitle = stringResource(
-                                MR.string.chat_select_a_conversation_subtitle
+                                MR.string.chat_select_a_conversation_hint
                             )
                         )
                     }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/EmptyDetailPane.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/EmptyDetailPane.kt
@@ -1,20 +1,55 @@
 package id.homebase.chat.widget
 
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.Chat
+import androidx.compose.material.icons.outlined.Lock
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import id.homebase.core.ui.theme.Dimens
+import id.homebase.resources.MR
+import id.homebase.resources.chat_select_a_conversation_privacy
+import org.jetbrains.compose.resources.stringResource
+import kotlin.math.cos
+import kotlin.math.sin
+
+private const val DegToRad = 0.017453292f
 
 @Composable
 fun EmptyDetailPane(
@@ -22,30 +57,198 @@ fun EmptyDetailPane(
     title: String,
     subtitle: String,
 ) {
-    Box(
+    val scheme = MaterialTheme.colorScheme
+
+    // One-shot only: a looping animation here pins the Skiko render loop for as long as the
+    // pane is empty, which on desktop is most of the session.
+    var entered by remember { mutableStateOf(false) }
+    LaunchedEffect(Unit) { entered = true }
+    val enter by animateFloatAsState(
+        targetValue = if (entered) 1f else 0f,
+        animationSpec = tween(durationMillis = 480, easing = FastOutSlowInEasing),
+    )
+
+    BoxWithConstraints(
         modifier = modifier
             .fillMaxSize()
-            .background(MaterialTheme.colorScheme.surfaceContainerLowest)
-            .padding(24.dp),
-        contentAlignment = Alignment.Center
+            .background(scheme.surfaceContainerLowest),
+        contentAlignment = Alignment.Center,
     ) {
+        val artSide = minOf(maxWidth * 0.5f, maxHeight * 0.34f, 244.dp)
+        val showArt = artSide >= 132.dp
+        val showPrivacyNote = maxHeight >= 400.dp && maxWidth >= 320.dp
+        val textWidth = (maxWidth - Dimens.Spacing.gutter * 4).coerceIn(0.dp, 360.dp)
+
         Column(
+            modifier = Modifier.padding(horizontal = Dimens.Spacing.gutter * 2),
             horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.Center
+            verticalArrangement = Arrangement.Center,
         ) {
+            if (showArt) {
+                ConversationHalo(
+                    side = artSide,
+                    enter = enter,
+                    modifier = Modifier.padding(bottom = 28.dp),
+                )
+            }
             Text(
                 text = title,
-                style = MaterialTheme.typography.titleMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                style = MaterialTheme.typography.headlineSmall,
+                color = scheme.onSurface,
                 textAlign = TextAlign.Center,
+                modifier = Modifier.graphicsLayer { alpha = enter },
             )
-            Spacer(modifier = Modifier.height(8.dp))
+            Spacer(Modifier.height(Dimens.Spacing.row))
             Text(
                 text = subtitle,
                 style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                color = scheme.onSurfaceVariant,
                 textAlign = TextAlign.Center,
+                modifier = Modifier
+                    .widthIn(max = textWidth)
+                    .graphicsLayer { alpha = enter },
             )
+        }
+
+        if (showPrivacyNote) {
+            Row(
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .fillMaxWidth()
+                    .padding(Dimens.Spacing.gutter * 2)
+                    .graphicsLayer { alpha = enter },
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.Center,
+            ) {
+                Icon(
+                    imageVector = Icons.Outlined.Lock,
+                    contentDescription = null,
+                    tint = scheme.onSurfaceVariant.copy(alpha = 0.65f),
+                    modifier = Modifier.size(13.dp),
+                )
+                Spacer(Modifier.size(Dimens.Spacing.item))
+                Text(
+                    text = stringResource(MR.string.chat_select_a_conversation_privacy),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = scheme.onSurfaceVariant.copy(alpha = 0.65f),
+                    textAlign = TextAlign.Center,
+                )
+            }
         }
     }
 }
+
+@Composable
+private fun ConversationHalo(
+    side: Dp,
+    enter: Float,
+    modifier: Modifier = Modifier,
+) {
+    val scheme = MaterialTheme.colorScheme
+    val hue = scheme.primary
+    val hairline = scheme.outlineVariant
+    val disc = scheme.primaryContainer
+    val glyph = scheme.onPrimaryContainer
+
+    Box(
+        modifier = modifier
+            .size(side)
+            .graphicsLayer {
+                alpha = enter
+                val grow = 0.94f + 0.06f * enter
+                scaleX = grow
+                scaleY = grow
+            },
+        contentAlignment = Alignment.Center,
+    ) {
+        Canvas(Modifier.fillMaxSize()) {
+            val r = size.minDimension / 2f
+            val c = Offset(size.width / 2f, size.height / 2f)
+
+            drawGlow(c, r * 1.46f, hue, peak = 0.19f)
+            drawGlow(
+                Offset(size.width * 0.36f, size.height * 0.32f),
+                r * 0.78f,
+                hue,
+                peak = 0.17f,
+            )
+
+            drawOrbit(c, r * 1.62f, 204f, 124f, hue.copy(alpha = 0.13f), 1.dp.toPx())
+            drawOrbit(c, r * 1.26f, 188f, 162f, hue.copy(alpha = 0.22f), 1.dp.toPx())
+            drawOrbit(c, r * 1.26f, 18f, 46f, hue.copy(alpha = 0.15f), 1.dp.toPx())
+            drawOrbit(c, r * 0.97f, -128f, 196f, hue.copy(alpha = 0.52f), 1.5.dp.toPx())
+            drawOrbit(c, r * 0.97f, 104f, 46f, hairline, 1.5.dp.toPx())
+
+            drawNode(c, r * 1.26f, 350f, 3.dp.toPx(), hue.copy(alpha = 0.3f))
+            drawNode(c, r * 0.97f, -128f, 4.dp.toPx(), hue.copy(alpha = 0.78f))
+            drawNode(c, r * 0.97f, 68f, 2.5.dp.toPx(), hue.copy(alpha = 0.42f))
+
+            val medallion = r * 0.44f
+            drawCircle(disc, radius = medallion, center = c)
+            drawCircle(hue.copy(alpha = 0.2f), radius = medallion, center = c)
+            drawCircle(
+                color = hue.copy(alpha = 0.24f),
+                radius = medallion,
+                center = c,
+                style = Stroke(width = 1.dp.toPx()),
+            )
+        }
+
+        Icon(
+            imageVector = Icons.AutoMirrored.Outlined.Chat,
+            contentDescription = null,
+            tint = glyph,
+            modifier = Modifier.size(side * 0.19f),
+        )
+    }
+}
+
+private fun DrawScope.drawGlow(
+    center: Offset,
+    radius: Float,
+    hue: Color,
+    peak: Float,
+) = drawCircle(
+    brush = Brush.radialGradient(
+        0f to hue.copy(alpha = peak),
+        0.34f to hue.copy(alpha = peak * 0.42f),
+        0.68f to hue.copy(alpha = peak * 0.1f),
+        1f to hue.copy(alpha = 0f),
+        center = center,
+        radius = radius,
+    ),
+    radius = radius,
+    center = center,
+)
+
+private fun DrawScope.drawOrbit(
+    center: Offset,
+    radius: Float,
+    startAngle: Float,
+    sweepAngle: Float,
+    color: Color,
+    strokeWidth: Float,
+) = drawArc(
+    color = color,
+    startAngle = startAngle,
+    sweepAngle = sweepAngle,
+    useCenter = false,
+    topLeft = Offset(center.x - radius, center.y - radius),
+    size = Size(radius * 2f, radius * 2f),
+    style = Stroke(width = strokeWidth, cap = StrokeCap.Round),
+)
+
+private fun DrawScope.drawNode(
+    center: Offset,
+    radius: Float,
+    angle: Float,
+    dotRadius: Float,
+    color: Color,
+) = drawCircle(
+    color = color,
+    radius = dotRadius,
+    center = Offset(
+        center.x + radius * cos(angle * DegToRad),
+        center.y + radius * sin(angle * DegToRad),
+    ),
+)

--- a/homebase-common/src/commonMain/composeResources/values-da/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values-da/strings.xml
@@ -503,7 +503,6 @@
     <string name="chat_filter_by_unread_description">Filtreret på ulæste</string>
     <string name="chat_search_empty_description">Ingen ulæste samtaler</string>
     <string name="chat_select_a_conversation">Vælg en samtale</string>
-    <string name="chat_select_a_conversation_subtitle">Vælg en samtale fra listen for at se beskederne</string>
     <string name="chat_search_placeholder">Søg</string>
     <string name="chat_mark_all_as_read">Markér alle som læste</string>
     <string name="chat_pin">Fastgør</string>

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -513,7 +513,8 @@
     <string name="chat_filter_by_unread_description">Filtered by unread</string>
     <string name="chat_search_empty_description">No unread conversations</string>
     <string name="chat_select_a_conversation">Select a conversation</string>
-    <string name="chat_select_a_conversation_subtitle">Choose a conversation from the list to view messages</string>
+    <string name="chat_select_a_conversation_hint">Open one from the list, or start something new.</string>
+    <string name="chat_select_a_conversation_privacy">End-to-end encrypted, on a server you own</string>
     <string name="chat_search_placeholder">Search</string>
     <string name="chat_mark_all_as_read">Mark all as read</string>
     <string name="chat_pin">Pin</string>


### PR DESCRIPTION
The detail pane's "nothing selected" state was two lines of `onSurfaceVariant`
text on a blank ground. On desktop it is the first thing you see every launch,
and it reads as an unfinished screen rather than a resting state.

## What it is now

A concentric halo drawn entirely in `Canvas` — soft radial glows, a handful of
partial orbit arcs at varying opacity with small nodes riding them, and a
`primaryContainer` medallion holding the chat glyph. Under it a real M3
hierarchy: `headlineSmall` on `onSurface` for the headline, `bodyMedium` on
`onSurfaceVariant` for the supporting line, and a low-emphasis lock + privacy
note pinned to the bottom.

Every colour is a `colorScheme` role, so the art recolours with the theme and
with a user palette change. No image assets, no new dependencies.

## Why the entrance animation is one-shot

A looping animation here would pin the Skiko render loop for as long as the pane
is empty — which on desktop is most of the session. This is the same failure
already documented on `ListDetailPaneScaffold`'s drag handle, where M3's
self-animating `VerticalDragHandle` held ~164 fps and ~15% GPU at idle. The
entrance is a single 480 ms fade/scale that settles and stops.

## Sizing

The pane is user-resizable via the splitter, so nothing is a fixed size:

- art is `min(50% width, 34% height, 244.dp)`, and drops out entirely below
  132.dp rather than clipping
- the privacy line hides below 400.dp tall or 320.dp wide
- supporting text caps at 360.dp so the measure stays readable on a wide pane

## Copy

`chat_select_a_conversation_subtitle` is renamed to
`chat_select_a_conversation_hint` with tighter copy ("Open one from the list, or
start something new."). The stale Danish translation of the old key is removed
rather than left orphaned; the headline keeps its existing translation.

## Known soft spot

Dark mode is more muted than light. This theme's dark `primary` is a low-chroma
periwinkle (`#B6C5FA`), so alpha-scaling the same values yields a softer result
than in light. Arguably correct for the palette; making it punchier would mean
hand-picking dark alphas instead of sharing one set.

## Verification

`:homebase-chat:compileKotlinJvm` and `:homebase-common:jvmTest` (the Konsist
Composable-string check) both green. Rendered off-screen in both themes at wide,
narrow and short pane sizes and reviewed before shipping; the harness is not in
the diff.
