### PR TITLE
Carry the message id on desktop notifications so a tap lands on the message

### DIFF
--- a/homebase-core/src/jvmMain/kotlin/id/homebase/core/notifications/DesktopChatNotificationBridge.kt
+++ b/homebase-core/src/jvmMain/kotlin/id/homebase/core/notifications/DesktopChatNotificationBridge.kt
@@ -90,6 +90,7 @@ class DesktopChatNotificationBridge(
             val payload = buildSyntheticPayload(
                 senderId = senderId,
                 conversationId = message.conversationId,
+                messageId = message.id,
                 createdEpochMs = message.created.toEpochMilliseconds(),
                 body = message.content,
             )
@@ -112,6 +113,7 @@ class DesktopChatNotificationBridge(
     private fun buildSyntheticPayload(
         senderId: String,
         conversationId: Uuid,
+        messageId: Uuid,
         createdEpochMs: Long,
         body: String,
     ): PushNotification {
@@ -122,6 +124,7 @@ class DesktopChatNotificationBridge(
             options = PushNotificationPayloadOptions(
                 appId = chatAppIdDashed,
                 typeId = conversationId.toString(),
+                tagId = messageId.toString(),
                 unEncryptedMessage = preview,
                 silent = false,
             ),


### PR DESCRIPTION
## What

`DesktopChatNotificationBridge.buildSyntheticPayload` never set `tagId`, so it stayed at its `""` default. `extractChatTapIds` (`NotificationService.kt:926`) returns null on a blank `tagId`, so a tapped desktop notification hit the `else` branch at `NotificationService.kt:652` and logged:

```
Chat tap without full (convoId, messageId) — typeId=<uuid> tagId=; no auto-navigate
```

The conversation still opened via `emitNavigationEvent(OpenConversation(typeId))` — it just never scrolled to the message that triggered the notification.

Threading `message.id` (the uniqueId, the same key `pendingNotificationTap.set()` and `MessageLookup.getMessage()` take) through as `tagId` makes `extractChatTapIds` return the pair, so the pending tap target is set like it is on Android and iOS.

## Knock-on

A non-blank `tagId` also unlocks the resolver branch in `decryptNotificationBody` (`NotificationService.kt:550`). The body now comes from `ChatNotificationMessageResolver` instead of falling straight through to `unEncryptedMessage`. Same string either way — `MessageUiModel.content` is exactly what the bridge already extracts — but untruncated, which is what Android does. The 200-codepoint preview the bridge builds stays as the timeout/miss fallback.

## Verification

- `./gradlew :homebase-core:compileKotlinJvm` — passes.
- No existing tests cover this bridge.
- Not verified live: `RichNotificationDisplayer.jvm.kt:22` suppresses all native notifications on macOS when `java.home` is an unbundled JVM, which includes `./gradlew desktopApp:run`. Confirming the tap end-to-end needs a packaged `createDistributable` build, or a Windows/Linux run.