### PR TITLE
Bound the emergency-contact reconcile sweep with a per-peer TTL and a per-pass budget

### DIFF
--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/contactbook/EmergencyContactReconciler.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/contactbook/EmergencyContactReconciler.kt
@@ -3,14 +3,23 @@
 package id.homebase.core.contactbook
 
 import co.touchlab.kermit.Logger
+import id.homebase.api.client.OdinApiException
 import id.homebase.api.client.contacts.Contact
 import id.homebase.api.client.contacts.ContactRepository
 import id.homebase.api.client.peer.temporal.TemporalDriveReadProvider
 import id.homebase.api.common.OdinId
 import id.homebase.core.config.locationLabeledDrive
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
+import kotlin.time.Clock
 import kotlin.uuid.ExperimentalUuidApi
+
+/** How long a probed peer is left alone before the sweep asks again. */
+const val RECONCILE_TTL_MS: Long = 7L * 24 * 60 * 60 * 1000
+
+/** Hard ceiling on preflights per pass, so cost stays flat as the contact book grows. */
+const val RECONCILE_BUDGET: Int = 25
 
 /**
  * Recovers a missed "they added me" designation — the set-only background backstop for the
@@ -20,6 +29,17 @@ import kotlin.uuid.ExperimentalUuidApi
  * preflighting the peer's location drive with
  * [TemporalDriveReadProvider.verifyTemporalAccess] (reads no data, fires no notification on the
  * peer).
+ *
+ * The sweep runs on every app start, so it is bounded twice (issue #1243): a peer probed within
+ * [RECONCILE_TTL_MS] is skipped, and at most [RECONCILE_BUDGET] peers are probed per pass,
+ * oldest-first. A 1000-contact book therefore costs 25 preflights per start instead of 1000, and
+ * still cycles fully within a couple of weeks — a missed designation self-heals rather than
+ * needing a gap signal to find it.
+ *
+ * We record the *attempt*, not the outcome: a peer that has granted us nothing answers 400, which
+ * is indistinguishable from a transport failure, so there is no trustworthy negative to cache yet.
+ * A 4xx is taken as "the server answered" and starts the TTL; anything else (offline, timeout,
+ * 5xx) is inconclusive and is retried on the next pass rather than buying a week of silence.
  *
  * Deliberately SET-only (issue #961): a non-throwing `hasAccess = false` is NOT a trustworthy
  * revocation signal — it also fires on benign/ambiguous negatives (and has been observed after
@@ -38,42 +58,108 @@ import kotlin.uuid.ExperimentalUuidApi
 class EmergencyContactReconciler(
     private val contactRepository: ContactRepository,
     private val temporalRead: TemporalDriveReadProvider,
+    private val attemptLog: EmergencyReconcileAttemptLog,
     private val scope: CoroutineScope,
 ) {
     private val locationDrive = locationLabeledDrive.drive.alias
 
-    /** Fire-and-forget the full set-only reconcile in the background (called once at login). */
+    /** Fire-and-forget the budgeted set-only reconcile in the background (called at login). */
     fun start() {
         scope.launch { runCatching { reconcileAll() } }
     }
 
     /**
      * Set-only pass over identity-backed contacts: recovers a designation the live status-message
-     * path missed. One temporal-access preflight per unflagged identity contact.
+     * path missed. At most [RECONCILE_BUDGET] preflights, skipping peers probed within
+     * [RECONCILE_TTL_MS].
      */
     suspend fun reconcileAll() {
         contactRepository.ensureLoaded()
-        for (contact in contactRepository.contacts.value) {
-            reconcileContact(contact)
+
+        // Group by odinId, not by contact row: one identity can hold several rows (issue #982),
+        // and probing each of them separately would burn the budget on the same peer.
+        val flaggable = contactRepository.contacts.value.mapNotNull { contact ->
+            val odinId = contact.content.odinId?.takeIf { it.isNotBlank() }?.lowercase()
+                ?: return@mapNotNull null
+            if (contact.versionTag == null) return@mapNotNull null
+            odinId to contact
         }
+        val unflagged = flaggable.filterNot { it.second.iCanLocate() }
+            .groupBy({ it.first }, { it.second })
+
+        val attempts = attemptLog.load()
+        val targets = selectProbeTargets(
+            candidates = unflagged.keys,
+            lastAttemptMs = attempts,
+            nowMs = nowMs(),
+            ttlMs = RECONCILE_TTL_MS,
+            budget = RECONCILE_BUDGET,
+        )
+        if (targets.isEmpty()) return
+
+        val updated = attempts.toMutableMap()
+        for (odinId in targets) {
+            val outcome = probe(OdinId(odinId))
+            if (outcome.conclusive) updated[odinId] = nowMs()
+            if (reconcileAction(outcome.hasAccess, flagged = false) == ReconcileAction.Set) {
+                unflagged[odinId].orEmpty().forEach { setFlag(it, odinId) }
+            }
+        }
+        // Drop peers that have left the contact book so the log can't grow without bound.
+        attemptLog.save(updated.filterKeys { key -> flaggable.any { it.first == key } })
     }
 
-    private suspend fun reconcileContact(contact: Contact) {
-        val odinId = contact.content.odinId?.takeIf { it.isNotBlank() }?.let { OdinId(it) } ?: return
+    private suspend fun setFlag(contact: Contact, odinId: String) {
         val versionTag = contact.versionTag ?: return
-        // Set-only: an already-flagged contact has nothing to recover — skip the preflight entirely.
-        if (contact.iCanLocate()) return
-
-        val status = runCatching { temporalRead.verifyTemporalAccess(odinId, locationDrive) }
-            .getOrNull()
-        if (reconcileAction(status?.hasAccess, flagged = false) == ReconcileAction.Set) {
-            runCatching { contactRepository.setICanLocate(contact.uniqueId, versionTag) }
-                .onFailure { Logger.w(it) { "reconcile: setICanLocate failed for ${odinId.domainName}" } }
-        }
+        runCatching { contactRepository.setICanLocate(contact.uniqueId, versionTag) }
+            .onFailure { Logger.w(it) { "reconcile: setICanLocate failed for $odinId" } }
     }
+
+    private suspend fun probe(odinId: OdinId): ProbeOutcome = try {
+        ProbeOutcome(
+            hasAccess = temporalRead.verifyTemporalAccess(odinId, locationDrive).hasAccess,
+            conclusive = true,
+        )
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        ProbeOutcome(hasAccess = null, conclusive = isConclusiveFailure(e))
+    }
+
+    private fun nowMs(): Long = Clock.System.now().toEpochMilliseconds()
+
+    private class ProbeOutcome(val hasAccess: Boolean?, val conclusive: Boolean)
 }
 
-/** What a verify-based reconcile pass may do to a contact's [iCanLocate] flag. */
+/**
+ * Whether a failed preflight still counts as "the peer path answered us", starting the TTL. A 4xx
+ * is the server's verdict (today a missing grant surfaces as 400); a 5xx or a transport failure is
+ * not, and must stay retryable so a spell offline can't silence a peer for a week.
+ */
+fun isConclusiveFailure(e: Throwable): Boolean {
+    val status = (e as? OdinApiException)?.status ?: return false
+    return status in 400..499
+}
+
+/**
+ * The peers this pass should preflight: those never probed or probed longer ago than [ttlMs],
+ * oldest-first, capped at [budget]. A stored timestamp in the future (clock moved backwards) is
+ * treated as stale rather than skipped forever.
+ */
+fun selectProbeTargets(
+    candidates: Set<String>,
+    lastAttemptMs: Map<String, Long>,
+    nowMs: Long,
+    ttlMs: Long,
+    budget: Int,
+): List<String> = candidates
+    .filter {
+        val last = lastAttemptMs[it] ?: 0L
+        last > nowMs || nowMs - last >= ttlMs
+    }
+    .sortedWith(compareBy<String> { lastAttemptMs[it] ?: 0L }.thenBy { it })
+    .take(budget)
+
 enum class ReconcileAction { Set, None }
 
 /**

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/contactbook/EmergencyReconcileAttemptLog.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/contactbook/EmergencyReconcileAttemptLog.kt
@@ -1,0 +1,37 @@
+package id.homebase.core.contactbook
+
+import id.homebase.api.serialization.OdinSystemSerializer
+import id.homebase.api.sync.database.DatabaseManager
+import kotlin.uuid.Uuid
+
+/**
+ * Persisted "when did we last preflight this peer" log, keyed by lowercased odinId.
+ *
+ * Records the *attempt*, not the answer: a denied grant currently arrives as a 400 and is
+ * indistinguishable from a real "no", so there is nothing trustworthy to cache yet (see
+ * [EmergencyContactReconciler]). An attempt timestamp is safe to keep either way and is what
+ * bounds the sweep.
+ *
+ * Lives in keyValue, so a logout wipes it — a new identity re-probes from scratch.
+ */
+class EmergencyReconcileAttemptLog(private val databaseManager: DatabaseManager) {
+
+    private val keyValue get() = databaseManager.keyValue
+
+    suspend fun load(): Map<String, Long> = runCatching {
+        keyValue.selectByKey(KEY) { _, data -> data }
+            ?.takeIf { it.isNotEmpty() }
+            ?.let { OdinSystemSerializer.deserialize<Map<String, Long>>(it.decodeToString()) }
+    }.getOrNull().orEmpty()
+
+    suspend fun save(attempts: Map<String, Long>) {
+        runCatching {
+            keyValue.upsertValue(KEY, OdinSystemSerializer.serialize(attempts).encodeToByteArray())
+        }
+    }
+
+    companion object {
+        // 0a08xx — next free namespace after Location (0a03xx) and the 0a04–0a07 add-ons.
+        val KEY: Uuid = Uuid.parse("00000000-0000-0000-0000-0000000a0801")
+    }
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
@@ -101,6 +101,7 @@ import id.homebase.api.client.contacts.ContactRepository
 import id.homebase.core.contactbook.ContactOverrideStore
 import id.homebase.core.contactbook.EmergencyContactReceiveService
 import id.homebase.core.contactbook.EmergencyContactReconciler
+import id.homebase.core.contactbook.EmergencyReconcileAttemptLog
 import id.homebase.core.ui.screens.contactbook.CircleMemberPickerViewModel
 import id.homebase.core.ui.screens.contactbook.ContactBookViewModel
 import id.homebase.core.ui.screens.contactbook.ContactCardImport
@@ -745,6 +746,7 @@ val appModule = module {
     singleOf(::ConnectionService)
     singleOf(::EmergencyCircleNotifier)
     singleOf(::EmergencyContactReceiveService)
+    single { EmergencyReconcileAttemptLog(get()) }
     singleOf(::EmergencyContactReconciler)
     singleOf(::ContactService)
     singleOf(::ConversationStream) bind ConversationLoader::class

--- a/homebase-core/src/jvmTest/kotlin/id/homebase/core/contactbook/EmergencyReconcileBudgetTest.kt
+++ b/homebase-core/src/jvmTest/kotlin/id/homebase/core/contactbook/EmergencyReconcileBudgetTest.kt
@@ -1,0 +1,124 @@
+package id.homebase.core.contactbook
+
+import id.homebase.api.client.ClientException
+import id.homebase.api.client.NotFoundException
+import id.homebase.api.client.OdinClientErrorCode
+import id.homebase.api.client.ProblemDetails
+import id.homebase.api.client.ServerException
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Pins the two bounds that keep the every-app-start sweep flat as the contact book grows
+ * (issue #1243): the per-peer TTL and the per-pass budget.
+ */
+class EmergencyReconcileBudgetTest {
+
+    private val now = 1_000_000_000_000L
+
+    @Test
+    fun `a peer probed inside the TTL is skipped`() {
+        val targets = selectProbeTargets(
+            candidates = setOf("a.example.com"),
+            lastAttemptMs = mapOf("a.example.com" to now - 1),
+            nowMs = now,
+            ttlMs = RECONCILE_TTL_MS,
+            budget = RECONCILE_BUDGET,
+        )
+        assertEquals(emptyList(), targets)
+    }
+
+    @Test
+    fun `a peer probed longer ago than the TTL is probed again`() {
+        val targets = selectProbeTargets(
+            candidates = setOf("a.example.com"),
+            lastAttemptMs = mapOf("a.example.com" to now - RECONCILE_TTL_MS),
+            nowMs = now,
+            ttlMs = RECONCILE_TTL_MS,
+            budget = RECONCILE_BUDGET,
+        )
+        assertEquals(listOf("a.example.com"), targets)
+    }
+
+    @Test
+    fun `a never-probed peer is a target`() {
+        val targets = selectProbeTargets(
+            candidates = setOf("a.example.com"),
+            lastAttemptMs = emptyMap(),
+            nowMs = now,
+            ttlMs = RECONCILE_TTL_MS,
+            budget = RECONCILE_BUDGET,
+        )
+        assertEquals(listOf("a.example.com"), targets)
+    }
+
+    @Test
+    fun `a thousand-contact book costs the budget, not the book`() {
+        val candidates = (1..1000).map { "peer$it.example.com" }.toSet()
+        val targets = selectProbeTargets(
+            candidates = candidates,
+            lastAttemptMs = emptyMap(),
+            nowMs = now,
+            ttlMs = RECONCILE_TTL_MS,
+            budget = RECONCILE_BUDGET,
+        )
+        assertEquals(RECONCILE_BUDGET, targets.size)
+    }
+
+    @Test
+    fun `the oldest attempts are probed first so the book cycles`() {
+        val targets = selectProbeTargets(
+            candidates = setOf("new.example.com", "old.example.com", "never.example.com"),
+            lastAttemptMs = mapOf(
+                "new.example.com" to now - RECONCILE_TTL_MS,
+                "old.example.com" to now - RECONCILE_TTL_MS * 4,
+            ),
+            nowMs = now,
+            ttlMs = RECONCILE_TTL_MS,
+            budget = 2,
+        )
+        assertEquals(listOf("never.example.com", "old.example.com"), targets)
+    }
+
+    @Test
+    fun `a timestamp in the future is treated as stale, not skipped forever`() {
+        val targets = selectProbeTargets(
+            candidates = setOf("a.example.com"),
+            lastAttemptMs = mapOf("a.example.com" to now + RECONCILE_TTL_MS),
+            nowMs = now,
+            ttlMs = RECONCILE_TTL_MS,
+            budget = RECONCILE_BUDGET,
+        )
+        assertEquals(listOf("a.example.com"), targets)
+    }
+
+    @Test
+    fun `a 400 is the server's verdict and starts the TTL`() {
+        assertTrue(isConclusiveFailure(badRequest()))
+    }
+
+    @Test
+    fun `a 404 is conclusive too`() {
+        assertTrue(isConclusiveFailure(NotFoundException()))
+    }
+
+    @Test
+    fun `a 5xx does not start the TTL`() {
+        assertFalse(isConclusiveFailure(ServerException(503, null, null)))
+    }
+
+    @Test
+    fun `a transport failure does not buy a week of silence`() {
+        assertFalse(isConclusiveFailure(RuntimeException("connection reset")))
+    }
+
+    private fun badRequest() = ClientException(
+        status = 400,
+        errorCode = OdinClientErrorCode.UnhandledScenario,
+        message = "Invalid request",
+        correlationId = null,
+        problem = ProblemDetails(),
+    )
+}


### PR DESCRIPTION
Closes #1243.

## The problem

`EmergencyContactReconciler.start()` runs from `onPostAuthenticated`, which fires on every process start — a cold start re-authenticates from the stored session, so this is every foreground launch, not just an interactive login. Each pass preflighted **every** unflagged identity contact. The cost scaled with the contact book and never decayed: a 1000-contact book meant 1000 peer calls per launch, mostly 400s, against our own peer path each time.

## The fix

Two bounds, persisted across launches in `keyValue`:

- **TTL** — a peer probed within `RECONCILE_TTL_MS` (7 days) is skipped.
- **Budget** — at most `RECONCILE_BUDGET` (25) peers per pass, oldest-first.

25 preflights per start instead of 1000, flat as the book grows. The book still cycles fully in ~1–2 weeks, so a designation the live status-message path missed still self-heals — no gap-detection signal required.

## Attempt, not answer

The log records **when we last asked**, not what came back.

A missing grant currently surfaces as a 400, indistinguishable from a transport failure, so there is no trustworthy negative to cache yet. Recording the attempt is safe either way and is what bounds the sweep — which also means this ships without waiting on any server change.

`isConclusiveFailure()` draws the line: a **4xx** counts as "the server answered" and starts the TTL; a **5xx or transport failure** stays inconclusive and retries next pass, so a launch with dead wifi can't silence a peer for a week.

## Grouping by odinId

Candidates are grouped by odinId before probing. Not dedup-as-optimization — with a budget, duplicate rows for one identity (#982) would burn budget slots on the same peer. Every row for that identity is still flagged on a hit, so the end state is unchanged.

## Constraints preserved

- **Set-only (#961)** — the sweep never clears `iCanLocate`. Clear remains solely `EmergencyContactReceiveService.onRevoked`.
- Missed designations are still recovered, just not by probing everyone on every start.

## Follow-ups (not in this PR)

- **Backend ask:** return `200 { hasAccess: false }` for a denied grant. That upgrades this from caching *"I asked recently"* to caching *"they said no"* — a much longer TTL for definitive denials, short retry for unreachable.
- **Batch endpoint** taking a list of odinIds. Collapses the remaining 25 client requests into 1; the peer fan-out is unchanged, so it's polish rather than the fix. Worth pairing with the response-semantics change above, since a batch response needs per-entry outcomes anyway.
- **`ConnectionChanged` invalidation** so a fresh connection is probed on the next pass rather than waiting out the TTL.

## Testing

`EmergencyReconcileBudgetTest` — TTL boundary, never-probed, the 1000-contact ceiling, oldest-first cycling, a future timestamp (clock skew) treated as stale rather than skipped forever, and the 4xx / 5xx / transport split.

`homebase-core:jvmTest` green. Compiles on JVM, Android, wasmJs, and iOS (main + test sources).

🤖 Generated with [Claude Code](https://claude.com/claude-code)