### PR TITLE
Serve the profile cache stale while it revalidates

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/profile/PublicProfileProviderCached.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/profile/PublicProfileProviderCached.kt
@@ -62,7 +62,8 @@ import kotlin.time.Clock
  */
 class PublicProfileProviderCached(
     private val httpClient: HttpClient,
-    fileOperationsProvider: FileOperationsProvider
+    fileOperationsProvider: FileOperationsProvider,
+    private val scope: CoroutineScope
 ) {
 
     private val serializer = OdinSystemSerializer
@@ -250,11 +251,11 @@ class PublicProfileProviderCached(
 
         if (cacheKey in notFoundCache) return null
 
-        // Pre-mutex peek: pure read, no remove. A hit returns immediately;
-        // a miss or expired entry falls through to the mutex where the
-        // refresh (and any remove) is serialised.
         readCachedOrLog(disk, cacheKey, readFromDisk)?.let { cached ->
-            if (!cached.isExpired(clock)) return cached.value
+            if (cached.isExpired(clock)) {
+                refreshInBackground(cacheKey, disk, ttlMillis, fetch, transform, writeToDisk)
+            }
+            return cached.value
         }
 
         val mutex = getMutex(cacheKey)
@@ -263,52 +264,82 @@ class PublicProfileProviderCached(
 
             if (cacheKey in notFoundCache) return@withLock null
 
-            readCachedOrLog(disk, cacheKey, readFromDisk)?.let { cached ->
-                if (!cached.isExpired(clock)) {
-                    return@withLock cached.value
-                } else {
+            readCachedOrLog(disk, cacheKey, readFromDisk)?.let { return@withLock it.value }
+
+            fetchAndStore(cacheKey, disk, ttlMillis, fetch, transform, writeToDisk, cacheNotFound = true)
+        }
+    }
+
+    private fun <T> refreshInBackground(
+        cacheKey: String,
+        disk: DiskCache,
+        ttlMillis: Long,
+        fetch: suspend () -> HttpResponse,
+        transform: suspend (HttpResponse) -> T,
+        writeToDisk: (Path, Long, T) -> Unit
+    ) {
+        scope.launch {
+            val mutex = getMutex(cacheKey)
+            // tryLock dedupes concurrent refreshes but leaves no handle to await;
+            // swap in a per-key Deferred map if a caller ever needs to join one.
+            if (!mutex.tryLock()) return@launch
+            try {
+                fetchAndStore(cacheKey, disk, ttlMillis, fetch, transform, writeToDisk, cacheNotFound = false)
+            } catch (e: Exception) {
+                Logger.w(tag = "PublicProfileIO", throwable = e) { "background refresh failed key=$cacheKey" }
+            } finally {
+                mutex.unlock()
+            }
+        }
+    }
+
+    // Caller owns the per-key mutex; this never takes it.
+    private suspend fun <T> fetchAndStore(
+        cacheKey: String,
+        disk: DiskCache,
+        ttlMillis: Long,
+        fetch: suspend () -> HttpResponse,
+        transform: suspend (HttpResponse) -> T,
+        writeToDisk: (Path, Long, T) -> Unit,
+        cacheNotFound: Boolean
+    ): T? {
+        val response = fetch()
+
+        return when (response.status.value) {
+
+            200 -> {
+                val expiry = now() + ttlMillis
+
+                val value = transform(response)
+
+                val editor = disk.openEditor(cacheKey.toDiskKey())
+                if (editor != null) {
                     try {
-                        disk.remove(cacheKey.toDiskKey())
+                        writeToDisk(editor.data, expiry, value)
+                        editor.commit()
                     } catch (e: Exception) {
-                        Logger.w(tag = "PublicProfileIO", throwable = e) { "remove expired entry failed key=$cacheKey" }
+                        try { editor.abort() } catch (_: Exception) {}
+                        Logger.w(tag = "PublicProfileIO", throwable = e) { "cache-write failed key=$cacheKey" }
                     }
                 }
+
+                value
             }
 
-            val response = fetch()
-
-            when (response.status.value) {
-
-                200 -> {
-                    val expiry = now() + ttlMillis
-
-                    val value = transform(response)
-
-                    val editor = disk.openEditor(cacheKey.toDiskKey())
-                    if (editor != null) {
-                        try {
-                            writeToDisk(editor.data, expiry, value)
-                            editor.commit()
-                        } catch (e: Exception) {
-                            try { editor.abort() } catch (_: Exception) {}
-                            Logger.w(tag = "PublicProfileIO", throwable = e) { "cache-write failed key=$cacheKey" }
-                        }
-                    }
-
-                    value
-                }
-
-                404 -> {
+            404 -> {
+                // Only a total miss may poison the key: notFoundCache has no TTL, so
+                // a background 404 would blank a working avatar for the whole session.
+                if (cacheNotFound) {
                     notFoundCacheMutex.withLock { notFoundCache = notFoundCache + cacheKey }
-                    null
                 }
+                null
+            }
 
-                else -> {
-                    Logger.w(tag = "PublicProfileIO") {
-                        "unexpected status=${response.status.value} key=$cacheKey"
-                    }
-                    throw Exception("Fetch failed: ${response.status}")
+            else -> {
+                Logger.w(tag = "PublicProfileIO") {
+                    "unexpected status=${response.status.value} key=$cacheKey"
                 }
+                throw Exception("Fetch failed: ${response.status}")
             }
         }
     }

--- a/homebase-api/src/jvmTest/kotlin/id/homebase/api/client/profile/PublicProfileProviderCachedTest.kt
+++ b/homebase-api/src/jvmTest/kotlin/id/homebase/api/client/profile/PublicProfileProviderCachedTest.kt
@@ -15,18 +15,26 @@ import io.ktor.http.Headers
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
+import kotlinx.coroutines.CompletableJob
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
 import kotlinx.coroutines.yield
+import java.nio.ByteBuffer
 import java.nio.file.Files
 import java.nio.file.Path
+import kotlin.system.measureTimeMillis
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
@@ -44,14 +52,18 @@ class PublicProfileProviderCachedTest {
     private var nextException: Exception? = null
     private var nextStatus = HttpStatusCode.OK
     private var nextCacheControl: String? = null
+    private var nextDelayMillis = 0L
     private val imageBytes = ByteArray(128) { it.toByte() }
+    private val refreshedImageBytes = ByteArray(64) { 0x7F }
+    private var nextImageBytes = imageBytes
 
     private val mockEngine = MockEngine { _ ->
         requestCount++
+        if (nextDelayMillis > 0) delay(nextDelayMillis)
         nextException?.let { e -> throw e }
         val headers = nextCacheControl?.let { headersOf(HttpHeaders.CacheControl, it) } ?: Headers.Empty
         if (nextStatus == HttpStatusCode.OK) {
-            respond(imageBytes, nextStatus, headers)
+            respond(nextImageBytes, nextStatus, headers)
         } else {
             respond("", nextStatus, headers)
         }
@@ -60,6 +72,7 @@ class PublicProfileProviderCachedTest {
     private val httpClient = HttpClient(mockEngine)
     private var tempDir: String = ""
     private lateinit var provider: PublicProfileProviderCached
+    private lateinit var scopeJob: CompletableJob
 
     private val logCollector = CollectingLogWriter()
 
@@ -68,9 +81,11 @@ class PublicProfileProviderCachedTest {
     @BeforeTest
     fun setup() {
         tempDir = Files.createTempDirectory("hb-pub-profile-cache-test").toString()
+        scopeJob = SupervisorJob()
 
         provider = PublicProfileProviderCached(
             httpClient = httpClient,
+            scope = CoroutineScope(scopeJob + Dispatchers.Default),
             fileOperationsProvider = object : FileOperationsProvider {
                 override fun getCacheDirectory() = tempDir
                 override fun openFileInput(path: String): InputProvider = error("not used in tests")
@@ -87,12 +102,15 @@ class PublicProfileProviderCachedTest {
         nextException = null
         nextStatus = HttpStatusCode.OK
         nextCacheControl = null
+        nextDelayMillis = 0L
+        nextImageBytes = imageBytes
         logCollector.entries.clear()
         Logger.setLogWriters(listOf(logCollector))
     }
 
     @AfterTest
     fun tearDown() {
+        scopeJob.cancel()
         httpClient.close()
         runCatching {
             Files.walk(Path.of(tempDir))
@@ -258,6 +276,100 @@ class PublicProfileProviderCachedTest {
         )
     }
 
+    @Test
+    fun `a total cache miss still fetches from the network`() = runTest {
+        assertEquals(0, requestCount)
+
+        val fresh = provider.getPublicImage(odinId)
+        assertContentEquals(imageBytes, fresh, "a total miss must be served from the network")
+        assertEquals(1, requestCount)
+
+        val second = provider.getPublicImage(odinId)
+        assertContentEquals(imageBytes, second)
+        assertEquals(1, requestCount, "the freshly written entry must serve the second call")
+    }
+
+    /**
+     * Real threads, not `runTest`'s virtual clock: the point of the test is that
+     * the caller returns while a genuinely slow request is still in flight.
+     */
+    @Test
+    fun `a stale entry is served without waiting on the network`() = runBlocking {
+        provider.getPublicImage(odinId)
+        expireCachedImageEntry()
+
+        nextDelayMillis = 10_000L
+        nextImageBytes = refreshedImageBytes
+
+        val elapsed = measureTimeMillis {
+            val stale = provider.getPublicImage(odinId)
+            assertContentEquals(imageBytes, stale, "the stale entry must be served, not the pending refresh")
+        }
+
+        assertTrue(elapsed < 2_000L, "stale read blocked on the network for ${elapsed}ms")
+
+        // Proves the entry really was treated as expired — a fresh one launches no refresh.
+        withTimeout(5_000L) { while (requestCount < 2) delay(10) }
+    }
+
+    @Test
+    fun `a failed background refresh leaves the stale entry intact`() = runBlocking {
+        provider.getPublicImage(odinId)
+        expireCachedImageEntry()
+
+        nextStatus = HttpStatusCode.InternalServerError
+        logCollector.entries.clear()
+
+        val stale = provider.getPublicImage(odinId)
+        assertContentEquals(imageBytes, stale, "a 500 refresh must not stop the stale entry being served")
+
+        awaitBackgroundRefreshes()
+        assertTrue(
+            logCollector.hasWarn(tag = "PublicProfileIO", substring = "background refresh failed"),
+            "expected the refresh to run and fail; got: ${logCollector.messages("PublicProfileIO")}"
+        )
+
+        val again = provider.getPublicImage(odinId)
+        assertContentEquals(imageBytes, again, "the failed refresh must not have removed the stale entry")
+        awaitBackgroundRefreshes()
+    }
+
+    @Test
+    fun `a successful background refresh replaces the stale entry`() = runBlocking {
+        provider.getPublicImage(odinId)
+        expireCachedImageEntry()
+
+        nextImageBytes = refreshedImageBytes
+
+        val stale = provider.getPublicImage(odinId)
+        assertContentEquals(imageBytes, stale, "the first read after expiry must still be the stale value")
+
+        awaitBackgroundRefreshes()
+        val countAfterRefresh = requestCount
+
+        val fresh = provider.getPublicImage(odinId)
+        assertContentEquals(refreshedImageBytes, fresh, "the refresh must have replaced the stale entry")
+        assertEquals(countAfterRefresh, requestCount, "the refreshed entry is fresh — no new request")
+    }
+
+    private suspend fun awaitBackgroundRefreshes() {
+        withTimeout(10_000L) { scopeJob.children.toList().forEach { it.join() } }
+    }
+
+    /** No clock seam on the provider, so expiry is forced by rewriting the entry's leading long. */
+    private fun expireCachedImageEntry() {
+        val entryBytes = (8 + 4 + imageBytes.size).toLong()
+        val entry = Files.walk(Path.of(tempDir, "homebase-public-images-v2")).use { stream ->
+            stream.filter {
+                Files.isRegularFile(it) && it.fileName.toString() != "journal" && Files.size(it) == entryBytes
+            }.toList()
+        }.single()
+
+        val bytes = Files.readAllBytes(entry)
+        ByteBuffer.wrap(bytes).putLong(0, System.currentTimeMillis() - 60_000L)
+        Files.write(entry, bytes)
+    }
+
     /**
      * Mirror of DriveFileProviderCachedTest's per-cache-resilience assertion.
      * A single FileKache ctor failure must not hide the healthy sibling row.
@@ -298,6 +410,9 @@ private class CollectingLogWriter : LogWriter() {
 
     fun hasError(tag: String, substring: String): Boolean =
         entries.any { it.tag == tag && it.severity == Severity.Error && it.message.contains(substring) }
+
+    fun hasWarn(tag: String, substring: String): Boolean =
+        entries.any { it.tag == tag && it.severity == Severity.Warn && it.message.contains(substring) }
 
     fun messages(tag: String): List<String> =
         entries.filter { it.tag == tag }.map { "[${it.severity}] ${it.message}" }

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageStreamLoadRaceTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMessageStreamLoadRaceTest.kt
@@ -376,7 +376,7 @@ class ChatMessageStreamLoadRaceTest {
             ),
             ownerSessionRepository = OwnerSessionRepository(
                 publicIdentityRepository = PublicIdentityRepository(httpClient),
-                publicProfileProviderCached = PublicProfileProviderCached(httpClient, fileOps),
+                publicProfileProviderCached = PublicProfileProviderCached(httpClient, fileOps, scope.backgroundScope),
                 eventBus = eventBus,
                 scope = scope.backgroundScope,
             ),


### PR DESCRIPTION
Closes #1449.

Middle layer of a 3-PR stack: #1451 (client TTL) → **this** → #1447 single contact gateway. Based on `profile-cache-client-ttl`; review the top commit only.

## The actual cause of the spinner

`getCached` did this on an expired entry:

1. Pre-mutex peek read the stale entry, saw it was expired, and **discarded the value**.
2. Inside the per-key mutex, `disk.remove()` deleted the stale bytes.
3. Then `fetch()` — awaited synchronously, inside the mutex, with no timeout.

So the moment a profile expired, the avatar and name were stuck on a round-trip to the *peer's* host, with the copy that would have rendered instantly already thrown away. That is the 10–20 s spinner, not the peer's `Cache-Control` (see #1451 for why that premise didn't hold).

## What changed

- `getCached` reads disk **once**. Any entry — fresh or stale — returns immediately. A stale one kicks a background refresh first. Only a total cache miss still awaits the network, because there is nothing to show.
- The `disk.remove()` on the expired branch is **deleted**. Stale bytes survive until `editor.commit()` replaces them, so a slow or failing refresh leaves the old name and picture on screen.
- The fetch → status → transform → write body moves into a shared `fetchAndStore`, so the background path never re-enters `getCached`. The per-key `Mutex` is not reentrant; re-entering would deadlock.
- Refreshes de-dupe via `tryLock()` on that same mutex — if it's held, a refresh is already in flight. No new `Deferred` map; the comment names the ceiling (no caller can await a refresh) and the upgrade path if that's ever needed.
- The ctor gains a `CoroutineScope`. Koin resolves it with no DI edit — `ApiModule.kt:70` already registers a single app scope and `:167` is `singleOf(::PublicProfileProviderCached)`.

## A background 404 no longer poisons the negative cache

`notFoundCache` has no TTL and no disk backing; it clears only on `invalidateProfile`/`invalidateImage`/`clearCaches`. So one transient background 404 — a peer mid-redeploy, a misconfigured proxy, a briefly unpublished profile — would blank a working avatar for the entire process lifetime. `fetchAndStore` now takes `cacheNotFound`, and only the foreground miss path passes `true`. That is the case the negative cache was built for: an identity with no profile at all, where there is no stale data to protect.

## Tests

Four new cases in the JVM test. There is no clock seam (`Clock.System` is a hardcoded field), so expiry is forced by rewriting the entry's leading 8-byte big-endian expiry long to the past.

- a stale entry is served without waiting on the network
- a failed background refresh leaves the stale entry intact
- a successful background refresh replaces the stale entry
- a total cache miss still fetches from the network — the guard against over-correcting into "never fetch"

Efficacy checked by mutation: reintroducing `disk.remove()` + the blocking fetch fails the first three and correctly leaves the fourth passing.

`:homebase-api:jvmTest` 1237 tests / 0 failures · `:homebase-chat:jvmTest` 1309 / 0 · compiles on JVM, Android, wasmJs and iosSimulatorArm64.