### PR TITLE
Only let a real blob: URL bypass the resolved video path (#1457)

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/util/StringExtensions.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/util/StringExtensions.kt
@@ -20,6 +20,8 @@ private fun codePointToString(cp: Int): String {
     }
 }
 
+fun String.isBlobUrl(): Boolean = startsWith("blob:")
+
 fun String.decodeHtmlEntities(): String {
     if ('&' !in this) return this
     return htmlEntityPattern.replace(this) { match ->

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/video/VideoPayloadProcessor.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/video/VideoPayloadProcessor.kt
@@ -12,6 +12,7 @@ import id.homebase.api.file.FileOperationsProvider
 import id.homebase.api.file.withResolvedFile
 import id.homebase.api.image.createThumbnails
 import id.homebase.api.serialization.OdinSystemSerializer
+import id.homebase.api.util.isBlobUrl
 import io.ktor.utils.io.core.toByteArray
 import okio.Path.Companion.toPath
 import kotlin.time.Duration
@@ -62,14 +63,15 @@ class VideoPayloadProcessor(
         trimStartMs: Long?,
         trimEndMs: Long?,
         videoQuality: VideoQuality,
-        // Web only: a blob: URL for the original. When present it's the ffmpeg/decoder INPUT read
-        // (poster + compress), so the original is read in JS — never copied into Kotlin or base64'd.
-        // null on native → falls back to the okio path. Read-only here; revoked by writeFileFromUrl.
+        // Web only: a blob: URL for the original, read by ffmpeg/decoder in JS (poster + compress)
+        // so the bytes never enter Kotlin. Read-only here; revoked by writeFileFromUrl.
         inputBlobUrl: String?,
     ): VideoProcessResult {
         // The okio path stays the source of truth for size, the compress-skip fallback, and the
         // non-HLS encrypt of an uncompressed clip; inputBlobUrl only short-circuits the INPUT reads.
-        val ffmpegInputPath = inputBlobUrl ?: payload.filePath
+        // Only a real blob: handle may bypass the resolved path — a raw content:// or PHAsset id
+        // here is unreadable by native ffmpeg.
+        val ffmpegInputPath = inputBlobUrl?.takeIf { it.isBlobUrl() } ?: payload.filePath
 
         /* ---------- PHASE 1: THUMBNAILS ---------- */
 

--- a/homebase-api/src/jvmTest/kotlin/id/homebase/api/video/VideoPayloadProcessorCompressionSeamTest.kt
+++ b/homebase-api/src/jvmTest/kotlin/id/homebase/api/video/VideoPayloadProcessorCompressionSeamTest.kt
@@ -33,8 +33,16 @@ class VideoPayloadProcessorCompressionSeamTest {
     /** Minimal in-memory [FileOperationsProvider] backed by a path→bytes map. */
     private inner class FakeFileOperationsProvider(
         private val store: MutableMap<String, ByteArray>,
+        // content:// → copy path, mirroring AndroidFileOperationsProvider.resolveToFilePath.
+        private val resolveMap: Map<String, String> = emptyMap(),
     ) : FileOperationsProvider {
         private var stagingCounter = 0
+
+        override suspend fun resolveToFilePath(path: String): String {
+            val target = resolveMap[path] ?: return path
+            store[target] = store[path] ?: error("missing source: $path")
+            return target
+        }
 
         override fun openFileInput(path: String): InputProvider =
             throw UnsupportedOperationException("not used")
@@ -177,6 +185,64 @@ class VideoPayloadProcessorCompressionSeamTest {
         assertEquals("video/mp4", result.videoMetadata.mimeType)
         assertNull(result.videoMetadata.hlsPlaylist)
         assertEquals(12_345f, result.videoMetadata.duration)
+    }
+
+    @Test
+    fun contentUriInputIsResolvedBeforeCompressionEvenWhenInputBlobUrlIsNotABlob() = runTest {
+        // #1457: on Android the gallery strip's content:// URI leaked into inputBlobUrl and won
+        // over the withResolvedFile copy, so ffmpeg got a URI it can't open.
+        val contentUri = "content://media/external/video/media/1000041257"
+        val resolvedPath = "$cacheDir/resolved_1457.mp4"
+        val compressedPath = "$cacheDir/compressed.mp4"
+        val store = mutableMapOf(
+            contentUri to ByteArray(1024),
+            compressedPath to ByteArray(1024),
+        )
+        val fileOps = FakeFileOperationsProvider(store, resolveMap = mapOf(contentUri to resolvedPath))
+        val compressor = FakeVideoCompressor(
+            compressedPath = compressedPath,
+            segmented = SegmentedVideo("$cacheDir/playlist.m3u8", "$cacheDir/segments.ts"),
+        )
+        val processor = VideoPayloadProcessor(fileOps, compressor, FakeVideoProbe(1_000L))
+
+        processor.process(
+            payload = PayloadFile(key = "vid", filePath = contentUri),
+            keyHeader = KeyHeader.newRandom16(),
+            onProgress = null,
+            descriptorContentPayloadKey = "descriptor",
+            inputBlobUrl = contentUri,
+        )
+
+        assertEquals(resolvedPath, compressor.compressInput)
+        assertFalse(store.containsKey(resolvedPath), "resolved copy must be reaped by withResolvedFile")
+        assertTrue(store.containsKey(contentUri), "the caller-owned source must not be reaped")
+    }
+
+    @Test
+    fun blobInputBlobUrlStillFeedsFfmpegDirectly() = runTest {
+        val inputPath = "$cacheDir/input.mp4"
+        val blobUrl = "blob:https://app.example/0c1d2e3f"
+        val compressedPath = "$cacheDir/compressed.mp4"
+        val store = mutableMapOf(
+            inputPath to ByteArray(1024),
+            compressedPath to ByteArray(1024),
+        )
+        val fileOps = FakeFileOperationsProvider(store)
+        val compressor = FakeVideoCompressor(
+            compressedPath = compressedPath,
+            segmented = SegmentedVideo("$cacheDir/playlist.m3u8", "$cacheDir/segments.ts"),
+        )
+        val processor = VideoPayloadProcessor(fileOps, compressor, FakeVideoProbe(1_000L))
+
+        processor.process(
+            payload = PayloadFile(key = "vid", filePath = inputPath),
+            keyHeader = KeyHeader.newRandom16(),
+            onProgress = null,
+            descriptorContentPayloadKey = "descriptor",
+            inputBlobUrl = blobUrl,
+        )
+
+        assertEquals(blobUrl, compressor.compressInput)
     }
 
     @Test

--- a/homebase-api/src/wasmJsMain/kotlin/id/homebase/api/video/BrowserVideoDecoder.kt
+++ b/homebase-api/src/wasmJsMain/kotlin/id/homebase/api/video/BrowserVideoDecoder.kt
@@ -3,6 +3,7 @@
 package id.homebase.api.video
 
 import id.homebase.api.file.systemFileSystem
+import id.homebase.api.util.isBlobUrl
 import kotlin.io.encoding.Base64
 import kotlin.js.Promise
 import kotlinx.coroutines.await
@@ -94,7 +95,7 @@ private class VideoUrlHandle private constructor(val url: String, private val ow
 
     companion object {
         fun resolve(videoPath: String): VideoUrlHandle? {
-            if (videoPath.startsWith("blob:")) return VideoUrlHandle(videoPath, owned = false)
+            if (videoPath.isBlobUrl()) return VideoUrlHandle(videoPath, owned = false)
             val bytes = readOkioBytes(videoPath) ?: return null
             val url = objectUrlFromBytesJs(Base64.encode(bytes), mimeFromPath(videoPath))
             return VideoUrlHandle(url, owned = true)

--- a/homebase-api/src/wasmJsMain/kotlin/id/homebase/api/video/FFmpegUtils.web.kt
+++ b/homebase-api/src/wasmJsMain/kotlin/id/homebase/api/video/FFmpegUtils.web.kt
@@ -4,6 +4,7 @@ package id.homebase.api.video
 
 import id.homebase.api.client.KeyHeader
 import id.homebase.api.file.systemFileSystem
+import id.homebase.api.util.isBlobUrl
 import kotlin.js.Promise
 import kotlin.math.abs
 import kotlin.random.Random
@@ -49,7 +50,7 @@ actual object FFmpegUtils {
         // Editor fast path: a blob: URL (minted from the picked File) has no okio bytes for mp4box
         // to parse. Read the duration straight off an HTML5 <video> instead — any codec the browser
         // can decode, no bytes copied into wasm, no 22 MB core.
-        if (inputPath.startsWith("blob:")) return videoDurationMsFromUrl(inputPath)
+        if (inputPath.isBlobUrl()) return videoDurationMsFromUrl(inputPath)
         val bytes = readOkioBytes(inputPath) ?: return 0L
         return FFmpegBridge.probe(bytes)?.durationMs ?: 0L
     }
@@ -88,7 +89,7 @@ actual object FFmpegUtils {
         //    (fetch → mp4box / ffmpeg.writeFile); the original never enters Kotlin and is never
         //    base64'd. Size comes from the probe.
         //  - okio path (e.g. a compressed intermediate, or native) → read bytes into Kotlin as before.
-        val isBlob = inputPath.startsWith("blob:")
+        val isBlob = inputPath.isBlobUrl()
         val inputBytes =
             if (isBlob) null
             else (readOkioBytes(inputPath)

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/AttachmentHandler.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/AttachmentHandler.kt
@@ -270,9 +270,8 @@ internal class AttachmentHandler(
                         val rawPath = gallery.file.toPlayableUrl()
                         // iOS quick-switch hands a bare PHAsset localIdentifier (ph://… / …/L0/…)
                         // that AVPlayer (the editor preview) and the thumbnail/duration probe can't
-                        // open — materialize it to a real temp file first. Other platforms
-                        // (Android content://, desktop real path) are already playable; pass through.
-                        // The send path resolves file (the identifier) on its own, so it's untouched.
+                        // open — materialize it to a real temp file first. Android content:// and
+                        // desktop paths are playable as-is; send resolves `file` separately either way.
                         val playable = if (rawPath.startsWith("ph://") || rawPath.contains("/L0/")) {
                             fileOperationsProvider.resolveToFilePath(rawPath)
                         } else {

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/MessageActionsHandler.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/MessageActionsHandler.kt
@@ -7,6 +7,7 @@ import id.homebase.api.file.SourceUnavailableException
 import id.homebase.api.image.ImageHeaderParser
 import id.homebase.api.image.ImageUtils
 import id.homebase.api.image.convertHeicToJpeg
+import id.homebase.api.util.isBlobUrl
 import id.homebase.api.util.truncateToCodePoints
 import id.homebase.chat.contactcard.SharedVCardDetector
 import id.homebase.chat.contactcard.VCardDescriptorFactory
@@ -711,10 +712,10 @@ internal class MessageActionsHandler(
                                 displayName = attachment.sourceFileName ?: attachment.file.name,
                                 trimStartMs = attachment.trimStartMs,
                                 trimEndMs = attachment.trimEndMs,
-                                // Web: the blob: URL becomes the ffmpeg compress INPUT (read in JS,
-                                // no Kotlin copy / base64). Null on native. Not revoked here — it
-                                // also backs the sent bubble's local preview; freed on logout/reload.
-                                inputBlobUrl = attachment.playablePath,
+                                // Web-only ffmpeg input (blob: object URL); native ffmpeg reads the
+                                // withResolvedFile path. Not revoked here — it also backs the sent
+                                // bubble's local preview; freed on logout/reload.
+                                inputBlobUrl = attachment.playablePath?.takeIf { it.isBlobUrl() },
                             )
                         )
                     }

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/builder/MessageAttachmentBuilderTrimTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/builder/MessageAttachmentBuilderTrimTest.kt
@@ -105,6 +105,24 @@ class MessageAttachmentBuilderTrimTest {
     }
 
     @Test
+    fun videoAttachmentInput_forwardsInputBlobUrlUntouched() = runTest {
+        // The builder is a pass-through; the blob:-only guard lives in VideoPayloadProcessor.
+        val input = AttachmentInput(
+            filePath = "/tmp/some_clip.mp4",
+            contentType = "video/mp4",
+            inputBlobUrl = "blob:https://app.example/0c1d2e3f",
+        )
+
+        val bundle = MessageAttachmentBuilder.buildSingle(
+            attachment = input,
+            fileOperationsProvider = fakeFs,
+            payloadKey = "chat_web0",
+        )
+
+        assertEquals("blob:https://app.example/0c1d2e3f", bundle.payloads.single().inputBlobUrl)
+    }
+
+    @Test
     fun fileAttachmentInput_doesNotInventTrim() = runTest {
         // Non-video, non-image, non-audio takes the same builder branch as video
         // (the `else ->` clause) but with content-type that signals "no trim".

--- a/homebase-chat/src/wasmJsMain/kotlin/id/homebase/chat/conversationlist/AttachmentUploadResolve.web.kt
+++ b/homebase-chat/src/wasmJsMain/kotlin/id/homebase/chat/conversationlist/AttachmentUploadResolve.web.kt
@@ -2,6 +2,7 @@
 
 package id.homebase.chat.conversationlist
 
+import id.homebase.api.util.isBlobUrl
 import io.github.vinceglb.filekit.PlatformFile
 
 // Mint a blob: object URL straight from the picked browser File. This is O(1): the browser keeps
@@ -11,7 +12,7 @@ import io.github.vinceglb.filekit.PlatformFile
 actual fun PlatformFile.toPlayableUrl(): String = createObjectUrlFromFile(file)
 
 actual fun revokePlayableUrl(url: String) {
-    if (url.startsWith("blob:")) revokeObjectUrlJs(url)
+    if (url.isBlobUrl()) revokeObjectUrlJs(url)
 }
 
 private fun createObjectUrlFromFile(file: JsAny): String = js("URL.createObjectURL(file)")

--- a/homebase-chat/src/wasmJsMain/kotlin/id/homebase/chat/widget/video/LocalVideoPlayerSurface.web.kt
+++ b/homebase-chat/src/wasmJsMain/kotlin/id/homebase/chat/widget/video/LocalVideoPlayerSurface.web.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.layout.boundsInWindow
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalDensity
 import id.homebase.api.file.systemFileSystem
+import id.homebase.api.util.isBlobUrl
 import kotlin.io.encoding.Base64
 import okio.Path.Companion.toPath
 
@@ -51,7 +52,7 @@ private class PlayerSrc(val url: String, val createdByUs: Boolean)
  * and wrapped in a fresh, owned blob URL (the only path that base64s; off the interactive hot path).
  */
 private fun resolvePlayerSrc(filePath: String): PlayerSrc? {
-    if (filePath.startsWith("blob:")) return PlayerSrc(filePath, createdByUs = false)
+    if (filePath.isBlobUrl()) return PlayerSrc(filePath, createdByUs = false)
     val bytes = readOkioBytes(filePath) ?: return null
     return PlayerSrc(bytesToObjectUrl(Base64.encode(bytes), mimeFromPath(filePath)), createdByUs = true)
 }


### PR DESCRIPTION
Fixes #1457

## What was wrong

Sending a video from the in-composer gallery strip on Android failed with `VideoCompressionFailedException: … content://media/… input file not found`.

`inputBlobUrl` was meant to be a web-only optimization (feed ffmpeg the browser `blob:` object URL), but nothing enforced that:

- `playablePath` is populated on every platform (`AttachmentHandler.extractThumbnailAsync`). The file-picker feeder materializes the file first, so its value is a sandbox path. The gallery-strip feeder passes the raw Android `content://` through.
- `MessageActionsHandler` copied `playablePath` into `inputBlobUrl` unconditionally, under a comment that said "Null on native".
- `VideoPayloadProcessor` resolved `payload.filePath` correctly via `withResolvedFile`, then discarded that result with `inputBlobUrl ?: payload.filePath`. Native ffmpeg cannot open a `content://` URI.

## Why it surfaced now (regression, not new code)

The Android gallery path has fed ffmpeg the raw URI since 2026-06-18 (`20a72d3ef`). Until 2026-08-17 Android's `compressVideo` returned null on a missing input and the processor fell back to uploading the resolved original, so the send succeeded but the video shipped uncompressed. `316c4d3b2` ("Fail the send when a transcode fails, rather than shipping the original") removed that fallback and turned the latent bug into a hard failure. A side effect of this fix is that gallery-strip videos on Android are now compressed for the first time.

## The fix

- `VideoPayloadProcessor`: `inputBlobUrl?.takeIf { it.isBlobUrl() } ?: payload.filePath`. This is the single choke point every video payload passes through (chat, moments, share, vault), so it is the invariant from acceptance criterion 2.
- `MessageActionsHandler`: only carry `playablePath` into `inputBlobUrl` when it is a `blob:` URL, so the `AttachmentInput`/`PayloadFile` docs ("web-only, null on native") are true again.
- `String.isBlobUrl()` in `homebase-api` `StringExtensions`; the five existing bare `startsWith("blob:")` checks in web source sets now use it. No behavior change there.
- Corrected the `AttachmentHandler` comment that claimed the send path was untouched by `playablePath`.

Deliberately **not** done: routing the gallery strip through `materializeForUpload` (the issue's belt-and-braces idea). Android gallery URIs are MediaStore items read under the app's own media permission, not a transient picker grant, so the #1420 stale-grant hazard does not apply, and it would add a full-size copy on every gallery tap on top of the send-time `resolved_*` copy. On iOS the gallery handle is a bare PHAsset identifier that FileKit `copyTo` cannot open, so the existing `resolveToFilePath` special case has to stay either way.

## Tests

- `VideoPayloadProcessorCompressionSeamTest`: the fake `FileOperationsProvider` now models `resolveToFilePath` (content:// → copy). New `contentUriInputIsResolvedBeforeCompressionEvenWhenInputBlobUrlIsNotABlob` fails without the processor change (`expected /cache/resolved_1457.mp4 but was content://media/…`) and passes with it. New `blobInputBlobUrlStillFeedsFfmpegDirectly` pins web behavior.
- `MessageAttachmentBuilderTrimTest`: pins that the builder forwards `inputBlobUrl` untouched, so the guard cannot silently migrate to the wrong layer.

Compile matrix green: `homebase-api` and `homebase-chat` on JVM, Android, wasmJs, plus test sources. `homebase-api:jvmTest` and `homebase-chat:jvmTest` green.

## Still to verify on device

- [ ] Android: gallery strip → video → send (compresses + uploads, bubble plays)
- [ ] Android: file picker / camera / share-sheet video send unchanged
- [ ] iOS: gallery quick-switch video send and editor preview still work

## Follow-ups (out of scope)

- Snapshot-on-pick (`materializeForUpload`) for the moments composer and the Android share-preview re-pick, which still hold raw platform handles across time.
- The iOS attach-time `resolveToFilePath` in `AttachmentHandler.handleAttachGalleryItem` writes a `resolved_*` temp file that nothing reaps on send.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018oaD6R9dVELCdBePha3MHH
