### PR TITLE
Guard the attachment editor against a stale pager index

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MediaAttachmentEditor.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MediaAttachmentEditor.kt
@@ -219,7 +219,8 @@ fun MediaAttachmentEditor(
                 userScrollEnabled = true,
                 beyondViewportPageCount = 1
             ) { page ->
-                when (val attachment = attachments[page]) {
+                // The pager composes a stale page index for one frame after the list shrinks.
+                when (val attachment = attachments.getOrNull(page) ?: return@HorizontalPager) {
                     is AttachmentPendingFile.File -> {
                         val isPdf = remember(attachment.file) {
                             resolveContentType(fileName = attachment.file.name) == "application/pdf"
@@ -430,7 +431,7 @@ fun MediaAttachmentEditor(
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 attachments.forEach { attachment ->
-                    val isSelected = attachments[pagerState.currentPage].attachmentId == attachment.attachmentId
+                    val isSelected = activeAttachment?.attachmentId == attachment.attachmentId
                     Box(
                         modifier = Modifier
                             .size(60.dp)


### PR DESCRIPTION
Crash reported via TestFlight on **1.4.1804** (iPhone 15 Pro, iOS 26.5.2) — `EXC_CRASH (SIGABRT)` from an unhandled `IndexOutOfBoundsException`.

```
0  kotlin.collections.ArrayList#get                     (ArrayList.kt:98)
1  MediaAttachmentEditor$$inlined$Column$4.invoke       (MediaAttachmentEditor.kt:400)
2  AnimatedVisibility                                   (AnimatedVisibility.kt:271)
3  MediaAttachmentEditor                                (MediaAttachmentEditor.kt:185)
```

## Cause

The attachment-strip row indexed the list with the pager's page index:

```kotlin
val isSelected = attachments[pagerState.currentPage].attachmentId == attachment.attachmentId
```

The X button that removes an attachment sits in that same `Row`, on the selected thumbnail. Swipe to the last attachment (`currentPage == N-1`) and tap X: `attachments` drops to `N-1` entries, but `PagerState.currentPage` doesn't settle until the pager re-measures. The strip recomposes first and reads one past the end. With a single attachment the list goes empty and `attachments[0]` throws immediately.

The stack pins it to the `AnimatedVisibility(visible = !collapseSecondaryChrome)` strip block, and that was the only `attachments[...]` inside it.

## Fix

`isSelected` now compares against `activeAttachment`, the `attachments.getOrNull(pagerState.currentPage)` already computed above for the video-trim controls — same reactivity, no new state, and the unsafe index is gone rather than clamped.

Two other reads of the same value in this file (lines 187 and 574) already used `getOrNull`; this line was the outlier.

The pager's own content lambda got the same guard. It reads `attachments[page]`, and the crash proves the list shrinks underneath it, so a stale `page` is reachable there for the same frame.

## Verification

`:homebase-chat:compileKotlinJvm` and `:homebase-chat:compileKotlinIosSimulatorArm64` both clean.

Not device-tested — reproducing it needs the exact one-frame window between the removal and the pager re-measure. Both changes are local, total two lines, and remove an index that the stack trace shows throwing.