### PR TITLE
Resolve ContactRepository on demand in ContactInfoGateway

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/contacts/ContactInfoGateway.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/contacts/ContactInfoGateway.kt
@@ -11,7 +11,9 @@ import kotlin.uuid.ExperimentalUuidApi
 // The one place that reaches /pub/profile and /pub/image. A known contact's name resolves from
 // the synced Contacts drive; the public endpoints serve everything else.
 class ContactInfoGateway internal constructor(
-    private val contactRepository: ContactRepository,
+    // Resolved on demand: the Coil ImageLoader builds a PublicImageFetcher.Factory holding this
+    // gateway before DatabaseManager.initialize() runs, and ContactRepository needs the database.
+    private val contactRepository: () -> ContactRepository,
     private val publicProfiles: PublicProfileProviderCached,
 ) {
 
@@ -34,9 +36,10 @@ class ContactInfoGateway internal constructor(
     suspend fun clearCaches() = publicProfiles.clearCaches()
 
     private suspend fun localContact(odinId: OdinId): Contact? {
-        contactRepository.ensureLoaded()
+        val repository = contactRepository()
+        repository.ensureLoaded()
         val domain = odinId.domainName
-        return contactRepository.contacts.value.firstOrNull {
+        return repository.contacts.value.firstOrNull {
             it.content.odinId?.equals(domain, ignoreCase = true) == true
         }
     }

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/di/ApiModule.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/di/ApiModule.kt
@@ -167,7 +167,7 @@ val apiModule = module {
     singleOf(::PublicProfileProviderCached)
     // The single supported entry point for a peer's name/avatar/profile; the provider above
     // is internal to this module so nothing else can reach /pub/profile or /pub/image.
-    singleOf(::ContactInfoGateway)
+    single { ContactInfoGateway(contactRepository = { get() }, publicProfiles = get()) }
 
     factoryOf(::SecurityContextProvider)
     factoryOf(::PushNotificationApi)

--- a/homebase-api/src/jvmTest/kotlin/id/homebase/api/client/contacts/ContactInfoGatewayLazyRepositoryTest.kt
+++ b/homebase-api/src/jvmTest/kotlin/id/homebase/api/client/contacts/ContactInfoGatewayLazyRepositoryTest.kt
@@ -1,0 +1,69 @@
+package id.homebase.api.client.contacts
+
+import id.homebase.api.client.profile.PublicProfileProviderCached
+import id.homebase.api.common.OdinId
+import id.homebase.api.file.FileOperationsProvider
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.request.forms.InputProvider
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.runBlocking
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertFalse
+
+/**
+ * The Coil ImageLoader builds a PublicImageFetcher.Factory holding this gateway before
+ * DatabaseManager.initialize() has run. ContactRepository needs the database, so resolving it
+ * from the gateway's constructor kills the launch with a Koin InstanceCreationException wrapping
+ * UninitializedPropertyAccessException.
+ */
+class ContactInfoGatewayLazyRepositoryTest {
+
+    private val imageBytes = ByteArray(32) { it.toByte() }
+
+    private fun provider(): PublicProfileProviderCached {
+        val tempDir = Files.createTempDirectory("hb-gateway-lazy-test").toString()
+        return PublicProfileProviderCached(
+            httpClient = HttpClient(MockEngine { respond(imageBytes, HttpStatusCode.OK) }),
+            scope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
+            fileOperationsProvider = object : FileOperationsProvider {
+                override fun getCacheDirectory() = tempDir
+                override fun openFileInput(path: String): InputProvider = error("unused")
+                override suspend fun readFileBytes(path: String): ByteArray = error("unused")
+                override fun deleteTempFile(path: String) = false
+                override fun getFileSize(path: String) = 0L
+                override suspend fun writeBytesToTempFile(bytes: ByteArray, prefix: String, suffix: String): String = error("unused")
+                override suspend fun writeBytesToShareOutboundFile(bytes: ByteArray, suffix: String): String = error("unused")
+                override suspend fun writeStream(path: String, data: Flow<ByteArray>) = error("unused")
+            },
+        )
+    }
+
+    @Test
+    fun constructionDoesNotResolveContactRepository() {
+        var resolved = false
+        ContactInfoGateway(
+            contactRepository = { resolved = true; error("resolved at construction") },
+            publicProfiles = provider(),
+        )
+        assertFalse(resolved, "constructing the gateway must not resolve ContactRepository")
+    }
+
+    @Test
+    fun avatarBytesDoesNotResolveContactRepository() = runBlocking {
+        var resolved = false
+        val gateway = ContactInfoGateway(
+            contactRepository = { resolved = true; error("resolved during avatar read") },
+            publicProfiles = provider(),
+        )
+        assertContentEquals(imageBytes, gateway.avatarBytes(OdinId("frodobaggins.me")))
+        assertFalse(resolved, "the avatar read must not resolve ContactRepository")
+    }
+}


### PR DESCRIPTION
**Regression from #1456. Build 1813 crashes on every iOS launch.** Reported from TestFlight and reproduced deterministically on the simulator.

```
org.koin.core.error.InstanceCreationException: Could not create instance for '[Singleton: 'coil3.ImageLoader']'
Caused by: ... '[Singleton: 'id.homebase.api.client.contacts.ContactInfoGateway']'
Caused by: ... '[Singleton: 'id.homebase.api.client.contacts.ContactRepository']'
Caused by: ... '[Singleton: 'id.homebase.api.sync.database.DatabaseManager']'
Caused by: kotlin.UninitializedPropertyAccessException: lateinit property instance has not been initialized
```

## Cause

The Coil `ImageLoader` is a **`single(createdAtStart = true)`** singleton, so `startKoin` builds it — and with it `PublicImageFetcher.Factory(get())` — eagerly. #1456 replaced the factory's `PublicProfileProvider` with `ContactInfoGateway`, which held a hard `ContactRepository`, which needs `DatabaseManager`. `apiModule` serves that from `single { DatabaseManager.appDb }`, a read of the `lateinit instance`.

On iOS `startKoin` (`MainViewController.kt:94`) runs ~56 lines **before** `DatabaseManager.initializeWithRecovery` (`:150`), so the eager creation throws and the process dies before writing a log line.

Android (`MainApplication.kt:74`) and Desktop (`Main.kt:125`) initialize the database **before** `startKoin` — Desktop's code even carries a comment describing this exact trap. iOS is the only platform with the order inverted, which is why CI stayed green and only iOS broke.

## Fix

The gateway resolves the repository on demand:

```kotlin
class ContactInfoGateway internal constructor(
    private val contactRepository: () -> ContactRepository,
    private val publicProfiles: PublicProfileProviderCached,
)
```

This restores the exact eager graph that shipped before #1456: `PublicImageFetcher` previously held `PublicProfileProvider`, a thin wrapper over the same `PublicProfileProviderCached`, whose dependencies are HttpClient + `FileOperationsProvider` + scope — no database. Only the `ContactRepository` edge was new, and it is the only one deferred here.

## Verification — A/B on the simulator

Same simulator, same signed-in container, only these two source files differing:

| Build | Result |
|---|---|
| pre-fix (`main`) | dies on launch; `crash-1788365163277.txt` shows the **identical** four-level `Caused by` chain from the TestFlight report |
| with fix | launches to the conversation list; avatars load through the gateway |

Two regression tests assert that constructing the gateway and reading `avatarBytes` never resolve `ContactRepository`. Mutation-tested: reintroducing an eager `contactRepository()` makes both fail.

`:homebase-api:jvmTest`, `:homebase-common:jvmTest`, and the iOS + JVM compiles of `homebase-api` / `homebase-core` are green.

## Follow-up, not in this PR

iOS should initialize the database before `startKoin` like the other two platforms, so the next eager singleton with a database edge can't do this again. Not bundled here: the DB init would also move above `LoggerConfig.initialize()`, losing DB-recovery logs, and iOS startup ordering is #1444 territory. Worth its own PR.