### PR TITLE
Instrument the iOS headless-launch black screen (#1444)

### DIFF
--- a/homebase-common/src/androidMain/kotlin/id/homebase/core/diagnostics/MainThreadWatchdog.kt
+++ b/homebase-common/src/androidMain/kotlin/id/homebase/core/diagnostics/MainThreadWatchdog.kt
@@ -1,6 +1,8 @@
 package id.homebase.core.diagnostics
 
 import android.os.Looper
+import android.os.Process
+import android.os.SystemClock
 
 /**
  * Android stack capture for [MainThreadWatchdog]: snapshots the main `Looper` thread.
@@ -16,3 +18,9 @@ internal actual fun captureMainThreadStackTrace(maxFrames: Int): String? {
         stack.take(maxFrames).forEach { appendLine("    at $it") }
     }
 }
+
+/** `elapsedRealtime` keeps counting through deep sleep and through an app-freezer suspension. */
+internal actual fun captureProcessTimes(): ProcessTimes? = ProcessTimes(
+    cpuMs = Process.getElapsedCpuTime(),
+    continuousMs = SystemClock.elapsedRealtime(),
+)

--- a/homebase-common/src/appleMain/kotlin/id/homebase/core/diagnostics/MainThreadWatchdog.apple.kt
+++ b/homebase-common/src/appleMain/kotlin/id/homebase/core/diagnostics/MainThreadWatchdog.apple.kt
@@ -1,5 +1,18 @@
 package id.homebase.core.diagnostics
 
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.alloc
+import kotlinx.cinterop.convert
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.ptr
+import platform.posix.CLOCK_MONOTONIC
+import platform.posix.RUSAGE_SELF
+import platform.posix.clock_gettime
+import platform.posix.getrusage
+import platform.posix.rusage
+import platform.posix.timespec
+import platform.posix.timeval
+
 /**
  * iOS stack capture for [MainThreadWatchdog].
  *
@@ -10,3 +23,23 @@ package id.homebase.core.diagnostics
  * launch/resume hangs.
  */
 internal actual fun captureMainThreadStackTrace(maxFrames: Int): String? = null
+
+/**
+ * On Darwin (unlike Linux) `CLOCK_MONOTONIC` keeps counting while the device sleeps and while the
+ * process is suspended, which is exactly the "continuous" clock this comparison needs.
+ * `mach_continuous_time` is not exposed by the Kotlin/Native platform libraries.
+ */
+@OptIn(ExperimentalForeignApi::class)
+internal actual fun captureProcessTimes(): ProcessTimes? = memScoped {
+    val usage = alloc<rusage>()
+    if (getrusage(RUSAGE_SELF, usage.ptr) != 0) return@memScoped null
+    val clock = alloc<timespec>()
+    if (clock_gettime(CLOCK_MONOTONIC.convert(), clock.ptr) != 0) return@memScoped null
+    ProcessTimes(
+        cpuMs = usage.ru_utime.toMillis() + usage.ru_stime.toMillis(),
+        continuousMs = clock.tv_sec * 1_000L + clock.tv_nsec / 1_000_000L,
+    )
+}
+
+@OptIn(ExperimentalForeignApi::class)
+private fun timeval.toMillis(): Long = tv_sec * 1_000L + tv_usec / 1_000L

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/diagnostics/MainThreadWatchdog.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/diagnostics/MainThreadWatchdog.kt
@@ -33,7 +33,8 @@ import kotlin.time.TimeSource
  *    `delay(tickIntervalMs)` and compares it to the wall-clock gap after waking up. If the gap
  *    vastly exceeds what was requested, the loop itself was starved — logged as
  *    [StallKind.WatchdogStarved] the instant it recovers. Needs nothing to run *during* the
- *    freeze.
+ *    freeze. Process CPU time is sampled either side of the same gap so the breadcrumb says
+ *    whether the OS suspended us or we froze ourselves (see [classifyStallCause]).
  *  - **[MainThreadLivenessProbe]** (Android/JVM only): a raw OS thread, scheduled directly by
  *    the OS rather than any coroutine dispatcher, independently checks the UI thread is alive.
  *    It survives `Dispatchers.Default` pool exhaustion that would otherwise silence this loop
@@ -116,10 +117,12 @@ class MainThreadWatchdog(
                 // rescheduling us: if that takes far longer than requested, the watchdog's own
                 // loop — not just the UI thread — was starved.
                 val checkpointMs = nowMs()
+                val checkpointTimes = captureProcessTimes()
                 delay(tickIntervalMs)
                 val actualGapMs = nowMs() - checkpointMs
                 val starvedMs = detectWatchdogStarvation(expectedGapMs = tickIntervalMs, actualGapMs = actualGapMs)
                 if (starvedMs != null) {
+                    val processDelta = processTimesDelta(checkpointTimes, captureProcessTimes())
                     val stack = captureMainThreadStackTrace()
                     reporter.reportIfDue {
                         renderStallMessage(
@@ -128,6 +131,7 @@ class MainThreadWatchdog(
                                 source = StallSource.CoroutineLoop,
                                 observedMs = starvedMs,
                                 memory = MemoryDiagnostics.capture(),
+                                processDelta = processDelta,
                             ),
                             stack = stack,
                         )

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/diagnostics/StallEvent.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/diagnostics/StallEvent.kt
@@ -12,7 +12,34 @@ internal data class StallEvent(
     val source: StallSource,
     val observedMs: Long,
     val memory: MemoryDiagnostics.Snapshot? = null,
+    val processDelta: ProcessTimes? = null,
 )
+
+/**
+ * Process CPU time and continuous (sleep-inclusive) wall time, sampled either side of the
+ * watchdog's own suspend point. The pair is what lets a [StallKind.WatchdogStarved] gap say
+ * whether the OS suspended the whole process or the process froze itself.
+ */
+internal data class ProcessTimes(val cpuMs: Long, val continuousMs: Long)
+
+/** Reads this process's cumulative CPU and continuous-clock times, or `null` where unavailable. */
+internal expect fun captureProcessTimes(): ProcessTimes?
+
+internal fun processTimesDelta(before: ProcessTimes?, after: ProcessTimes?): ProcessTimes? {
+    if (before == null || after == null) return null
+    return ProcessTimes(
+        cpuMs = after.cpuMs - before.cpuMs,
+        continuousMs = after.continuousMs - before.continuousMs,
+    )
+}
+
+/**
+ * A gap the process was suspended through burns essentially no CPU; one it spun through burns
+ * CPU roughly in step with the wall clock. That difference is the only thing that separates
+ * "iOS held our foreground request" from "we wedged ourselves".
+ */
+internal fun classifyStallCause(delta: ProcessTimes, cpuShareThreshold: Double = 0.25): String =
+    if (delta.cpuMs < delta.continuousMs * cpuShareThreshold) "OS-SUSPENDED" else "SELF-STALLED"
 
 /**
  * Given the gap this loop iteration expected to sleep for ([expectedGapMs], i.e.
@@ -43,8 +70,11 @@ internal fun renderStallMessage(event: StallEvent, stack: String?): String = bui
         }
 
         StallKind.WatchdogStarved -> {
+            val cause = event.processDelta?.let {
+                ", ${classifyStallCause(it)}: cpu +${it.cpuMs}ms over ${it.continuousMs}ms wall"
+            }.orEmpty()
             appendLine(
-                "${prefix}Process/dispatchers stalled ~${event.observedMs}ms (watchdog starved) — " +
+                "${prefix}Process/dispatchers stalled ~${event.observedMs}ms (watchdog starved$cause) — " +
                     "the watchdog's own loop was delayed; likely Dispatchers.Default pool " +
                     "exhaustion or an OS-level freeze."
             )

--- a/homebase-common/src/commonTest/kotlin/id/homebase/core/diagnostics/MainThreadWatchdogTest.kt
+++ b/homebase-common/src/commonTest/kotlin/id/homebase/core/diagnostics/MainThreadWatchdogTest.kt
@@ -93,6 +93,56 @@ class MainThreadWatchdogTest {
         assertTrue(!withoutMemory.contains("Memory at stall"))
     }
 
+    @Test
+    fun watchdogStarved_withNoCpuBurnedAcrossTheGap_readsOsSuspended() {
+        val message = renderStallMessage(
+            StallEvent(
+                kind = StallKind.WatchdogStarved,
+                source = StallSource.CoroutineLoop,
+                observedMs = 28961,
+                processDelta = ProcessTimes(cpuMs = 3, continuousMs = 28961),
+            ),
+            stack = null,
+        )
+        assertTrue(
+            message.startsWith(
+                "Process/dispatchers stalled ~28961ms (watchdog starved, OS-SUSPENDED: cpu +3ms over 28961ms wall)"
+            ),
+            message,
+        )
+    }
+
+    @Test
+    fun watchdogStarved_withCpuBurnedInStep_readsSelfStalled() {
+        val message = renderStallMessage(
+            StallEvent(
+                kind = StallKind.WatchdogStarved,
+                source = StallSource.CoroutineLoop,
+                observedMs = 28961,
+                processDelta = ProcessTimes(cpuMs = 28400, continuousMs = 28961),
+            ),
+            stack = null,
+        )
+        assertTrue(message.contains("SELF-STALLED: cpu +28400ms over 28961ms wall"), message)
+    }
+
+    // --- classifyStallCause ------------------------------------------------------------------
+
+    @Test
+    fun classifyStallCause_splitsOnTheCpuShareThreshold() {
+        assertEquals("OS-SUSPENDED", classifyStallCause(ProcessTimes(cpuMs = 200, continuousMs = 10_000)))
+        assertEquals("SELF-STALLED", classifyStallCause(ProcessTimes(cpuMs = 9_500, continuousMs = 10_000)))
+    }
+
+    @Test
+    fun processTimesDelta_isNullUnlessBothSamplesExist() {
+        val before = ProcessTimes(cpuMs = 100, continuousMs = 1_000)
+        val after = ProcessTimes(cpuMs = 103, continuousMs = 30_000)
+        assertEquals(ProcessTimes(cpuMs = 3, continuousMs = 29_000), processTimesDelta(before, after))
+        assertNull(processTimesDelta(null, after))
+        assertNull(processTimesDelta(before, null))
+    }
+
     // --- detectWatchdogStarvation ----------------------------------------------------------
 
     @Test

--- a/homebase-common/src/jvmMain/kotlin/id/homebase/core/diagnostics/MainThreadWatchdog.jvm.kt
+++ b/homebase-common/src/jvmMain/kotlin/id/homebase/core/diagnostics/MainThreadWatchdog.jvm.kt
@@ -17,3 +17,9 @@ internal actual fun captureMainThreadStackTrace(maxFrames: Int): String? {
         edt.value.take(maxFrames).forEach { appendLine("    at $it") }
     }
 }
+
+/**
+ * A desktop JVM process is never suspended by the OS the way a mobile app is, so the
+ * OS-suspended-vs-self-stalled split has nothing to distinguish here.
+ */
+internal actual fun captureProcessTimes(): ProcessTimes? = null

--- a/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/diagnostics/MainThreadWatchdog.web.kt
+++ b/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/diagnostics/MainThreadWatchdog.web.kt
@@ -4,3 +4,5 @@ package id.homebase.core.diagnostics
 // stack the way the JVM/native actuals do — there is nothing to render. Returning null matches
 // the expect's contract for platforms that can't capture a foreign thread's stack.
 internal actual fun captureMainThreadStackTrace(maxFrames: Int): String? = null
+
+internal actual fun captureProcessTimes(): ProcessTimes? = null

--- a/homebase-core/src/nativeMain/kotlin/id/homebase/core/diagnostics/IosGpuTextDiagnostics.kt
+++ b/homebase-core/src/nativeMain/kotlin/id/homebase/core/diagnostics/IosGpuTextDiagnostics.kt
@@ -104,3 +104,12 @@ fun installGpuTextDiagnostics() {
 fun logPrevention(note: String) {
     Logger.i(tag = GpuTextDiagnostics.TAG) { "prevention: $note" }
 }
+
+/**
+ * Swift-callable launch/lifecycle breadcrumb, same tag as [logPrevention] so one grep gives the
+ * whole "why did this process start → when did the scene go active → when was ComposeView built"
+ * timeline. Exported as `IosGpuTextDiagnosticsKt.logLaunchTrace(note:)`.
+ */
+fun logLaunchTrace(note: String) {
+    Logger.i(tag = GpuTextDiagnostics.TAG) { "launch: $note" }
+}

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -26,8 +26,9 @@ struct ContentView: View {
     // Compose's first frame then renders while backgrounded, iOS rejects the Metal submissions, and
     // the glyph atlas is born dead → all text blank at the first real foreground (fingerprint
     // fontCacheUsed=6889 count=4, 3/3 field captures). Latched true forever after — backgrounding
-    // later must NOT tear the view down.
-    @State private var hasBeenActive = false
+    // later must NOT tear the view down — hence the process-scoped seed: SwiftUI can drop this
+    // view's identity and a plain @State would come back false, un-building a live ComposeView.
+    @State private var hasBeenActive = ComposeGate.hasBeenActive
     // Crash recovery: when a crash report from the previous run is pending, show the
     // native SwiftUI recovery screen INSTEAD of Compose until the user taps Continue
     // (which runs the deferred heavy init and flips pendingReportPath back to nil).
@@ -48,8 +49,9 @@ struct ContentView: View {
                     .ignoresSafeArea()
             } else {
                 // Native placeholder while the scene has never been active (background launch, or
-                // the first milliseconds of a normal launch before .active lands).
-                Color(UIColor.systemBackground)
+                // the first milliseconds of a normal launch before .active lands). Mirrors the
+                // UILaunchScreen dict in Info.plist so the handoff from it is seamless.
+                LaunchPlaceholderView()
                     .ignoresSafeArea()
             }
 
@@ -64,11 +66,13 @@ struct ContentView: View {
             // when we appear, onChange never fires — latch here so a later backgrounding can never
             // un-build ComposeView (tearing it down on .background would recreate the very bug).
             if scenePhase == .active && !hasBeenActive {
+                ComposeGate.hasBeenActive = true
                 hasBeenActive = true
                 IosGpuTextDiagnosticsKt.logPrevention(note: "appeared already .active — ComposeView built immediately")
             }
         }
-        .onChange(of: scenePhase) { _, newPhase in
+        .onChange(of: scenePhase) { oldPhase, newPhase in
+            IosGpuTextDiagnosticsKt.logLaunchTrace(note: "scenePhase \(oldPhase) → \(newPhase)")
             switch newPhase {
             case .inactive:
                 if VaultPrivacyBridge.shared.shouldProtect {
@@ -83,12 +87,29 @@ struct ContentView: View {
                 // PREVENTION latch: first .active ever → ComposeView gets built now (and stays built
                 // through later backgrounding). Log it so homebase.log shows the deferral timeline.
                 if !hasBeenActive {
+                    ComposeGate.hasBeenActive = true
                     hasBeenActive = true
                     IosGpuTextDiagnosticsKt.logPrevention(note: "first .active — ComposeView built now (deferred since launch)")
                 }
             default:
                 break
             }
+        }
+    }
+}
+
+/// Latch outliving any ContentView instance.
+private enum ComposeGate {
+    static var hasBeenActive = false
+}
+
+/// Mirrors the Info.plist `UILaunchScreen` dict: LaunchBackground behind a centred LaunchLogo
+/// at its natural size (`UIImageRespectsSafeAreaInsets` false).
+private struct LaunchPlaceholderView: View {
+    var body: some View {
+        ZStack {
+            Color("LaunchBackground")
+            Image("LaunchLogo")
         }
     }
 }

--- a/iosApp/iosApp/iOSApp.swift
+++ b/iosApp/iosApp/iOSApp.swift
@@ -34,6 +34,13 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
           MainViewControllerKt.initializeApp()
       }
 
+      // After initializeApp() because that is what installs Kermit's file writer. Key names only:
+      // launchOptions values carry payload. appState raw: 0=active, 1=inactive, 2=background.
+      let launchKeys = (launchOptions ?? [:]).keys.map { $0.rawValue }.sorted().joined(separator: ",")
+      let prewarm = ProcessInfo.processInfo.environment["ActivePrewarm"] ?? "0"
+      IosGpuTextDiagnosticsKt.logLaunchTrace(
+          note: "didFinishLaunching keys=[\(launchKeys)] prewarm=\(prewarm) appState=\(application.applicationState.rawValue)")
+
       //By default showPushNotification value is true.
       //When set showPushNotification to false foreground push  notification will not be shown.
       //You can still get notification content using #onPushNotification listener method.C


### PR DESCRIPTION
Instrumentation only for #1444 — this does **not** attempt to fix the black screen.

The ~30s black screen on a rare background/headless launch currently leaves no evidence
that can tell the two stories apart:

- **Story A** — the user tapped the icon late; the process resumed instantly on tap and the
  real blackout was short.
- **Story B** — the user tapped early and iOS held the foreground request for ~29s
  (SpringBoard/RunningBoard stall).

The primary trace (2026-09-01 15:08) shows `Process/dispatchers stalled ~28961ms (watchdog
starved)` — a number that is identical under either story. These four changes make the next
field occurrence self-diagnosing.

### 1. Launch reason (`iOSApp.swift`)

Logs `didFinishLaunching keys=[…] prewarm=… appState=N` — which `UIApplication.LaunchOptionsKey`s
are present (key rawValues only; the values carry payload), `ActivePrewarm`, and
`applicationState`. Placed after `initializeApp()` because that is what installs Kermit's file
writer — logging earlier lands in the console only, not `homebase.log`.

### 2. The watchdog gap classifies itself (`StallEvent.kt` + platform actuals)

A stall now samples process CPU time alongside the wall clock and reports a verdict:

```
Process/dispatchers stalled ~28961ms (watchdog starved, OS-SUSPENDED: cpu +3ms over 28961ms wall)
Process/dispatchers stalled ~28961ms (watchdog starved, SELF-STALLED: cpu +28400ms over 28961ms wall)
```

Near-zero CPU across a huge wall gap means the OS suspended us (Story B). CPU growing in step
with wall means we wedged ourselves. The existing message prefix is preserved so old greps
still match, and where a platform has no CPU source the line renders exactly as it does today.

Apple uses `getrusage(RUSAGE_SELF)` + `clock_gettime(CLOCK_MONOTONIC)` — `mach_continuous_time`
is not exposed by the Kotlin/Native platform klibs, and on Darwin `CLOCK_MONOTONIC` is the
sleep-inclusive clock (unlike Linux). Android uses `Process.getElapsedCpuTime()` +
`SystemClock.elapsedRealtime()`; JVM and wasmJs return null.

### 3. Every lifecycle transition (`ContentView.swift`)

`.onChange(of: scenePhase)` swallowed `.background` in its `default:` branch. It now logs
`scenePhase <old> → <new>` first, so the log shows the whole `background → inactive → active`
timeline on one grep with the launch reason and the ComposeView-built line.

### 4. Placeholder and latch (`ContentView.swift`)

**The placeholder was pure black.** `Color(UIColor.systemBackground)` in dark mode is
indistinguishable from a dead app, which is most of why this reads as a crash rather than a
slow launch. It now renders `LaunchBackground` + `LaunchLogo`, mirroring the `UILaunchScreen`
dict in `Info.plist` so the handoff from the launch screen is seamless. The identical colour
inside `PrivacyOverlayView` is untouched.

**`hasBeenActive` was a real latent bug.** As `@State` it resets to `false` when SwiftUI drops
the view's identity, which would tear down a live `ComposeView` while backgrounded — exactly
the condition the glyph-atlas comment warns against. The truth now lives in a process-scoped
`ComposeGate`, seeding the `@State` so the flip still invalidates the view.

### Not changed

The background location session is untouched, `ComposeView` is not built any earlier, and it is
not torn down on backgrounding. The `hasBeenActive || scenePhase == .active` gate keeps its
exact semantics.

### Verification

| Command | Result |
| --- | --- |
| `./gradlew :homebase-common:compileKotlinIosSimulatorArm64 :homebase-core:compileKotlinIosSimulatorArm64` | pass |
| `./gradlew homebase-common:jvmTest` | pass — `MainThreadWatchdogTest` 14 tests incl. 4 new |
| `./gradlew :homebase-common:compileAndroidMain :homebase-common:compileKotlinWasmJs` | pass |
| `xcodebuild -scheme iosApp -configuration Debug -destination 'platform=iOS Simulator,…'` | BUILD SUCCEEDED, signed |
| `assetutil --info Assets.car \| grep Launch` | `LaunchBackground` and `LaunchLogo` both resolve in the built bundle |

A simulator run cannot exercise what this instruments — the deferral window on a normal launch
is milliseconds, and the headless path needs a real background-location cold start. Installed and
launched on a physical iPhone 15 (iOS 26.6.1, the same model as the field crash reports); all three
new line types appear in `homebase.log`:

```
17:35:49.654  (StartupLogger) ========== APP STARTUP ==========
17:35:49.665  (GpuTextDiag) event=ColdStart fontCacheUsed=0 …
17:35:49.692  (GpuTextDiag) launch: didFinishLaunching keys=[] prewarm=0 appState=2
17:35:49.770  (GpuTextDiag) launch: scenePhase inactive → active
17:35:49.770  (GpuTextDiag) prevention: first .active — ComposeView built now (deferred since launch)
```

`appState=2` is `.background` — even this ordinary launch begins backgrounded, and the deferral
window is now measurable end to end: 78 ms here, against the ~29 s of the field trace. That single
number is the thing that was previously unobservable.

The classification line is not in this capture because no stall occurred during the run; it is
covered by the 4 new unit tests, and needs a real stall to appear in the field.

Closes nothing — #1444 stays open until a field occurrence comes back with a verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6McDnpKJjiPQN6b4w5ofx
