### PR TITLE
Stop reading an unreachable security context as "all permissions granted"

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/youauth/PermissionExtensionManager.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/youauth/PermissionExtensionManager.kt
@@ -33,12 +33,15 @@ class MissingPermissionsResult(
      * carries the live callback-server port.
      */
     val buildExtendPermissionUrl: () -> String
-) {
-    val hasMissingPermissions: Boolean
-        get() =
-            missingDrives.isNotEmpty() ||
-                    missingPermissions.isNotEmpty() ||
-                    missingAllConnectedCircle
+)
+
+sealed interface PermissionCheckResult {
+    /** The security context could not be fetched, so no verdict was reached. */
+    data object Unknown : PermissionCheckResult
+
+    data object AllGranted : PermissionCheckResult
+
+    data class Missing(val details: MissingPermissionsResult) : PermissionCheckResult
 }
 
 /**
@@ -50,19 +53,13 @@ class PermissionExtensionManager(
     private val securityContextProvider: SecurityContextProvider,
     private val hostIdentity: String
 ) {
-    /**
-     * Check if the app is missing any required permissions.
-     *
-     * @param config Configuration with required drives and permissions
-     * @return MissingPermissionsResult if there are missing permissions, null if all granted
-     */
     suspend fun getMissingPermissions(
         config: PermissionExtensionConfig
-    ): MissingPermissionsResult? {
+    ): PermissionCheckResult {
         val context = securityContextProvider.getSecurityContext()
         if (context == null) {
             Logger.w(tag = TAG) { "Could not fetch security context" }
-            return null
+            return PermissionCheckResult.Unknown
         }
 
         // Get all drive grants from permission groups
@@ -113,31 +110,32 @@ class PermissionExtensionManager(
         val hasAllConnectedCircle = context.caller.isGrantedConnectedIdentitiesSystemCircle
         val missingAllConnectedCircle = config.needsAllConnected && !hasAllConnectedCircle
 
-        // If nothing is missing, return null
         if (missingDrives.isEmpty() &&
             missingPermissions.isEmpty() &&
             !missingAllConnectedCircle
         ) {
-            return null
+            return PermissionCheckResult.AllGranted
         }
 
         val missingPermissionValues = missingPermissions.map { it.value }
 
-        return MissingPermissionsResult(
-            missingDrives = missingDrives,
-            missingPermissions = missingPermissions,
-            missingAllConnectedCircle = missingAllConnectedCircle,
-            buildExtendPermissionUrl = {
-                getExtendPermissionUrl(
-                    host = hostIdentity,
-                    appId = config.appId,
-                    missingDrives = missingDrives,
-                    circleDrives = config.circleDrives,
-                    missingPermissions = missingPermissionValues,
-                    needsAllConnected = missingAllConnectedCircle,
-                    returnUrl = config.returnUrl()
-                )
-            }
+        return PermissionCheckResult.Missing(
+            MissingPermissionsResult(
+                missingDrives = missingDrives,
+                missingPermissions = missingPermissions,
+                missingAllConnectedCircle = missingAllConnectedCircle,
+                buildExtendPermissionUrl = {
+                    getExtendPermissionUrl(
+                        host = hostIdentity,
+                        appId = config.appId,
+                        missingDrives = missingDrives,
+                        circleDrives = config.circleDrives,
+                        missingPermissions = missingPermissionValues,
+                        needsAllConnected = missingAllConnectedCircle,
+                        returnUrl = config.returnUrl()
+                    )
+                }
+            )
         )
     }
 

--- a/homebase-api/src/jvmTest/kotlin/id/homebase/api/youauth/PermissionExtensionManagerTest.kt
+++ b/homebase-api/src/jvmTest/kotlin/id/homebase/api/youauth/PermissionExtensionManagerTest.kt
@@ -1,0 +1,112 @@
+package id.homebase.api.youauth
+
+import id.homebase.api.client.auth.ApiCredentials
+import id.homebase.api.client.auth.CredentialsManager
+import id.homebase.api.common.OdinId
+import id.homebase.api.common.SecureByteArray
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.engine.mock.respondError
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
+
+class PermissionExtensionManagerTest {
+
+    private val me = OdinId("me.example.com")
+    private val driveAlias = "1f2c3d4e5a6b7c8d9e0f1a2b3c4d5e6f"
+    private val driveType = "0a1b2c3d4e5f60718293a4b5c6d7e8f9"
+
+    private val config = PermissionExtensionConfig(
+        appId = "0c3f4e5a6b7c8d9e0f1a2b3c4d5e6f70",
+        appName = "Test App",
+        drives = listOf(
+            TargetDriveAccessRequest(
+                alias = driveAlias,
+                type = driveType,
+                name = "Test drive",
+                description = "Test drive",
+                permissions = listOf(DrivePermission.Read, DrivePermission.Write),
+            )
+        ),
+        permissions = listOf(AppPermissionType.SendPushNotifications),
+        returnUrl = { "https://return.example.com" },
+    )
+
+    // No X-SSE header, so SecurityContextProvider treats the body as plaintext.
+    private fun contextJson(driveGrants: String, keys: String) = """
+        {
+          "caller": { "odinId": "$me", "securityLevel": "owner" },
+          "permissionContext": {
+            "permissionGroups": [
+              { "driveGrants": [$driveGrants], "permissionSet": { "keys": [$keys] } }
+            ]
+          }
+        }
+    """.trimIndent()
+
+    private val grantedDrive = """
+        {
+          "permissionedDrive": {
+            "drive": { "alias": "$driveAlias", "type": "$driveType" },
+            "permission": "readwrite"
+          }
+        }
+    """.trimIndent()
+
+    private fun jsonEngine(body: String) = MockEngine {
+        respond(
+            content = body,
+            status = HttpStatusCode.OK,
+            headers = headersOf(HttpHeaders.ContentType, "application/json"),
+        )
+    }
+
+    private suspend fun manager(engine: MockEngine): PermissionExtensionManager {
+        val credentials = CredentialsManager()
+        credentials.setActiveCredentials(
+            ApiCredentials.create(
+                domain = me,
+                clientAccessToken = "test-token",
+                sharedSecret = SecureByteArray(ByteArray(16) { 1 }),
+            )
+        )
+        return PermissionExtensionManager.create(
+            securityContextProvider = SecurityContextProvider(HttpClient(engine), credentials),
+            hostIdentity = me.domainName,
+        )
+    }
+
+    @Test
+    fun unreachableSecurityContext_isUnknown_notAllGranted() = runTest {
+        val manager = manager(MockEngine { respondError(HttpStatusCode.Unauthorized) })
+        assertEquals(PermissionCheckResult.Unknown, manager.getMissingPermissions(config))
+    }
+
+    @Test
+    fun everythingGranted_isAllGranted() = runTest {
+        val manager = manager(
+            jsonEngine(contextJson(grantedDrive, AppPermissionType.SendPushNotifications.value.toString()))
+        )
+        assertEquals(PermissionCheckResult.AllGranted, manager.getMissingPermissions(config))
+    }
+
+    @Test
+    fun ungrantedDriveAndPermission_areReportedAsMissing() = runTest {
+        val manager = manager(jsonEngine(contextJson("", "")))
+
+        val result = manager.getMissingPermissions(config)
+
+        assertTrue(result is PermissionCheckResult.Missing, "expected Missing, got $result")
+        assertEquals(listOf(driveAlias), result.details.missingDrives.map { it.alias })
+        assertEquals(
+            listOf(AppPermissionType.SendPushNotifications),
+            result.details.missingPermissions,
+        )
+    }
+}

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ExtendPermissionViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ExtendPermissionViewModel.kt
@@ -7,6 +7,7 @@ import id.homebase.api.client.auth.CredentialsManager
 import id.homebase.api.client.eventbus.BackendEvent
 import id.homebase.api.client.eventbus.EventBus
 import id.homebase.api.youauth.MissingPermissionsResult
+import id.homebase.api.youauth.PermissionCheckResult
 import id.homebase.api.youauth.PermissionExtensionConfig
 import id.homebase.api.youauth.PermissionExtensionManager
 import id.homebase.api.youauth.SecurityContextProvider
@@ -37,8 +38,8 @@ class ExtendPermissionViewModel(
      * Flips to true once [checkPermissions] has actually completed against the active
      * credentials at least once. Lets callers (e.g. the feed webview) wait for a
      * permissions verdict before loading content that would otherwise hit the network
-     * with insufficient grants. Stale-VM and no-credentials short-circuits do not flip
-     * this.
+     * with insufficient grants. Stale-VM, no-credentials and unreachable-security-context
+     * outcomes do not flip this.
      */
     private val _permissionsChecked = MutableStateFlow(false)
     val permissionsChecked: StateFlow<Boolean> = _permissionsChecked.asStateFlow()
@@ -137,22 +138,35 @@ class ExtendPermissionViewModel(
                 boundToken = activeToken
             }
             val manager = PermissionExtensionManager.create(securityContextProvider, activeDomain)
-            val result = manager.getMissingPermissions(config)
 
-            if (result != null && result.hasMissingPermissions) {
-                Logger.i(tag = TAG) {
-                    "Missing permissions detected: drives=${result.missingDrives.size}, permissions=${result.missingPermissions.size}, allConnected=${result.missingAllConnectedCircle}"
+            when (val result = manager.getMissingPermissions(config)) {
+                // An unreachable security context is not a grant. Leaving _permissionsChecked
+                // false is the point: a wrong verdict cached here would be treated as final
+                // for the rest of the session.
+                PermissionCheckResult.Unknown ->
+                    Logger.w(tag = TAG) {
+                        "Security context unavailable — permissions left unverified"
+                    }
+
+                is PermissionCheckResult.Missing -> {
+                    val details = result.details
+                    Logger.i(tag = TAG) {
+                        "Missing permissions detected: drives=${details.missingDrives.size}, permissions=${details.missingPermissions.size}, allConnected=${details.missingAllConnectedCircle}"
+                    }
+                    lastMissingResult = details
+                    _permissionsGranted.value = false
+                    _uiState.value =
+                        ExtendPermissionUiState.ShowDialog(appName = config.appName)
+                    _permissionsChecked.value = true
                 }
-                lastMissingResult = result
-                _permissionsGranted.value = false
-                _uiState.value =
-                    ExtendPermissionUiState.ShowDialog(appName = config.appName)
-            } else {
-                Logger.d(tag = TAG) { "All permissions are granted" }
-                lastMissingResult = null
-                _permissionsGranted.value = true
+
+                PermissionCheckResult.AllGranted -> {
+                    Logger.d(tag = TAG) { "All permissions are granted" }
+                    lastMissingResult = null
+                    _permissionsGranted.value = true
+                    _permissionsChecked.value = true
+                }
             }
-            _permissionsChecked.value = true
         } catch (e: Exception) {
             Logger.e(throwable = e, tag = TAG) { "Error checking permissions: ${e.message}" }
         }

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/conversationlist/ExtendPermissionViewModelTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/conversationlist/ExtendPermissionViewModelTest.kt
@@ -1,0 +1,140 @@
+package id.homebase.chat.conversationlist
+
+import id.homebase.api.client.auth.ApiCredentials
+import id.homebase.api.client.auth.CredentialsManager
+import id.homebase.api.client.eventbus.EventBus
+import id.homebase.api.common.OdinId
+import id.homebase.api.common.SecureByteArray
+import id.homebase.api.youauth.DrivePermission
+import id.homebase.api.youauth.PermissionExtensionConfig
+import id.homebase.api.youauth.SecurityContextProvider
+import id.homebase.api.youauth.TargetDriveAccessRequest
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.engine.mock.respondError
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.withTimeoutOrNull
+
+class ExtendPermissionViewModelTest {
+
+    private val me = OdinId("me.example.com")
+    private val driveAlias = "1f2c3d4e5a6b7c8d9e0f1a2b3c4d5e6f"
+    private val driveType = "0a1b2c3d4e5f60718293a4b5c6d7e8f9"
+
+    private val config = PermissionExtensionConfig(
+        appId = "0c3f4e5a6b7c8d9e0f1a2b3c4d5e6f70",
+        appName = "Test App",
+        drives = listOf(
+            TargetDriveAccessRequest(
+                alias = driveAlias,
+                type = driveType,
+                name = "Test drive",
+                description = "Test drive",
+                permissions = listOf(DrivePermission.Read, DrivePermission.Write),
+            )
+        ),
+        permissions = emptyList(),
+        returnUrl = { "https://return.example.com" },
+    )
+
+    // No X-SSE header, so SecurityContextProvider treats the body as plaintext.
+    private fun contextJson(driveGrants: String) = """
+        {
+          "caller": { "odinId": "$me", "securityLevel": "owner" },
+          "permissionContext": {
+            "permissionGroups": [ { "driveGrants": [$driveGrants] } ]
+          }
+        }
+    """.trimIndent()
+
+    private val grantedDrive = """
+        {
+          "permissionedDrive": {
+            "drive": { "alias": "$driveAlias", "type": "$driveType" },
+            "permission": "readwrite"
+          }
+        }
+    """.trimIndent()
+
+    private fun jsonEngine(body: String) = MockEngine {
+        respond(
+            content = body,
+            status = HttpStatusCode.OK,
+            headers = headersOf(HttpHeaders.ContentType, "application/json"),
+        )
+    }
+
+    private suspend fun viewModel(engine: MockEngine): ExtendPermissionViewModel {
+        val credentials = CredentialsManager()
+        credentials.setActiveCredentials(
+            ApiCredentials.create(
+                domain = me,
+                clientAccessToken = "test-token",
+                sharedSecret = SecureByteArray(ByteArray(16) { 1 }),
+            )
+        )
+        return ExtendPermissionViewModel(
+            securityContextProvider = SecurityContextProvider(HttpClient(engine), credentials),
+            credentialsManager = credentials,
+            eventBus = EventBus(),
+            config = config,
+        )
+    }
+
+    @BeforeTest
+    fun setUp() = Dispatchers.setMain(Dispatchers.Default)
+
+    @AfterTest
+    fun tearDown() = Dispatchers.resetMain()
+
+    @Test
+    fun unreachableSecurityContext_doesNotReportPermissionsGranted() = runBlocking<Unit> {
+        val engine = MockEngine { respondError(HttpStatusCode.Unauthorized) }
+        val vm = viewModel(engine)
+
+        val granted = withTimeoutOrNull(2.seconds) { vm.permissionsGranted.first { it } }
+
+        assertNull(granted, "a 401 on /auth/context must not read as a grant")
+        assertEquals(1, engine.requestHistory.size, "the context must actually have been asked for")
+        assertFalse(vm.permissionsChecked.value, "an unknown verdict must not be cached as checked")
+        assertEquals(ExtendPermissionUiState.Idle, vm.uiState.value)
+    }
+
+    @Test
+    fun everythingGranted_reportsPermissionsGranted() = runBlocking<Unit> {
+        val vm = viewModel(jsonEngine(contextJson(grantedDrive)))
+
+        withTimeout(10.seconds) { vm.permissionsChecked.first { it } }
+
+        assertTrue(vm.permissionsGranted.value)
+    }
+
+    @Test
+    fun missingDrive_reportsNotGranted_andSurfacesTheDialog() = runBlocking<Unit> {
+        val vm = viewModel(jsonEngine(contextJson("")))
+
+        withTimeout(10.seconds) { vm.permissionsChecked.first { it } }
+
+        assertFalse(vm.permissionsGranted.value)
+        assertEquals(ExtendPermissionUiState.ShowDialog(config.appName), vm.uiState.value)
+        assertNotNull(vm.buildExtendPermissionUrl(), "the missing drive must reach the extend URL")
+    }
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/email/EmailViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/email/EmailViewModel.kt
@@ -72,10 +72,6 @@ class EmailViewModel(
         // mounting a drive the identity never created leaves DriveSync retrying `400
         // InvalidDrive` once a second forever, and writes the drive into the cross-device
         // registry, which makes it survive a restart and re-mount on every future login.
-        //
-        // The permission check cannot stand in for this: it reports "granted" when it could not
-        // reach the security context at all, so a failed lookup used to read as permission to
-        // mount. Seen on a fresh identity that had never been through the approval flow.
         viewModelScope.launch {
             emailPermissionViewModel.permissionsGranted.filter { it }.collect {
                 // Re-read the status FIRST. The grant is what provisions the drive, so the


### PR DESCRIPTION
A 401 on `/auth/context` currently reads as **"all permissions granted"**, which green-lights a
drive activation that 401s and terminates the process.

Found while device-testing on a physical iPhone: the app died ~1 s after every launch, five times
across two builds (including one from Aug 28, so this is standing behaviour, not a regression).

### The fail-open

```
SecurityContextProvider.kt:51    catches the 401, returns null
PermissionExtensionManager.kt:56 returns null for "couldn't reach the context"
                                 …the SAME null it returns for "nothing is missing" (:117)
ExtendPermissionViewModel.kt:151 else branch → _permissionsGranted.value = true
                                 logs "All permissions are granted"
```

One `null`, two opposite meanings. The caller cannot tell them apart, so an unreachable security
context is indistinguishable from a clean bill of health.

`EmailViewModel.kt:70-77` already documented this in a comment — *"it reports 'granted' when it
could not reach the security context at all, so a failed lookup used to read as permission to
mount"* — and worked around it locally. This fixes it at the source, so all seven consumers
(Moments, Location, Feed, Vault, WebDrop, Email, Chat) benefit rather than just the one.

### The fix

```kotlin
sealed interface PermissionCheckResult {
    data object Unknown : PermissionCheckResult
    data object AllGranted : PermissionCheckResult
    data class Missing(val details: MissingPermissionsResult) : PermissionCheckResult
}
```

A sealed result rather than an extra flag, so the compiler forces every caller to name all three
cases. A future caller cannot silently re-conflate them, which is exactly how this arose.
`Unknown` leaves both `permissionsGranted` and `permissionsChecked` false — the app neither claims
permission it could not verify nor caches the wrong answer.

Also removes `MissingPermissionsResult.hasMissingPermissions`: `Missing` is only constructed when
something is missing, so it had become a constant `true` with no callers.

### Scope

`getMissingPermissions` has exactly one caller repo-wide (`ExtendPermissionViewModel.kt:140`). The
seven features each get their own `ExtendPermissionViewModel` instance from `AppModule.kt` with a
different `PermissionExtensionConfig`, all funnelling through that one call.

`EmailViewModel`'s `driveProvisioned` gate is **kept** — its load-bearing job is drive *existence*,
not permission. Mounting is local, so mounting a drive the identity never created leaves DriveSync
retrying `400 InvalidDrive` once a second forever. A permission grant is not proof the drive
exists. Only the now-false comment paragraph was removed.

### Tests

Six new, driving the real `SecurityContextProvider` over a Ktor `MockEngine` (following
`FeedPermissionServiceTest`), no production seam needed:

- `unreachableSecurityContext_isUnknown_notAllGranted` / `…_doesNotReportPermissionsGranted`
- `everythingGranted_isAllGranted` / `…_reportsPermissionsGranted`
- `ungrantedDriveAndPermission_areReportedAsMissing` / `missingDrive_reportsNotGranted_andSurfacesTheDialog`

Mutation-checked twice. Reverting the manager fix fails 2 tests; leaving the manager correct but
re-introducing the fail-open in the ViewModel's `Unknown` branch fails 1 — so both layers are
guarded independently.

The negative test asserts `withTimeoutOrNull(2s) { permissionsGranted.first { it } } == null`
**and** `engine.requestHistory.size == 1`, so it cannot pass vacuously by the request never firing.

### Verification

| Command | Result |
| --- | --- |
| `./gradlew homebase-api:jvmTest homebase-chat:jvmTest homebase-common:jvmTest` | 3148 tests, 0 failures |
| `./gradlew :homebase-api:compileKotlinIosSimulatorArm64 :homebase-chat:… :homebase-core:…` | pass |
| `./gradlew :homebase-api:compileAndroidMain :homebase-chat:… :homebase-core:…` | pass |
| `./gradlew :homebase-core:compileKotlinJvm :homebase-api:compileKotlinWasmJs` | pass |

### Device verification

Built and installed on a physical iPhone 15 (iOS 26.6.1) against the same identity that crashed
5/5 launches across two builds. **No crash** — the crash directory is empty where it previously
held five reports, and the new branch is visible in `homebase.log`:

```
18:49:02.412  SecurityContextProvider: Error fetching security context: Unauthorized
18:49:02.412  PermissionExtensionManager: Could not fetch security context
18:49:02.413  ExtendPermissionViewModel: Security context unavailable — permissions left unverified
```

The identical 401 previously logged *"All permissions are granted"*, activated the drive, and
terminated the process ~285 ms later. The app now survives it.

Surviving that first second let the app reach the WebSocket, whose pre-existing dead-token
detection then did its job — `client token is dead — logging out`, DB wipe, Login screen. That is
correct behaviour and is not changed by this PR; it is only reachable now because the process
stops dying before the WS connects. Worth knowing when testing: a genuinely dead token will end at
Login rather than in the app.

### Scope note

This removes the *trigger*, not the amplifier. The unguarded `viewModelScope.launch` around drive
activation still turns any uncaught 401 into a process kill; #1465
handles the 401 half of that, and the broader 381-site coroutine-handler migration is not attempted
in either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6McDnpKJjiPQN6b4w5ofx
