### PR TITLE
Route a REST 401 to the auth layer instead of the uncaught handler

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/ForbiddenException.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/ForbiddenException.kt
@@ -15,9 +15,10 @@ class ForbiddenException(
  * Used by the platform uncaught-exception handlers exactly like [isTransientNetworkFailure] and
  * [isRecoverableServerConflict], for a 403 that leaks from a write on a scope with no
  * CoroutineExceptionHandler of its own (a bare `viewModelScope.launch`). Deliberately narrow:
- * 403 only. A 401 stays fatal — an invalid token is an auth-state problem the auth layer has to
- * act on, not something to keep running through. Walks the cause chain defensively (guards
- * against a cyclic chain).
+ * 403 only. A 401 stays fatal *to the uncaught handler* — the auth layer already heard about that
+ * response through [id.homebase.api.client.auth.AuthFailureReporter], so anything reaching the
+ * uncaught handler with one is a path that should have caught it. Walks the cause chain
+ * defensively (guards against a cyclic chain).
  */
 fun Throwable.isRecoverablePermissionFailure(): Boolean {
     val seen = HashSet<Throwable>()

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/OdinApiProviderBase.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/OdinApiProviderBase.kt
@@ -109,6 +109,25 @@ abstract class OdinApiProviderBase(
             throw e
         }
 
+    /**
+     * Route the verdict on this device's app token to whoever registered as the
+     * [id.homebase.api.client.auth.AuthFailureReporter] — one call per response, so a consecutive
+     * count downstream corresponds to distinct server answers.
+     *
+     * Own identity host only. `PeerFileByGlobalTransitProvider`'s CDN fallback answers 401 for
+     * every drive whose AllowCdn is off (the default), and that request carries no token at all —
+     * counting those would log the user out on the first feed scroll.
+     */
+    private suspend fun reportAuthOutcome(response: HttpResponse) {
+        val status = response.status.value
+        if (status != 401 && status !in 200..299) return
+        val ownHost = credentialsManager.getActiveDomain()?.domainName ?: return
+        if (!response.call.request.url.host.equals(ownHost, ignoreCase = true)) return
+
+        if (status == 401) credentialsManager.reportRestUnauthorized()
+        else credentialsManager.reportRestAuthorized()
+    }
+
     protected suspend fun request(
         block: suspend () -> HttpResponse,
         secret: SecureByteArray?
@@ -120,6 +139,7 @@ abstract class OdinApiProviderBase(
             val r = block()
             r to r.body<String>()
         }
+        reportAuthOutcome(response)
 
         // Decrypt when the server flags it (X-SSE) OR the body is unmistakably the shared-secret
         // envelope. The header is the fast path used on native; but browsers strip non-safelisted
@@ -188,6 +208,7 @@ abstract class OdinApiProviderBase(
                 r to r.readRawBytes()
             }
         }
+        reportAuthOutcome(response)
 
         val contentType =
             response.headers["decryptedcontenttype"]

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/UnauthorizedException.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/UnauthorizedException.kt
@@ -2,3 +2,20 @@ package id.homebase.api.client
 
 class UnauthorizedException :
     OdinApiException(401, "Unauthorized")
+
+/**
+ * True when [this] (or anything in its cause chain) is a 401. The response that produced it was
+ * already routed to the auth layer by `OdinApiProviderBase.reportAuthOutcome`, so a caller
+ * matching on this is deciding only what to do locally — never whether the token gets acted on.
+ * Walks the cause chain defensively (guards against a cyclic chain), like
+ * [isRecoverablePermissionFailure].
+ */
+fun Throwable.isUnauthorized(): Boolean {
+    val seen = HashSet<Throwable>()
+    var cur: Throwable? = this
+    while (cur != null && seen.add(cur)) {
+        if (cur is UnauthorizedException) return true
+        cur = cur.cause
+    }
+    return false
+}

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/auth/AuthFailureReporter.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/auth/AuthFailureReporter.kt
@@ -1,0 +1,19 @@
+package id.homebase.api.client.auth
+
+/**
+ * How a REST response reaches the auth layer. Declared here, in the module that issues the
+ * requests, and implemented in the module that owns the session — `homebase-api` must not depend
+ * on `homebase-core`/`homebase-common`, so the auth layer registers itself via
+ * [CredentialsManager.setAuthFailureReporter] instead of being injected into all 21
+ * [id.homebase.api.client.OdinApiProviderBase] subclasses.
+ *
+ * Only responses from the identity host we sent the token to are reported — see
+ * `OdinApiProviderBase.reportAuthOutcome`.
+ */
+interface AuthFailureReporter {
+    /** The identity host rejected this token. One call per 401 response. */
+    fun onRestUnauthorized()
+
+    /** The identity host accepted this token. One call per 2xx response. */
+    fun onRestAuthorized()
+}

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/auth/CredentialsManager.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/auth/CredentialsManager.kt
@@ -7,12 +7,30 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlin.concurrent.Volatile
 
 class CredentialsManager {
     private val mutex = Mutex()
     private val storedCredentials = mutableMapOf<String, ApiCredentials>()
 
     private var activeCredentials: ApiCredentials? = null
+
+    // Deliberately outside [mutex]: the report fires from every HTTP response, and taking the
+    // credentials lock there would serialize the whole client on it.
+    @Volatile
+    private var authFailureReporter: AuthFailureReporter? = null
+
+    fun setAuthFailureReporter(reporter: AuthFailureReporter?) {
+        authFailureReporter = reporter
+    }
+
+    fun reportRestUnauthorized() {
+        authFailureReporter?.onRestUnauthorized()
+    }
+
+    fun reportRestAuthorized() {
+        authFailureReporter?.onRestAuthorized()
+    }
 
     private val _credentialsFlow = MutableStateFlow<ApiCredentials?>(null)
     val credentialsFlow: StateFlow<ApiCredentials?> = _credentialsFlow.asStateFlow()

--- a/homebase-api/src/jvmTest/kotlin/id/homebase/api/client/RestAuthOutcomeReportingTest.kt
+++ b/homebase-api/src/jvmTest/kotlin/id/homebase/api/client/RestAuthOutcomeReportingTest.kt
@@ -1,0 +1,135 @@
+package id.homebase.api.client
+
+import id.homebase.api.client.auth.ApiCredentials
+import id.homebase.api.client.auth.AuthFailureReporter
+import id.homebase.api.client.auth.CredentialsManager
+import id.homebase.api.common.OdinId
+import id.homebase.api.common.SecureByteArray
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.request.get
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+private const val OWN_HOST = "test.homebase.id"
+
+// The CDN fallback in PeerFileByGlobalTransitProvider: no bearer token, and 401 is its ordinary
+// answer for a peer drive with AllowCdn off (the default). Counting those would log a user out on
+// the first feed scroll.
+private const val CDN_HOST = "cdn.ravenhosting.cloud"
+
+class RestAuthOutcomeReportingTest {
+
+    private class Recorder : AuthFailureReporter {
+        var unauthorized = 0
+        var authorized = 0
+        override fun onRestUnauthorized() {
+            unauthorized++
+        }
+
+        override fun onRestAuthorized() {
+            authorized++
+        }
+    }
+
+    private class TestProvider(
+        httpClient: HttpClient,
+        credentialsManager: CredentialsManager,
+    ) : OdinApiProviderBase(httpClient, credentialsManager) {
+        suspend fun read(url: String): ApiResponse =
+            request({ httpClient.get(url) }, secret = null)
+
+        suspend fun readBytes(url: String): ByteApiResponse =
+            requestBytes { httpClient.get(url) }
+    }
+
+    private suspend fun setup(
+        vararg statusByHost: Pair<String, HttpStatusCode>,
+    ): Pair<TestProvider, Recorder> {
+        val statuses = statusByHost.toMap()
+        val engine = MockEngine { request ->
+            respond(
+                content = "{}",
+                status = statuses[request.url.host] ?: HttpStatusCode.OK,
+                headers = headersOf(
+                    "Content-Type" to listOf(ContentType.Application.Json.toString()),
+                ),
+            )
+        }
+        val cm = CredentialsManager()
+        cm.setActiveCredentials(
+            ApiCredentials.create(
+                domain = OdinId(OWN_HOST),
+                clientAccessToken = "test-token",
+                sharedSecret = SecureByteArray("test-secret".encodeToByteArray()),
+            )
+        )
+        val recorder = Recorder()
+        cm.setAuthFailureReporter(recorder)
+        return TestProvider(HttpClient(engine), cm) to recorder
+    }
+
+    @Test
+    fun reportsUnauthorizedOnIdentityHost401() = runTest {
+        val (provider, recorder) = setup(OWN_HOST to HttpStatusCode.Unauthorized)
+
+        provider.read("https://$OWN_HOST/api/v2/anything")
+
+        assertEquals(1, recorder.unauthorized, "a REST 401 must reach the auth layer")
+        assertEquals(0, recorder.authorized)
+    }
+
+    @Test
+    fun reportsAuthorizedOnIdentityHost2xx() = runTest {
+        val (provider, recorder) = setup(OWN_HOST to HttpStatusCode.OK)
+
+        provider.read("https://$OWN_HOST/api/v2/anything")
+
+        assertEquals(1, recorder.authorized, "a 2xx is the proof of life that resets the streak")
+        assertEquals(0, recorder.unauthorized)
+    }
+
+    @Test
+    fun reportsOncePerResponseIncludingByteReads() = runTest {
+        val (provider, recorder) = setup(OWN_HOST to HttpStatusCode.Unauthorized)
+
+        provider.read("https://$OWN_HOST/api/v2/anything")
+        provider.readBytes("https://$OWN_HOST/api/v2/payload")
+
+        assertEquals(2, recorder.unauthorized, "byte reads 401 too, and each response counts once")
+    }
+
+    @Test
+    fun ignoresA401FromAHostWeDidNotAuthenticateAgainst() = runTest {
+        val (provider, recorder) = setup(CDN_HOST to HttpStatusCode.Unauthorized)
+
+        provider.readBytes("https://$CDN_HOST/?forward=whatever")
+
+        assertEquals(0, recorder.unauthorized, "an AllowCdn-off 401 says nothing about our token")
+        assertEquals(0, recorder.authorized)
+    }
+
+    @Test
+    fun ignoresA2xxFromAHostWeDidNotAuthenticateAgainst() = runTest {
+        val (provider, recorder) = setup(CDN_HOST to HttpStatusCode.OK)
+
+        provider.readBytes("https://$CDN_HOST/?forward=whatever")
+
+        assertEquals(0, recorder.authorized, "a CDN hit must not clear evidence of a dead token")
+    }
+
+    @Test
+    fun ignoresStatusesThatSayNothingAboutTheToken() = runTest {
+        val (provider, recorder) = setup(OWN_HOST to HttpStatusCode.Forbidden)
+
+        provider.read("https://$OWN_HOST/api/v2/anything")
+
+        assertEquals(0, recorder.unauthorized)
+        assertEquals(0, recorder.authorized)
+    }
+}

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/auth/AuthConnectionCoordinator.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/auth/AuthConnectionCoordinator.kt
@@ -2,6 +2,7 @@ package id.homebase.core.auth
 
 import androidx.compose.runtime.Immutable
 import co.touchlab.kermit.Logger
+import id.homebase.api.client.auth.AuthFailureReporter
 import id.homebase.api.client.auth.CredentialsManager
 import id.homebase.api.client.auth.OwnerSessionRepository
 import id.homebase.api.client.drives.TargetDrive
@@ -25,6 +26,7 @@ import id.homebase.core.config.mandatorySyncDrives
 import id.homebase.core.sync.DriveRegistry
 import id.homebase.core.avatars.AppConnectionStatus
 import id.homebase.core.session.IdentitySessionScope
+import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -107,6 +109,13 @@ class AuthConnectionCoordinator(
     // specifically said 401 to this token.
     @Volatile
     private var consecutiveUpgradeAuthFailures = 0
+
+    // The REST half of the same detection. A token can die while the WS is deliberately parked
+    // (backgrounded on a push-capable platform), and every REST call then 401s with nothing
+    // watching — the state the field logs show: hours of `Unauthorized` under authState ==
+    // Authenticated. Counted separately from the WS streak because the two have different reset
+    // rules; both feed the one threshold and the one logout.
+    private val restAuthFailures = RestUnauthorizedCounter { startDeadTokenLogout() }
 
     // logout() has no internal in-flight guard and wipes the DB, so two concurrent callers would
     // each run a full wipe. 401s keep arriving during the ~seconds logout takes; this latches.
@@ -212,6 +221,7 @@ class AuthConnectionCoordinator(
 
     init {
         Logger.i(tag = "AuthLifecycle") { "AuthCC: collector started" }
+        credentialsManager.setAuthFailureReporter(restAuthFailures)
         scope.launch {
             youAuthFlowManager.authState.collect {
                 onAuthStateChanged(it)
@@ -572,6 +582,7 @@ class AuthConnectionCoordinator(
                     // Also clears the latch: a later session on this same process whose token
                     // dies must be able to trigger the logout again.
                     consecutiveUpgradeAuthFailures = 0
+                    restAuthFailures.onRestAuthorized()
                     deadTokenLogoutStarted = false
                     logLifecycleSnapshot("onConnected")
                     scope.launch {
@@ -1010,6 +1021,26 @@ internal const val DEAD_TOKEN_THRESHOLD = 3
  */
 internal fun nextUpgradeAuthFailureCount(previous: Int, error: Throwable): Int =
     if (error.isWebSocketUpgradeUnauthorized()) previous + 1 else 0
+
+/**
+ * [DEAD_TOKEN_THRESHOLD] consecutive REST 401s from the identity host means the same thing an
+ * upgrade-401 streak does — the token is void — and calls [onDeadToken]. Any 2xx from that host
+ * resets the streak, so hours of intermittent 401s can never accumulate into a logout; only an
+ * unbroken run of them can. Atomic because responses land on several dispatcher threads at once.
+ */
+internal class RestUnauthorizedCounter(
+    private val onDeadToken: () -> Unit,
+) : AuthFailureReporter {
+    private val consecutive = atomic(0)
+
+    override fun onRestUnauthorized() {
+        if (consecutive.incrementAndGet() >= DEAD_TOKEN_THRESHOLD) onDeadToken()
+    }
+
+    override fun onRestAuthorized() {
+        consecutive.value = 0
+    }
+}
 
 // Match compareStringUuId's normalization so drive ids compare regardless of hyphen/case format.
 internal fun normalizeDriveId(driveId: String): String = driveId.lowercase().replace("-", "")

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/sync/DriveRegistry.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/sync/DriveRegistry.kt
@@ -18,6 +18,7 @@ import id.homebase.api.client.eventbus.BackendEvent
 import id.homebase.api.client.eventbus.EventBus
 import id.homebase.api.client.isRecoverablePermissionFailure
 import id.homebase.api.client.isTransientNetworkFailure
+import id.homebase.api.client.isUnauthorized
 import id.homebase.api.crypto.ByteArrayUtil
 import id.homebase.api.serialization.OdinSystemSerializer
 import id.homebase.api.sync.database.DatabaseManager
@@ -290,17 +291,21 @@ class DriveRegistry(
 
     /**
      * Register [drive] without letting the registry write decide whether the activation
-     * happens. Two failures are contained, both of which mean "the server would not take the
+     * happens. Three failures are contained, all of which mean "the server would not take the
      * write", never "the client is broken":
      *
-     *  - a transport failure (offline, timeout, dropped socket), and
+     *  - a transport failure (offline, timeout, dropped socket),
      *  - a 403 on the Chat drive that holds the registry file — the app token's write grant was
-     *    revoked or narrowed in the owner console.
+     *    revoked or narrowed in the owner console, and
+     *  - a 401 — the whole token is void. `OdinApiProviderBase` already routed that response to
+     *    [AuthFailureReporter], which is the component that can actually end the session;
+     *    rethrowing here would only add a process death on the way there, and would count the
+     *    one server response a second time if it re-reported it.
      *
-     * In both cases the drive stays out of the cross-device list until a later activation
+     * In all three the drive stays out of the cross-device list until a later activation
      * re-registers it, and [AuthConnectionCoordinator.mountDrive] carries on to mount it
      * locally — which is the caller's actual goal and works off a read grant this write does not
-     * gate. Rethrowing the 403 instead both aborted the local mount and, because every add-on
+     * gate. Rethrowing instead both aborted the local mount and, because every add-on
      * activates from a `viewModelScope.launch` with no CoroutineExceptionHandler, killed the
      * process. Every other failure still propagates.
      */
@@ -311,9 +316,14 @@ class DriveRegistry(
             throw e
         } catch (e: Throwable) {
             val transport = e.isTransientNetworkFailure()
-            if (!transport && !e.isRecoverablePermissionFailure()) throw e
+            val unauthorized = e.isUnauthorized()
+            if (!transport && !unauthorized && !e.isRecoverablePermissionFailure()) throw e
             Logger.w(tag = TAG, throwable = e) {
-                val reason = if (transport) "a transport failure" else "a 403 on the Chat drive"
+                val reason = when {
+                    transport -> "a transport failure"
+                    unauthorized -> "a 401 — the auth layer has been told"
+                    else -> "a 403 on the Chat drive"
+                }
                 "addDrive(${drive.label}) hit $reason — not registered this session"
             }
         }

--- a/homebase-common/src/jvmTest/kotlin/id/homebase/core/auth/DeadTokenLogoutTest.kt
+++ b/homebase-common/src/jvmTest/kotlin/id/homebase/core/auth/DeadTokenLogoutTest.kt
@@ -77,6 +77,59 @@ class DeadTokenLogoutTest {
         assertEquals(2, count)
         assertEquals(0, nextUpgradeAuthFailureCount(count, IOException("Connection reset")))
     }
+
+    // ---------- REST half: the same threshold, fed by OdinApiProviderBase ----------
+
+    @Test
+    fun `consecutive REST 401s reach the threshold and trigger the logout`() {
+        var logouts = 0
+        val counter = RestUnauthorizedCounter { logouts++ }
+
+        repeat(DEAD_TOKEN_THRESHOLD - 1) { counter.onRestUnauthorized() }
+        assertEquals(0, logouts, "below the threshold nothing happens")
+
+        counter.onRestUnauthorized()
+        assertEquals(1, logouts)
+    }
+
+    // The acceptance criterion for the REST path: a session that 401s once an hour for a day must
+    // never log out, because the successful calls in between clear the streak.
+    @Test
+    fun `a 2xx between 401s prevents the streak from ever completing`() {
+        var logouts = 0
+        val counter = RestUnauthorizedCounter { logouts++ }
+
+        repeat(10) {
+            repeat(DEAD_TOKEN_THRESHOLD - 1) { counter.onRestUnauthorized() }
+            counter.onRestAuthorized()
+        }
+
+        assertEquals(0, logouts, "intermittent 401s must not accumulate into a logout")
+    }
+
+    @Test
+    fun `the streak restarts from zero after a 2xx`() {
+        var logouts = 0
+        val counter = RestUnauthorizedCounter { logouts++ }
+
+        repeat(DEAD_TOKEN_THRESHOLD - 1) { counter.onRestUnauthorized() }
+        counter.onRestAuthorized()
+        counter.onRestUnauthorized()
+
+        assertEquals(0, logouts, "one 401 after a reset is one, not DEAD_TOKEN_THRESHOLD")
+    }
+
+    // startDeadTokenLogout() latches internally, but the counter keeps counting while logout runs —
+    // it must not stop reporting, and it must not be the thing that dedupes.
+    @Test
+    fun `401s past the threshold keep firing so the latch downstream owns dedup`() {
+        var logouts = 0
+        val counter = RestUnauthorizedCounter { logouts++ }
+
+        repeat(DEAD_TOKEN_THRESHOLD + 2) { counter.onRestUnauthorized() }
+
+        assertEquals(3, logouts)
+    }
 }
 
 private class CyclicThrowable : RuntimeException("boom") {

--- a/homebase-common/src/jvmTest/kotlin/id/homebase/core/sync/DriveRegistryTest.kt
+++ b/homebase-common/src/jvmTest/kotlin/id/homebase/core/sync/DriveRegistryTest.kt
@@ -7,6 +7,7 @@ import id.homebase.api.client.OdinClientErrorCode
 import id.homebase.api.client.ProblemDetails
 import id.homebase.api.client.UnauthorizedException
 import id.homebase.api.client.auth.ApiCredentials
+import id.homebase.api.client.auth.AuthFailureReporter
 import id.homebase.api.client.auth.CredentialsManager
 import id.homebase.api.client.drives.HomebaseFile
 import id.homebase.api.client.drives.SystemDriveConstants
@@ -347,19 +348,62 @@ class DriveRegistryTest {
         db.close()
     }
 
+    // A 401 IS acted on by the auth layer — OdinApiProviderBase reported this very response to the
+    // registered AuthFailureReporter before the exception was ever thrown. Rethrowing it here only
+    // added a process death (mountDrive's contract is "must not throw") on the way to a logout that
+    // was already under way.
     @Test
-    fun addDriveBestEffortPropagatesUnauthorized() = runTest {
-        // 401 is not a permission denial to shrug off — the auth layer has to act on a dead
-        // token. Guards the containment from widening past 403.
+    fun addDriveBestEffortContainsUnauthorized() = runTest {
+        val db = createTestDatabaseManager()
+        val recorder = WriteRecorder(uploadThrowsOnCall = { UnauthorizedException() })
+        val registry = buildRegistry(db, recorder = recorder)
+
+        registry.addDriveBestEffort(feedLabeledDrive)
+
+        assertEquals(1, recorder.uploads.size, "the write was attempted, and refused")
+        db.close()
+    }
+
+    @Test
+    fun unauthorizedDoesNotEscapeAViewModelScopedActivation() = runTest {
         val db = createTestDatabaseManager()
         val registry = buildRegistry(
             db,
             recorder = WriteRecorder(uploadThrowsOnCall = { UnauthorizedException() }),
         )
 
-        assertFailsWith<UnauthorizedException> {
-            registry.addDriveBestEffort(feedLabeledDrive)
-        }
+        var escaped: Throwable? = null
+        val viewModelLikeScope = CoroutineScope(
+            SupervisorJob() + Dispatchers.Unconfined + CoroutineExceptionHandler { _, e -> escaped = e },
+        )
+
+        viewModelLikeScope.launch { registry.addDriveBestEffort(feedLabeledDrive) }.join()
+
+        assertNull(escaped, "a 401 on the registry write must not reach the uncaught path; was: $escaped")
+        db.close()
+    }
+
+    // The counter downstream corroborates a dead token from distinct server responses. This layer
+    // sees an exception, not a response, so it must not add a second report for the one 401 the
+    // HTTP layer already counted.
+    @Test
+    fun addDriveBestEffortDoesNotDoubleReportTheSame401() = runTest {
+        val db = createTestDatabaseManager()
+        val credentialsManager = CredentialsManager()
+        var unauthorizedReports = 0
+        credentialsManager.setAuthFailureReporter(object : AuthFailureReporter {
+            override fun onRestUnauthorized() { unauthorizedReports++ }
+            override fun onRestAuthorized() {}
+        })
+        val registry = buildRegistry(
+            db,
+            recorder = WriteRecorder(uploadThrowsOnCall = { UnauthorizedException() }),
+            credentialsManager = credentialsManager,
+        )
+
+        registry.addDriveBestEffort(feedLabeledDrive)
+
+        assertEquals(0, unauthorizedReports, "the response was already reported by OdinApiProviderBase")
         db.close()
     }
 
@@ -926,8 +970,8 @@ class DriveRegistryTest {
         db: DatabaseManager,
         eventBus: EventBus = EventBus(),
         recorder: WriteRecorder = WriteRecorder(),
+        credentialsManager: CredentialsManager = CredentialsManager(),
     ): DriveRegistry {
-        val credentialsManager = CredentialsManager()
         kotlinx.coroutines.runBlocking {
             credentialsManager.setActiveCredentials(
                 ApiCredentials.create(


### PR DESCRIPTION
`ForbiddenException.kt:17` states the policy:

> *"A 401 stays fatal — an invalid token is an auth-state problem the auth layer has to act on."*

The auth layer never receives one. This makes that sentence true.

### What exists today

- **Ktor has no 401 handling at all.** `HttpClientProvider.kt:30-48` installs four plugins: a
  request breadcrumb, `ContentNegotiation`, `ContentEncoding`, `HttpTimeout`. No `Auth`, no
  `HttpResponseValidator`, no `HttpSend`. Tokens go on per-call via `bearerAuth(...)`.
- **`OdinApiProviderBase.kt:543` throws `UnauthorizedException` and tells nothing.**
  That exception has **zero production catchers** — 13 repo hits are 1 declaration, 1 throw, 11 tests.
- **The only 401→logout path is the WebSocket** (`AuthConnectionCoordinator.kt:626`), which counts
  consecutive *upgrade* 401s. The WS is deliberately parked while backgrounded (`:1031`), so a
  token that dies in the background is invisible until foreground. A REST 401 never reaches it.
- **`restoreSession` emits `Authenticated` after three `SecureStorage` reads and no network call**
  (`YouAuthFlowManager.kt:178-186`). A revoked token restores identically to a valid one.

Observed on a physical iPhone: an entire session of `Unauthorized` — connections refresh, security
context, pending-upgrade check, seven peer `verifyTemporalAccess` — all under `authState ==
Authenticated`, ending in a process kill.

### The change

**A. Report the outcome.** `AuthFailureReporter` is declared in `homebase-api` and implemented in
`homebase-common`, registered through `CredentialsManager` — which is already a constructor param
of all 21 `OdinApiProviderBase` subclasses, so no constructor churn, and is a DI singleton so tests
get isolation free. Dependency direction holds: the module issuing requests declares the interface,
the module owning the session implements it.

Reporting lives in `request()` / `requestBytes()`, **not** `throwForFailure`. That has 95 call
sites and many callers inspect status themselves without calling it, so both the 401s and — worse —
the 2xx resets would be missed. One report per HTTP response is the invariant the threshold needs.

**Host-scoped, and this part is load-bearing.** `PeerFileByGlobalTransitProvider.kt:213` fetches
peer media from `cdn.ravenhosting.cloud` **with no bearer token**, where 401 is the ordinary answer
for any drive with `AllowCdn` off — which is the default. Counting those would sign the user out on
the first feed scroll. Only a response from the identity host whose token we sent counts; all
`/peer/…` transit calls are our own host answering about our token, so they count. Two tests pin
both directions.

**B. Count and act.** `RestUnauthorizedCounter` reuses the existing `DEAD_TOKEN_THRESHOLD` and
`startDeadTokenLogout()` rather than inventing a parallel mechanism. Separate streak from the WS
counter — the two have different reset rules, and sharing one int would let a WS network blip erase
REST evidence. Resets on any own-host 2xx and on WS connect. atomicfu, since responses land on
several dispatcher threads.

**C. `mountDrive` honours its own contract.** `AuthConnectionCoordinator.kt:708` says *"Must not
throw: callers activate add-ons from a viewModelScope with no handler"* — and the next line called
`addDriveBestEffort`, which contained transport failures and 403 but rethrew 401
(`DriveRegistry.kt:314`). Now it contains 401 too: the registry write is abandoned (the server
refused it), the local mount proceeds (the caller's actual goal, off a read grant this write does
not gate), and the dead token reaches the one component that can end the session.

`DriveRegistryTest.kt:351` pinned the rethrow. Rewritten to assert *contained and reported*.
Changing a test to match new behaviour is justified here only because the behaviour it pinned
contradicted a documented contract 400 lines away.

### Deliberately not done

- **No report from `addDriveBestEffort`** — that 401 already came from `request()`, so a second
  report would count one server answer twice and break the consecutive-distinct-responses
  invariant. `addDriveBestEffortDoesNotDoubleReportTheSame401` pins that.
- **No blocking token validation in `restoreSession`** — it would slow every cold start and still
  miss a token that dies mid-session. (`YouAuthProvider.hasValidToken()` exists with zero callers;
  left alone.)
- **No `ktor-client-auth`**, no new dependencies.
- **Not** widening the crash-handler allowlist to contain 401 — that buries auth bugs on all four
  platforms, and three containment tests deliberately refuse it.

### Tests

`RestAuthOutcomeReportingTest` (MockEngine): reports on own-host 401 and 2xx, once per response
including byte reads, ignores both 401 and 2xx from a host we did not authenticate against, ignores
statuses that say nothing about the token. Plus 4 in `DeadTokenLogoutTest` and 3 in
`DriveRegistryTest`.

Mutation-checked five ways — dropping the report calls, dropping the host guard, no-op'ing the
reset, never firing at threshold, and removing the containment each failed exactly the guards they
should:

| Mutation | Tests failed |
| --- | --- |
| Drop both `reportAuthOutcome` calls | 3 |
| Drop the host guard | 2 |
| `onRestAuthorized()` → no-op | 2 |
| Never call `onDeadToken` at threshold | 2 |
| Remove `!unauthorized` containment | 3 |

### Verification

| Command | Result |
| --- | --- |
| `./gradlew homebase-api:jvmTest homebase-common:jvmTest homebase-chat:jvmTest` | pass |
| `./gradlew :homebase-api:compileKotlinIosSimulatorArm64 :homebase-common:… :homebase-core:…` | pass |
| `./gradlew :homebase-api:compileAndroidMain :homebase-common:compileAndroidMain` | pass |

Independent of #1464, which removes the trigger that surfaced this. Neither attempts the 381-site
`viewModelScope.launch` handler migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6McDnpKJjiPQN6b4w5ofx
