### PR TITLE
Write Event RSVP, Groodle and Poll votes as idempotent set-state, not toggles

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/files/DriveOutboxUploader.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/files/DriveOutboxUploader.kt
@@ -450,14 +450,25 @@ class DriveOutboxUploader(
         val lock = reactionSetLocksGuard.withLock {
             reactionSetLocks.getOrPut(request.fileId) { Mutex() }
         }
+        val row = outboxRecord.uniqueId
+        Logger.i(
+            "$TAG setReactions: row=$row file=${request.fileId} attempt=${outboxRecord.checkOutCount + 1} " +
+                "remove=${request.remove} add=${request.add} recipients=${request.recipients.size}"
+        )
         lock.withLock {
             for (reaction in request.remove) {
-                reactionProvider.deleteReaction(
-                    driveId = request.driveId,
-                    fileId = request.fileId,
-                    reaction = reaction,
-                    recipients = request.recipients,
-                )
+                try {
+                    reactionProvider.deleteReaction(
+                        driveId = request.driveId,
+                        fileId = request.fileId,
+                        reaction = reaction,
+                        recipients = request.recipients,
+                    )
+                    Logger.i("$TAG setReactions: row=$row deleted $reaction")
+                } catch (t: Throwable) {
+                    Logger.e("$TAG setReactions: row=$row FAILED deleting $reaction: ${t.message}")
+                    throw t
+                }
             }
             for (reaction in request.add) {
                 try {
@@ -467,12 +478,19 @@ class DriveOutboxUploader(
                         reaction = reaction,
                         recipients = request.recipients,
                     )
+                    Logger.i("$TAG setReactions: row=$row added $reaction")
                 } catch (e: ClientException) {
                     // The server's add is not idempotent: a reaction that already landed (an
                     // earlier attempt of this row, or the user's other device) is a 400. The
                     // desired state holds, so it is a success for a set-state row.
-                    if (!e.isDuplicateReaction()) throw e
-                    Logger.i("$TAG setReactions: reaction already present on ${request.fileId} — treating as applied")
+                    if (!e.isDuplicateReaction()) {
+                        Logger.e("$TAG setReactions: row=$row FAILED adding $reaction: ${e.message}")
+                        throw e
+                    }
+                    Logger.i("$TAG setReactions: row=$row $reaction already present — treating as applied")
+                } catch (t: Throwable) {
+                    Logger.e("$TAG setReactions: row=$row FAILED adding $reaction: ${t.message}")
+                    throw t
                 }
             }
         }

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/files/DriveOutboxUploader.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/files/DriveOutboxUploader.kt
@@ -23,6 +23,7 @@ import id.homebase.api.client.drives.upload.UploadFileRequest
 import id.homebase.api.client.drives.upload.validateForUpload
 import id.homebase.api.crypto.ByteArrayUtil
 import id.homebase.api.client.drives.files.reactions.DriveFileGroupReactionProvider
+import id.homebase.api.client.drives.files.reactions.SetReactionsOutboxRequest
 import id.homebase.api.client.drives.files.reactions.ToggleReactionOutboxRequest
 import id.homebase.api.client.eventbus.BackendEvent
 import id.homebase.api.client.eventbus.EventBus
@@ -30,6 +31,8 @@ import id.homebase.api.serialization.OdinSystemSerializer
 import id.homebase.api.sync.database.DatabaseManager
 import id.homebase.api.sync.database.Outbox
 import id.homebase.api.sync.database.OutboxUploader
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlin.uuid.Uuid
 
 class DriveOutboxUploader(
@@ -54,6 +57,7 @@ class DriveOutboxUploader(
                 UpdateLocalMetadataContent -> updateLocalMetadataContent(outboxRecord)
                 SendReadReceiptByFileIds -> sendReadReceiptByFileIds(outboxRecord)
                 ToggleReaction -> toggleReaction(outboxRecord)
+                SetReactions -> setReactions(outboxRecord)
                 DeleteFilesByGroupId -> deleteFilesByGroupId(outboxRecord)
             }
         } catch (e: ClientException) {
@@ -435,6 +439,48 @@ class DriveOutboxUploader(
         )
     }
 
+    // Rows for the same file may be checked out by parallel workers; a newer
+    // set-state must apply strictly after an older in-flight one, or the two
+    // interleave and the older one's adds land last.
+    private val reactionSetLocks = mutableMapOf<Uuid, Mutex>()
+    private val reactionSetLocksGuard = Mutex()
+
+    private suspend fun setReactions(outboxRecord: Outbox) {
+        val request = OdinSystemSerializer.deserialize<SetReactionsOutboxRequest>(outboxRecord.json.decodeToString())
+        val lock = reactionSetLocksGuard.withLock {
+            reactionSetLocks.getOrPut(request.fileId) { Mutex() }
+        }
+        lock.withLock {
+            for (reaction in request.remove) {
+                reactionProvider.deleteReaction(
+                    driveId = request.driveId,
+                    fileId = request.fileId,
+                    reaction = reaction,
+                    recipients = request.recipients,
+                )
+            }
+            for (reaction in request.add) {
+                try {
+                    reactionProvider.addReaction(
+                        driveId = request.driveId,
+                        fileId = request.fileId,
+                        reaction = reaction,
+                        recipients = request.recipients,
+                    )
+                } catch (e: ClientException) {
+                    // The server's add is not idempotent: a reaction that already landed (an
+                    // earlier attempt of this row, or the user's other device) is a 400. The
+                    // desired state holds, so it is a success for a set-state row.
+                    if (!e.isDuplicateReaction()) throw e
+                    Logger.i("$TAG setReactions: reaction already present on ${request.fileId} — treating as applied")
+                }
+            }
+        }
+    }
+
+    private fun ClientException.isDuplicateReaction(): Boolean =
+        status == 400 && message?.contains("duplicate reaction", ignoreCase = true) == true
+
     private suspend fun deleteFilesByGroupId(outboxRecord: Outbox) {
         val request = OdinSystemSerializer.deserialize<DeleteFilesByGroupIdOutboxRequest>(outboxRecord.json.decodeToString())
         fileProvider.deleteFilesByGroupId(request.driveId, request.groupIds)
@@ -453,6 +499,8 @@ class DriveOutboxUploader(
         const val SendReadReceiptByFileIds = 7L
         const val ToggleReaction = 8L
         const val DeleteFilesByGroupId = 9L
+        // 10 and 11 belong to ScheduledPushOutboxUploader; CompositeOutboxUploader routes on these ids.
+        const val SetReactions = 12L
     }
 }
 

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/files/reactions/SetReactionsOutboxRequest.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/drives/files/reactions/SetReactionsOutboxRequest.kt
@@ -1,0 +1,20 @@
+package id.homebase.api.client.drives.files.reactions
+
+import id.homebase.api.common.OdinId
+import kotlinx.serialization.Serializable
+import kotlin.uuid.Uuid
+
+/**
+ * Declarative reaction state for one scope of a file (an event's RSVP, one
+ * Groodle slot, a poll): every reaction in [remove] is deleted, then every one
+ * in [add] is added. Both halves are idempotent, so a retried or replayed row
+ * converges on the same server state instead of flipping like a toggle.
+ */
+@Serializable
+data class SetReactionsOutboxRequest(
+    val driveId: Uuid,
+    val fileId: Uuid,
+    val add: List<String>,
+    val remove: List<String>,
+    val recipients: List<OdinId>,
+)

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/client/notifications/ScheduledPushOutboxUploader.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/client/notifications/ScheduledPushOutboxUploader.kt
@@ -191,7 +191,7 @@ class ScheduledPushOutboxUploader(
     companion object {
         private const val TAG = "ScheduledPushOutboxUploader"
 
-        // uploadType ids — continue the DriveOutboxUploader sequence (1..9) without overlapping it.
+        // uploadType ids — continue the DriveOutboxUploader sequence (1..9, 12) without overlapping it.
         const val SchedulePush = 10L
         const val CancelPush = 11L
     }

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/OutboxSync.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/OutboxSync.kt
@@ -885,6 +885,13 @@ class OutboxSync(
             )
             return EnqueueResult.WouldStrandCreate
         }
+        if (existing != null) {
+            Logger.i(
+                "OutboxSync: replaceEnqueue superseding pending uniqueId=$uniqueId " +
+                    "${existing.uploadTypeLabel()} attempts=${existing.checkOutCount} " +
+                    "inFlight=${existing.checkOutStamp != null} with ${uploadTypeName(uploadType)}"
+            )
+        }
         databaseManager.outbox.deleteBy(driveId, uniqueId)
         return tryEnqueue(driveId, uniqueId, dependencyUniqueId, priority, uploadType, json)
     }

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/OutboxSync.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/OutboxSync.kt
@@ -6,6 +6,7 @@ import id.homebase.api.client.isTransientNetworkFailure
 import id.homebase.api.client.drives.files.DeleteLocalFilesByFileIdRequest
 import id.homebase.api.client.drives.files.DriveOutboxUploader
 import id.homebase.api.client.drives.files.SendReadReceiptByFileIdsOutboxRequest
+import id.homebase.api.client.drives.files.reactions.SetReactionsOutboxRequest
 import id.homebase.api.client.drives.files.reactions.ToggleReactionOutboxRequest
 import id.homebase.api.client.notifications.CancelScheduledPushRequest
 import id.homebase.api.client.notifications.ScheduledPushOutboxUploader
@@ -47,6 +48,7 @@ private fun uploadTypeName(t: Long): String = when (t) {
     DriveOutboxUploader.SendReadReceiptByFileIds -> "SendReadReceiptByFileIds"
     DriveOutboxUploader.ToggleReaction -> "ToggleReaction"
     DriveOutboxUploader.DeleteFilesByGroupId -> "DeleteFilesByGroupId"
+    DriveOutboxUploader.SetReactions -> "SetReactions"
     else -> "Unknown"
 }
 
@@ -809,6 +811,29 @@ class OutboxSync(
             dependencyUniqueId = dependencyUniqueId,
             priority = priority,
             uploadType = DriveOutboxUploader.ToggleReaction,
+            json = OdinSystemSerializer.serialize(request)
+        ),
+        sendNow,
+    )
+
+    /**
+     * One row per [uniqueId] (a per-scope key derived by the caller): a newer set-state for
+     * the same scope supersedes a pending one instead of queueing behind it, so rapid taps
+     * converge on the last state and a backed-off stale row can never replay over a fresh one.
+     */
+    public suspend fun replaceEnqueue(
+        request: SetReactionsOutboxRequest,
+        uniqueId: Uuid,
+        priority: Long = 100,
+        dependencyUniqueId: Uuid? = null,
+        sendNow: Boolean = true
+    ): EnqueueResult = kickIfEnqueued(
+        replaceEnqueue(
+            driveId = request.driveId,
+            uniqueId = uniqueId,
+            dependencyUniqueId = dependencyUniqueId,
+            priority = priority,
+            uploadType = DriveOutboxUploader.SetReactions,
             json = OdinSystemSerializer.serialize(request)
         ),
         sendNow,

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/database/OutboxUploadTypeIdsTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/sync/database/OutboxUploadTypeIdsTest.kt
@@ -1,0 +1,31 @@
+package id.homebase.api.sync.database
+
+import id.homebase.api.client.drives.files.DriveOutboxUploader
+import id.homebase.api.client.notifications.ScheduledPushOutboxUploader
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/** CompositeOutboxUploader routes on these ids, so a collision silently sends a row to the wrong uploader. */
+class OutboxUploadTypeIdsTest {
+
+    @Test
+    fun drive_and_push_upload_type_ids_do_not_overlap() {
+        val drive = listOf(
+            DriveOutboxUploader.UploadNewFile,
+            DriveOutboxUploader.UpdateFile,
+            DriveOutboxUploader.DeleteFile,
+            DriveOutboxUploader.UpdateLocalMetadataTags,
+            DriveOutboxUploader.UpdateLocalMetadataContent,
+            DriveOutboxUploader.SendReadReceiptByFileIds,
+            DriveOutboxUploader.ToggleReaction,
+            DriveOutboxUploader.DeleteFilesByGroupId,
+            DriveOutboxUploader.SetReactions,
+        )
+        val push = listOf(
+            ScheduledPushOutboxUploader.SchedulePush,
+            ScheduledPushOutboxUploader.CancelPush,
+        )
+        val all = drive + push
+        assertEquals(all.size, all.toSet().size, "duplicate outbox uploadType id in $all")
+    }
+}

--- a/homebase-api/src/jvmTest/kotlin/id/homebase/api/client/drives/files/DriveOutboxUploaderSetReactionsTest.kt
+++ b/homebase-api/src/jvmTest/kotlin/id/homebase/api/client/drives/files/DriveOutboxUploaderSetReactionsTest.kt
@@ -1,0 +1,158 @@
+package id.homebase.api.client.drives.files
+
+import id.homebase.api.client.ClientException
+import id.homebase.api.client.auth.ApiCredentials
+import id.homebase.api.client.auth.CredentialsManager
+import id.homebase.api.client.drives.cache.DriveFileProviderCached
+import id.homebase.api.client.drives.files.reactions.DriveFileGroupReactionProvider
+import id.homebase.api.client.drives.files.reactions.SetReactionsOutboxRequest
+import id.homebase.api.client.drives.upload.DriveUploadProvider
+import id.homebase.api.client.eventbus.EventBus
+import id.homebase.api.common.OdinId
+import id.homebase.api.common.SecureByteArray
+import id.homebase.api.file.FileOperationsProvider
+import id.homebase.api.serialization.OdinSystemSerializer
+import id.homebase.api.sync.database.DatabaseManager
+import id.homebase.api.sync.database.Outbox
+import id.homebase.api.sync.database.createInMemoryDatabase
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.request.forms.InputProvider
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.uuid.Uuid
+
+/**
+ * [DriveOutboxUploader.setReactions]: a set-state row deletes before it
+ * adds, and treats the server's "duplicate reaction" 400 as already applied so
+ * a retried row converges instead of failing on what an earlier attempt landed.
+ */
+class DriveOutboxUploaderSetReactionsTest {
+
+    private val driveId = Uuid.parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+    private val fileId = Uuid.parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+
+    private val calls = mutableListOf<HttpMethod>()
+    private var addResponder: () -> Pair<String, HttpStatusCode> = { "{}" to HttpStatusCode.OK }
+
+    private val mockEngine = MockEngine { request ->
+        calls += request.method
+        val (body, status) = when (request.method) {
+            HttpMethod.Delete -> "{}" to HttpStatusCode.OK
+            HttpMethod.Post -> addResponder()
+            else -> error("unexpected ${request.method}")
+        }
+        respond(body, status, headersOf(HttpHeaders.ContentType, "application/json"))
+    }
+
+    private val httpClient = HttpClient(mockEngine)
+    private val credentialsManager = CredentialsManager()
+    private lateinit var dbm: DatabaseManager
+
+    private val fileOps = object : FileOperationsProvider {
+        override fun getCacheDirectory() = ""
+        override fun openFileInput(path: String): InputProvider = error("not used")
+        override suspend fun readFileBytes(path: String): ByteArray = error("not used")
+        override fun deleteTempFile(path: String) = false
+        override fun getFileSize(path: String) = 0L
+        override suspend fun writeBytesToTempFile(bytes: ByteArray, prefix: String, suffix: String): String = error("not used")
+        override suspend fun writeBytesToShareOutboundFile(bytes: ByteArray, suffix: String): String = error("not used")
+        override suspend fun writeStream(path: String, data: Flow<ByteArray>) = error("not used")
+    }
+
+    @BeforeTest
+    fun setup() = runBlocking {
+        credentialsManager.setActiveCredentials(
+            ApiCredentials.create(
+                domain = OdinId("owner.test"),
+                clientAccessToken = "test-token",
+                sharedSecret = SecureByteArray(ByteArray(16)),
+            )
+        )
+        dbm = DatabaseManager({ createInMemoryDatabase() })
+    }
+
+    @AfterTest
+    fun tearDown() {
+        dbm.close()
+        httpClient.close()
+    }
+
+    private fun uploader(): DriveOutboxUploader {
+        val driveCache = DriveFileProviderCached(httpClient, credentialsManager, fileOps)
+        return DriveOutboxUploader(
+            driveUploadProvider = DriveUploadProvider(httpClient, credentialsManager, fileOps),
+            fileProvider = DriveFileProvider(httpClient, credentialsManager, driveCache),
+            operationsProvider = DriveFileOperationsProvider(httpClient, credentialsManager),
+            reactionProvider = DriveFileGroupReactionProvider(httpClient, credentialsManager),
+            databaseManager = dbm,
+            credentialsManager = credentialsManager,
+        )
+    }
+
+    private fun row(add: List<String>, remove: List<String>) = Outbox(
+        rowId = 1L,
+        driveId = driveId,
+        uniqueId = Uuid.random(),
+        dependencyUniqueId = null,
+        priority = 100,
+        lastAttempt = 0,
+        nextRunTime = 0,
+        checkOutCount = 0,
+        checkOutStamp = null,
+        uploadType = DriveOutboxUploader.SetReactions,
+        json = OdinSystemSerializer.serialize(
+            SetReactionsOutboxRequest(
+                driveId = driveId,
+                fileId = fileId,
+                add = add,
+                remove = remove,
+                recipients = listOf(OdinId("frodo.test")),
+            )
+        ).encodeToByteArray(),
+        files = null,
+    )
+
+    private fun duplicateReaction400(): Pair<String, HttpStatusCode> =
+        """{"status":400,"title":"Cannot add duplicate reaction","extensions":{"errorCode":"UnhandledScenario"}}""" to
+            HttpStatusCode.BadRequest
+
+    @Test
+    fun deletes_run_before_adds() = runTest {
+        uploader().upload(row(add = listOf("""{"emoji":"✅"}"""), remove = listOf("""{"emoji":"🤔"}""", """{"emoji":"❌"}""")), EventBus())
+
+        assertEquals(listOf(HttpMethod.Delete, HttpMethod.Delete, HttpMethod.Post), calls)
+    }
+
+    @Test
+    fun duplicate_add_is_treated_as_applied() = runTest {
+        addResponder = ::duplicateReaction400
+
+        uploader().upload(row(add = listOf("""{"emoji":"✅"}"""), remove = listOf("""{"emoji":"🤔"}""")), EventBus())
+
+        assertEquals(listOf(HttpMethod.Delete, HttpMethod.Post), calls)
+    }
+
+    @Test
+    fun other_add_failures_still_fail_the_row() = runTest {
+        addResponder = {
+            """{"status":400,"title":"Too many Reactions","extensions":{"errorCode":"UnhandledScenario"}}""" to
+                HttpStatusCode.BadRequest
+        }
+
+        assertFailsWith<ClientException> {
+            uploader().upload(row(add = listOf("""{"emoji":"✅"}"""), remove = emptyList()), EventBus())
+        }
+    }
+}

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/event/EventDetailDialog.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/event/EventDetailDialog.kt
@@ -59,6 +59,7 @@ import id.homebase.api.client.drives.upload.EmbeddedThumb
 import id.homebase.api.common.OdinId
 import kotlinx.collections.immutable.ImmutableList
 import id.homebase.chat.services.ChatMessageActionService
+import id.homebase.chat.services.outbox.MutationOutcome
 import id.homebase.chat.services.convo.contact.ContactService
 import id.homebase.chat.widget.ChatMarkdown
 import id.homebase.chat.widget.MediaItem
@@ -580,20 +581,10 @@ private suspend fun applyRsvp(
     currentRsvp: String?,
     newRsvp: String,
 ) {
-    // The reaction toggle uses toggle semantics (add if absent, remove if present); compute the
-    // RSVP the user ends up on so the reminder can be reconciled to match.
-    val resultingRsvp: String? = if (currentRsvp == newRsvp) {
-        // Same button tapped twice → toggle off (no RSVP).
-        actionService.toggleReaction(conversationId, messageId, newRsvp)
-        null
-    } else {
-        if (currentRsvp != null) {
-            // Switch RSVP: clear the prior one before recording the new.
-            actionService.toggleReaction(conversationId, messageId, currentRsvp)
-        }
-        actionService.toggleReaction(conversationId, messageId, newRsvp)
-        newRsvp
-    }
+    val change = EventRsvp.change(currentRsvp, newRsvp)
+    val outcome = actionService.setReactions(conversationId, messageId, change)
+    if (outcome != MutationOutcome.Queued) return
+    val resultingRsvp: String? = change.add.firstOrNull()
 
     // Reconcile the self-reminder to the resulting state: Going schedules, anything else (Maybe /
     // Not going / retracted) cancels. Best-effort — a reminder hiccup must never fail the RSVP,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/event/EventRsvp.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/event/EventRsvp.kt
@@ -3,12 +3,13 @@ package id.homebase.chat.event
 import id.homebase.api.client.drives.files.ReactionSummary
 import id.homebase.api.client.drives.files.reactions.ReactionContent
 import id.homebase.api.serialization.OdinSystemSerializer
+import id.homebase.chat.services.ReactionSetChange
 
 /**
  * RSVPs are stored as ordinary chat reactions on the event message — three
- * specific emoji codepoints. The detail screen surfaces them as big buttons
- * and clears any prior RSVP from the same user before recording a new one
- * (so a user can't simultaneously be "going" and "not going").
+ * specific emoji codepoints. The detail screen surfaces them as big buttons;
+ * a tap declares the whole RSVP state at once via [change] (so a user can't
+ * simultaneously be "going" and "not going").
  *
  * Source of truth for the *current user's* RSVP is [MessageUiModel.ownReactions]
  * — already mirrored from `localAppData.localReactions`. The aggregate counts
@@ -38,6 +39,22 @@ object EventRsvp {
     /** Returns the user's current RSVP emoji, or null if none. */
     fun currentRsvp(ownReactions: Iterable<String>): String? =
         ownReactions.firstOrNull { it in ALL }
+
+    /**
+     * The reaction change a tap on [tapped] declares: tapping the current RSVP
+     * retracts it (all three cleared), anything else sets it and clears the
+     * other two. Always covers all three so stale state can't leave a ghost.
+     */
+    fun change(currentRsvp: String?, tapped: String): ReactionSetChange {
+        require(tapped in ALL) { "not an RSVP emoji: $tapped" }
+        return if (currentRsvp == tapped) {
+            ReactionSetChange(scope = SCOPE, add = emptySet(), remove = ALL)
+        } else {
+            ReactionSetChange(scope = SCOPE, add = setOf(tapped), remove = ALL - tapped)
+        }
+    }
+
+    private const val SCOPE = "rsvp"
 
     /**
      * Aggregate count of each RSVP across all reactors, read from the

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/groodle/GroodleDetailDialog.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/groodle/GroodleDetailDialog.kt
@@ -71,9 +71,9 @@ import org.koin.compose.koinInject
  *    tally, and Yes / Maybe / No vote buttons reflecting the viewer's choice
  *  - the leading slot highlighted by score (Y=2, M=1, N=0)
  *
- * Voting writes ordinary chat reactions ([GroodleVote] codes). Tapping a
- * different choice clears the user's prior vote for that slot first (clear-then-
- * set), so the two can't coexist. Past the deadline the buttons lock.
+ * Voting writes ordinary chat reactions ([GroodleVote] codes). A tap declares
+ * the whole slot's state in one idempotent row (set the choice, clear the slot's
+ * others), so two choices can't coexist. Past the deadline the buttons lock.
  */
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalUuidApi::class)
 @Composable
@@ -218,7 +218,15 @@ private fun GroodleDetailContent(
                     isClosed = isClosed,
                     onVote = { choice ->
                         scope.launch {
-                            applyVote(actionService, conversationId, messageId, myVotes[slotIndex], slotIndex, choice)
+                            applyVote(
+                                actionService,
+                                conversationId,
+                                messageId,
+                                myVotes[slotIndex],
+                                slotIndex,
+                                choice,
+                                descriptor.allowMaybe,
+                            )
                         }
                     },
                 )
@@ -387,16 +395,11 @@ private suspend fun applyVote(
     currentChoice: GroodleVote.Choice?,
     slotIndex: Int,
     newChoice: GroodleVote.Choice,
+    allowMaybe: Boolean,
 ) {
-    val newCode = GroodleVote.encode(slotIndex, newChoice)
-    if (currentChoice == newChoice) {
-        // Same choice tapped twice → toggle off (clear the vote).
-        actionService.toggleReaction(conversationId, messageId, newCode)
-        return
-    }
-    if (currentChoice != null) {
-        // Switch choice: clear the prior vote for this slot first.
-        actionService.toggleReaction(conversationId, messageId, GroodleVote.encode(slotIndex, currentChoice))
-    }
-    actionService.toggleReaction(conversationId, messageId, newCode)
+    actionService.setReactions(
+        conversationId,
+        messageId,
+        GroodleVote.change(slotIndex, currentChoice, newChoice, allowMaybe),
+    )
 }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/groodle/GroodleVote.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/groodle/GroodleVote.kt
@@ -1,6 +1,7 @@
 package id.homebase.chat.groodle
 
 import id.homebase.api.client.drives.files.ReactionSummary
+import id.homebase.chat.services.ReactionSetChange
 import id.homebase.chat.services.decodeReactionCode
 
 /**
@@ -52,6 +53,31 @@ object GroodleVote {
     }
 
     /**
+     * The reaction change a tap on [tapped] for one slot declares: tapping the
+     * current choice clears the slot, anything else sets it and clears the slot's
+     * other choices. Only this slot's codes are touched; other slots' votes are
+     * left alone.
+     */
+    fun change(
+        slotIndex1Based: Int,
+        currentChoice: Choice?,
+        tapped: Choice,
+        allowMaybe: Boolean,
+    ): ReactionSetChange {
+        val slotCodes = Choice.entries
+            .filter { allowMaybe || it != Choice.MAYBE }
+            .map { encode(slotIndex1Based, it) }
+            .toSet()
+        val scope = "slot:$slotIndex1Based"
+        return if (currentChoice == tapped) {
+            ReactionSetChange(scope = scope, add = emptySet(), remove = slotCodes)
+        } else {
+            val code = encode(slotIndex1Based, tapped)
+            ReactionSetChange(scope = scope, add = setOf(code), remove = slotCodes - code)
+        }
+    }
+
+    /**
      * Extracts the emoji/code string from a single `ownReactions` entry. The stored
      * shape is JSON-encoded ReactionContent (`{"emoji":"_1Y"}`). Delegates to the
      * shared [decodeReactionCode].
@@ -60,8 +86,8 @@ object GroodleVote {
 
     /**
      * The current user's vote per slot, decoded from their own reactions. Last
-     * write wins per slot (the detail dialog clears a prior vote before setting a
-     * new one, so well-behaved clients have at most one per slot anyway).
+     * write wins per slot (a vote is written as a set-state over the slot's codes,
+     * so well-behaved clients have at most one per slot anyway).
      */
     fun myVotes(
         ownReactions: Iterable<String>,
@@ -89,7 +115,7 @@ object GroodleVote {
      * Per-slot tally across all reactors, read from the server-side reaction
      * preview. Returns an entry for every slot in `1..slotCount` (zeroed when no
      * votes). Aggregate counts can't be de-duped per voter, so correctness relies
-     * on the detail dialog's clear-then-set on vote change (same as Event RSVP).
+     * on each vote being written as a set-state over the slot (same as Event RSVP).
      */
     fun counts(summary: ReactionSummary?, slotCount: Int, allowMaybe: Boolean): Map<Int, SlotCounts> {
         val yes = IntArray(slotCount + 1)

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/poll/PollBubble.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/poll/PollBubble.kt
@@ -195,6 +195,7 @@ fun PollBubble(
                                 messageId = target.first,
                                 optionIndex = i,
                                 own = own,
+                                optionCount = optionCount,
                                 allowMultiple = descriptor.allowMultiple,
                             )
                         }
@@ -393,15 +394,6 @@ private fun UnparseablePollBubble(
     }
 }
 
-/**
- * Applies a poll vote for [optionIndex]:
- * - [allowMultiple]: each option toggles independently.
- * - Single-choice: if a different option is currently voted, clear it first, then
- *   toggle the tapped option (clear-then-set). Tapping the already-chosen option
- *   toggles it off (clear only).
- *
- * Mirrors [id.homebase.chat.groodle.GroodleDetailDialog]'s `applyVote` logic.
- */
 @OptIn(ExperimentalUuidApi::class)
 private suspend fun applyPollVote(
     actionService: ChatMessageActionService,
@@ -409,20 +401,12 @@ private suspend fun applyPollVote(
     messageId: Uuid,
     optionIndex: Int,
     own: Set<Int>,
+    optionCount: Int,
     allowMultiple: Boolean,
 ) {
-    val newCode = PollVote.codeFor(optionIndex)
-    if (allowMultiple) {
-        // Each option is an independent toggle.
-        actionService.toggleReaction(conversationId, messageId, newCode)
-        return
-    }
-    // Single-choice: clear EVERY other currently-voted option before toggling the
-    // tapped one. Iterating (not firstOrNull) defends against a stale `own` set that
-    // somehow holds more than one prior vote, which would otherwise leave a ghost.
-    own.filter { it != optionIndex }.forEach { prev ->
-        actionService.toggleReaction(conversationId, messageId, PollVote.codeFor(prev))
-    }
-    // Toggle the tapped option (sets it if not voted, clears it if already voted).
-    actionService.toggleReaction(conversationId, messageId, newCode)
+    actionService.setReactions(
+        conversationId,
+        messageId,
+        PollVote.change(optionIndex, own, optionCount, allowMultiple),
+    )
 }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/poll/PollVote.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/poll/PollVote.kt
@@ -2,6 +2,7 @@ package id.homebase.chat.poll
 
 import id.homebase.api.client.drives.files.ReactionSummary
 import id.homebase.api.common.OdinId
+import id.homebase.chat.services.ReactionSetChange
 import id.homebase.chat.services.decodeReactionCode
 import id.homebase.core.widget.EmojiReaction
 
@@ -42,10 +43,35 @@ object PollVote {
         ownReactions.mapNotNull { optionOf(it) }.filter { it in 0 until optionCount }.toSet()
 
     /**
+     * The reaction change a tap on [tapped] declares, given the user's current
+     * [own] votes. Multi-select polls treat every option as its own scope (an
+     * idempotent add or remove of just that code). Single-choice polls cover all
+     * [optionCount] codes: tapping the chosen option clears it, anything else
+     * sets it and clears the rest.
+     */
+    fun change(tapped: Int, own: Set<Int>, optionCount: Int, allowMultiple: Boolean): ReactionSetChange {
+        require(tapped in 0 until optionCount) { "option $tapped out of range" }
+        val code = codeFor(tapped)
+        if (allowMultiple) {
+            return if (tapped in own) {
+                ReactionSetChange(scope = "poll:$tapped", add = emptySet(), remove = setOf(code))
+            } else {
+                ReactionSetChange(scope = "poll:$tapped", add = setOf(code), remove = emptySet())
+            }
+        }
+        val allCodes = (0 until optionCount).map { codeFor(it) }.toSet()
+        return if (own == setOf(tapped)) {
+            ReactionSetChange(scope = "poll", add = emptySet(), remove = allCodes)
+        } else {
+            ReactionSetChange(scope = "poll", add = setOf(code), remove = allCodes - code)
+        }
+    }
+
+    /**
      * Aggregate vote count per option, read from the server-side reaction
      * preview. Returns an [IntArray] of length [optionCount] (zeroed when no
      * votes). Aggregate counts can't be de-duped per voter, so correctness
-     * relies on the bubble's clear-then-set on vote change (same as Groodle).
+     * relies on the bubble writing each vote as a set-state (same as Groodle).
      */
     fun counts(summary: ReactionSummary?, optionCount: Int): IntArray {
         val out = IntArray(optionCount)

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageActionService.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageActionService.kt
@@ -22,6 +22,8 @@ import id.homebase.api.sync.database.enqueued
 import id.homebase.chat.data.MessageUiModel
 import id.homebase.chat.services.outbox.OptimisticWriter
 import id.homebase.api.client.drives.files.reactions.ReactionContent
+import id.homebase.api.crypto.Md5
+import id.homebase.chat.services.outbox.MutationOutcome
 import id.homebase.chat.services.convo.ConversationParticipantLookup
 import id.homebase.chat.services.convo.ConversationService
 import id.homebase.chat.services.convo.LocalLastReadUpdater
@@ -245,6 +247,30 @@ class ChatMessageActionService(
             getRecipients(conversationId)
         }
         return ToggleReactionResult(resultType = resultType)
+    }
+
+    /**
+     * Applies a vote-style reaction change (RSVP, Groodle slot, poll option) as one
+     * idempotent set-state row: removes first, then adds. The row is keyed per
+     * (message, scope) so a newer tap replaces a still-pending one.
+     */
+    suspend fun setReactions(
+        conversationId: Uuid,
+        messageId: Uuid,
+        change: ReactionSetChange,
+    ): MutationOutcome {
+        require(change.add.none { it in change.remove }) { "add and remove overlap" }
+        if ((change.add + change.remove).any { !isValidEmoji(it) }) {
+            return MutationOutcome.Refused(IllegalArgumentException("invalid reaction code"))
+        }
+        val toJson = { code: String -> OdinSystemSerializer.serialize(ReactionContent(emoji = code)) }
+        return optimisticWriter.setReactions(
+            driveId = chatDrive,
+            uniqueId = messageId,
+            rowKey = Md5.toGuidId("reaction-set:$messageId:${change.scope}"),
+            add = change.add.map(toJson).toSet(),
+            remove = change.remove.map(toJson).toSet(),
+        ) { getRecipients(conversationId) }
     }
 
     // -------------------- DELETE --------------------

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageActionService.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMessageActionService.kt
@@ -264,13 +264,19 @@ class ChatMessageActionService(
             return MutationOutcome.Refused(IllegalArgumentException("invalid reaction code"))
         }
         val toJson = { code: String -> OdinSystemSerializer.serialize(ReactionContent(emoji = code)) }
-        return optimisticWriter.setReactions(
+        val rowKey = Md5.toGuidId("reaction-set:$messageId:${change.scope}")
+        val outcome = optimisticWriter.setReactions(
             driveId = chatDrive,
             uniqueId = messageId,
-            rowKey = Md5.toGuidId("reaction-set:$messageId:${change.scope}"),
+            rowKey = rowKey,
             add = change.add.map(toJson).toSet(),
             remove = change.remove.map(toJson).toSet(),
         ) { getRecipients(conversationId) }
+        Logger.i(tag = REACTIONS_TAG) {
+            "setReactions msg=$messageId scope=${change.scope} add=${change.add} remove=${change.remove} " +
+                "rowKey=$rowKey outcome=$outcome"
+        }
+        return outcome
     }
 
     // -------------------- DELETE --------------------

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ReactionSetChange.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ReactionSetChange.kt
@@ -1,0 +1,12 @@
+package id.homebase.chat.services
+
+/**
+ * What one vote tap declares for a [scope] of a message: reaction codes to
+ * [add] and to [remove]. Sent as a single idempotent outbox row, never as a
+ * toggle, so retries and replays converge on the same state.
+ */
+data class ReactionSetChange(
+    val scope: String,
+    val add: Set<String>,
+    val remove: Set<String>,
+)

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/outbox/OptimisticWriter.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/outbox/OptimisticWriter.kt
@@ -15,6 +15,7 @@ import id.homebase.api.client.drives.files.LocalAppMetadata
 import id.homebase.api.client.drives.files.PayloadDescriptor
 import id.homebase.api.client.drives.files.ReactionEntry
 import id.homebase.api.client.drives.files.ReactionSummary
+import id.homebase.api.client.drives.files.reactions.SetReactionsOutboxRequest
 import id.homebase.api.client.drives.files.reactions.ToggleReactionResultType
 import id.homebase.api.client.drives.upload.UploadFileMetadata
 import id.homebase.api.client.eventbus.BackendEvent
@@ -56,7 +57,7 @@ class OptimisticWriter(
     private val fileProcessor: MainIndexMetaHelpers.HomebaseFileProcessor =
         MainIndexMetaHelpers.HomebaseFileProcessor(dbm)
 
-    // Per-message lock guarding the read-modify-write inside writeReactionToggle.
+    // Per-message lock guarding the read-modify-write inside writeReactionToggle and setReactions.
     // Without this, rapid taps on the bottom sheet have all five coroutines
     // read the same starting state, each compute "remove my one", and last-
     // writer-wins clobbers most of the removes. Per-(driveId, uniqueId) so
@@ -553,6 +554,99 @@ class OptimisticWriter(
                 )
             )
         }
+
+    /**
+     * Declares the caller's reaction state for one scope of a message: [remove] is deleted,
+     * [add] is added, as ONE outbox row keyed by [rowKey] (see [OutboxSync.replaceEnqueue])
+     * that replaces any still-pending row for the same scope. Unlike [toggleReaction] the
+     * intent is fixed at tap time, so a retry cannot flip it. The local mirror only counts
+     * reactions that actually change, so re-applying the same state is a no-op there too.
+     */
+    suspend fun setReactions(
+        driveId: Uuid,
+        uniqueId: Uuid,
+        rowKey: Uuid,
+        add: Set<String>,
+        remove: Set<String>,
+        recipients: suspend (original: HomebaseFile) -> List<OdinId>,
+    ): MutationOutcome = reactionLockFor(driveId, uniqueId).withLock {
+        val credentials = credentialsManager.requireActiveCredentials()
+
+        val existingFile = dbm.driveMainIndex.selectHomebaseFileByUnique(
+            credentials.getIdentityId(), driveId, uniqueId
+        )
+        if (existingFile == null) {
+            Logger.w(tag = TAG) { "Optimistic reaction set: no row for uniqueId=$uniqueId" }
+            return@withLock MutationOutcome.NoRow
+        }
+
+        gate("reaction set", uniqueId) {
+            outboxSync.replaceEnqueue(
+                request = SetReactionsOutboxRequest(
+                    driveId = driveId,
+                    fileId = existingFile.fileId,
+                    add = add.toList(),
+                    remove = remove.toList(),
+                    recipients = recipients(existingFile),
+                ),
+                uniqueId = rowKey,
+                dependencyUniqueId = uniqueId,
+            )
+        }?.let { return@withLock it }
+
+        val currentLocalReactions =
+            existingFile.fileMetadata.localAppData?.localReactions.orEmpty()
+        val actuallyRemoved = remove.filter { it in currentLocalReactions }
+        val actuallyAdded = add.filter { it !in currentLocalReactions }
+        val updatedLocalReactions = currentLocalReactions - actuallyRemoved.toSet() + actuallyAdded
+
+        val currentReactions =
+            existingFile.fileMetadata.reactionPreview?.reactions.orEmpty().toMutableMap()
+        for (reactionJson in actuallyRemoved) {
+            val key = currentReactions.entries
+                .firstOrNull { it.value.reactionContent == reactionJson }?.key ?: continue
+            val entry = currentReactions.getValue(key)
+            if (entry.count <= 1) currentReactions.remove(key)
+            else currentReactions[key] = entry.copy(count = entry.count - 1)
+        }
+        for (reactionJson in actuallyAdded) {
+            val key = currentReactions.entries
+                .firstOrNull { it.value.reactionContent == reactionJson }?.key
+            if (key == null) {
+                currentReactions[reactionJson] = ReactionEntry(
+                    key = reactionJson,
+                    count = 1,
+                    reactionContent = reactionJson
+                )
+            } else {
+                val entry = currentReactions.getValue(key)
+                currentReactions[key] = entry.copy(count = entry.count + 1)
+            }
+        }
+
+        val updatedFile = existingFile.copy(
+            fileMetadata = existingFile.fileMetadata.copy(
+                updated = existingFile.optimisticStamp(),
+                reactionPreview = (existingFile.fileMetadata.reactionPreview
+                    ?: ReactionSummary()).copy(
+                    reactions = currentReactions
+                ),
+                localAppData = (existingFile.fileMetadata.localAppData
+                    ?: LocalAppMetadata()).copy(
+                    localReactions = updatedLocalReactions
+                ),
+            )
+        )
+
+        try {
+            upsertAndEmit(credentials.getIdentityId(), driveId, updatedFile)
+        } catch (e: Exception) {
+            Logger.e(throwable = e, tag = TAG) {
+                "Optimistic reaction set failed (non-fatal, already queued) for uniqueId=$uniqueId"
+            }
+        }
+        MutationOutcome.Queued
+    }
 
     private suspend fun writeDelete(
         driveId: Uuid,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/outbox/OptimisticWriter.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/outbox/OptimisticWriter.kt
@@ -599,6 +599,10 @@ class OptimisticWriter(
         val actuallyRemoved = remove.filter { it in currentLocalReactions }
         val actuallyAdded = add.filter { it !in currentLocalReactions }
         val updatedLocalReactions = currentLocalReactions - actuallyRemoved.toSet() + actuallyAdded
+        Logger.i(tag = TAG) {
+            "Optimistic reaction set uniqueId=$uniqueId rowKey=$rowKey own before=$currentLocalReactions " +
+                "after=$updatedLocalReactions"
+        }
 
         val currentReactions =
             existingFile.fileMetadata.reactionPreview?.reactions.orEmpty().toMutableMap()

--- a/homebase-chat/src/commonTest/kotlin/id/homebase/chat/event/EventRsvpChangeTest.kt
+++ b/homebase-chat/src/commonTest/kotlin/id/homebase/chat/event/EventRsvpChangeTest.kt
@@ -1,0 +1,41 @@
+package id.homebase.chat.event
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class EventRsvpChangeTest {
+
+    @Test
+    fun tapping_new_rsvp_sets_it_and_clears_the_other_two() {
+        val change = EventRsvp.change(currentRsvp = null, tapped = EventRsvp.GOING)
+        assertEquals(setOf(EventRsvp.GOING), change.add)
+        assertEquals(setOf(EventRsvp.MAYBE, EventRsvp.NOT_GOING), change.remove)
+    }
+
+    @Test
+    fun switching_rsvp_clears_every_other_choice_not_just_the_known_one() {
+        val change = EventRsvp.change(currentRsvp = EventRsvp.MAYBE, tapped = EventRsvp.NOT_GOING)
+        assertEquals(setOf(EventRsvp.NOT_GOING), change.add)
+        assertEquals(setOf(EventRsvp.GOING, EventRsvp.MAYBE), change.remove)
+    }
+
+    @Test
+    fun tapping_current_rsvp_retracts_all_three() {
+        val change = EventRsvp.change(currentRsvp = EventRsvp.GOING, tapped = EventRsvp.GOING)
+        assertEquals(emptySet(), change.add)
+        assertEquals(EventRsvp.ALL, change.remove)
+    }
+
+    @Test
+    fun scope_is_the_same_for_every_tap_so_a_newer_tap_replaces_a_pending_one() {
+        val a = EventRsvp.change(null, EventRsvp.GOING)
+        val b = EventRsvp.change(EventRsvp.GOING, EventRsvp.MAYBE)
+        assertEquals(a.scope, b.scope)
+    }
+
+    @Test
+    fun rejects_non_rsvp_emoji() {
+        assertFailsWith<IllegalArgumentException> { EventRsvp.change(null, "👍") }
+    }
+}

--- a/homebase-chat/src/commonTest/kotlin/id/homebase/chat/groodle/GroodleVoteTest.kt
+++ b/homebase-chat/src/commonTest/kotlin/id/homebase/chat/groodle/GroodleVoteTest.kt
@@ -100,4 +100,38 @@ class GroodleVoteTest {
         val votes = GroodleVote.myVotes(own, slotCount = 3, allowMaybe = false)
         assertEquals(mapOf(1 to GroodleVote.Choice.YES), votes)
     }
+
+    @Test
+    fun change_sets_choice_and_clears_only_that_slots_other_choices() {
+        val change = GroodleVote.change(
+            slotIndex1Based = 2,
+            currentChoice = GroodleVote.Choice.YES,
+            tapped = GroodleVote.Choice.NO,
+            allowMaybe = true,
+        )
+        assertEquals("slot:2", change.scope)
+        assertEquals(setOf("_2N"), change.add)
+        assertEquals(setOf("_2Y", "_2M"), change.remove)
+    }
+
+    @Test
+    fun change_never_touches_a_maybe_code_when_maybe_is_disallowed() {
+        val change = GroodleVote.change(2, null, GroodleVote.Choice.YES, allowMaybe = false)
+        assertEquals(setOf("_2Y"), change.add)
+        assertEquals(setOf("_2N"), change.remove)
+    }
+
+    @Test
+    fun change_on_current_choice_clears_the_slot() {
+        val change = GroodleVote.change(3, GroodleVote.Choice.MAYBE, GroodleVote.Choice.MAYBE, allowMaybe = true)
+        assertEquals(emptySet(), change.add)
+        assertEquals(setOf("_3Y", "_3N", "_3M"), change.remove)
+    }
+
+    @Test
+    fun change_scope_differs_per_slot() {
+        val a = GroodleVote.change(1, null, GroodleVote.Choice.YES, allowMaybe = true)
+        val b = GroodleVote.change(2, null, GroodleVote.Choice.YES, allowMaybe = true)
+        assertEquals(false, a.scope == b.scope)
+    }
 }

--- a/homebase-chat/src/commonTest/kotlin/id/homebase/chat/poll/PollVoteTest.kt
+++ b/homebase-chat/src/commonTest/kotlin/id/homebase/chat/poll/PollVoteTest.kt
@@ -126,4 +126,35 @@ class PollVoteTest {
     )
 
     private fun json(code: String) = """{"emoji":"$code"}"""
+
+    @Test fun change_single_choice_sets_tapped_and_clears_every_other_option() {
+        val change = PollVote.change(tapped = 1, own = setOf(0), optionCount = 3, allowMultiple = false)
+        assertEquals("poll", change.scope)
+        assertEquals(setOf("_p1"), change.add)
+        assertEquals(setOf("_p0", "_p2"), change.remove)
+    }
+
+    @Test fun change_single_choice_retap_clears_all_options() {
+        val change = PollVote.change(tapped = 1, own = setOf(1), optionCount = 3, allowMultiple = false)
+        assertEquals(emptySet(), change.add)
+        assertEquals(setOf("_p0", "_p1", "_p2"), change.remove)
+    }
+
+    @Test fun change_single_choice_with_ghost_votes_converges_on_tapped() {
+        val change = PollVote.change(tapped = 1, own = setOf(0, 1), optionCount = 3, allowMultiple = false)
+        assertEquals(setOf("_p1"), change.add)
+        assertEquals(setOf("_p0", "_p2"), change.remove)
+    }
+
+    @Test fun change_multi_select_adds_or_removes_only_the_tapped_option() {
+        val add = PollVote.change(tapped = 2, own = setOf(0), optionCount = 3, allowMultiple = true)
+        assertEquals("poll:2", add.scope)
+        assertEquals(setOf("_p2"), add.add)
+        assertEquals(emptySet(), add.remove)
+
+        val remove = PollVote.change(tapped = 0, own = setOf(0, 2), optionCount = 3, allowMultiple = true)
+        assertEquals("poll:0", remove.scope)
+        assertEquals(emptySet(), remove.add)
+        assertEquals(setOf("_p0"), remove.remove)
+    }
 }

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/outbox/OptimisticWriterReactionSetTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/outbox/OptimisticWriterReactionSetTest.kt
@@ -1,0 +1,345 @@
+package id.homebase.chat.services.outbox
+
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import id.homebase.api.client.auth.ApiCredentials
+import id.homebase.api.client.auth.CredentialsManager
+import id.homebase.api.client.drives.HomebaseFile
+import id.homebase.api.client.drives.files.DriveOutboxUploader
+import id.homebase.api.client.drives.files.reactions.SetReactionsOutboxRequest
+import id.homebase.api.client.eventbus.EventBus
+import id.homebase.api.common.OdinId
+import id.homebase.api.common.SecureByteArray
+import id.homebase.api.crypto.Md5
+import id.homebase.api.serialization.OdinSystemSerializer
+import id.homebase.api.sync.database.DatabaseManager
+import id.homebase.api.sync.database.MainIndexMetaHelpers
+import id.homebase.api.sync.database.OdinDatabase
+import id.homebase.api.sync.database.Outbox
+import id.homebase.api.sync.database.OutboxSync
+import id.homebase.api.sync.database.OutboxUploader
+import id.homebase.chat.services.ChatProtocol
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.time.Clock
+import kotlin.uuid.Uuid
+import kotlinx.coroutines.test.runTest
+
+/**
+ * OptimisticWriter.setReactions: one idempotent set-state outbox row per
+ * (message, scope), and a local mirror that only counts reactions that actually
+ * change, so re-applying the same state never double-counts.
+ */
+class OptimisticWriterReactionSetTest {
+
+    private val testIdentityId: Uuid = Uuid.parse("7b1be23b-48bb-4304-bc7b-db5910c09a92")
+    private val chatDriveId: Uuid = Uuid.parse("9ff813af-f2d6-1e2f-9b9d-b189e72d1a11")
+    private val testDomain: String = "owner.test"
+
+    private lateinit var dbm: DatabaseManager
+    private lateinit var credentialsManager: CredentialsManager
+    private lateinit var eventBus: EventBus
+    private lateinit var writer: OptimisticWriter
+
+    @AfterTest
+    fun tearDown() {
+        if (::dbm.isInitialized) {
+            try { dbm.close() } catch (_: java.sql.SQLException) { }
+        }
+    }
+
+    private suspend fun setUp() {
+        dbm = DatabaseManager({
+            val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+            OdinDatabase.Schema.create(driver)
+            driver
+        })
+        credentialsManager = CredentialsManager().also {
+            it.setActiveCredentials(
+                ApiCredentials.create(
+                    domain = OdinId(testDomain),
+                    clientAccessToken = "test-token",
+                    sharedSecret = SecureByteArray(ByteArray(16)),
+                )
+            )
+        }
+        eventBus = EventBus()
+        writer = OptimisticWriter(
+            credentialsManager = credentialsManager,
+            dbm = dbm,
+            eventBus = eventBus,
+            outboxSync = OutboxSync(
+                databaseManager = dbm,
+                uploader = object : OutboxUploader {
+                    override suspend fun upload(outboxRecord: Outbox, eventBus: EventBus) =
+                        error("no uploads in this test")
+                },
+                eventBus = eventBus,
+            ),
+        )
+    }
+
+    /**
+     * Build the JSON for a single ReactionEntry block keyed by the JSON-form
+     * reaction (matching what OptimisticWriter writes). Caller passes count.
+     */
+    private fun previewJson(reactions: Map<String, Int>): String {
+        if (reactions.isEmpty()) return "null"
+        val entries = reactions.entries.joinToString(",") { (json, count) ->
+            // The map key is the JSON form, e.g. {"emoji":"😀"}.
+            // We need to embed it as a JSON string key — escape its quotes.
+            val keyEscaped = json.replace("\\", "\\\\").replace("\"", "\\\"")
+            val contentEscaped = keyEscaped
+            """"$keyEscaped":{"key":"$keyEscaped","count":$count,"reactionContent":"$contentEscaped"}"""
+        }
+        return """{"reactions":{$entries},"comments":[],"totalCommentCount":0}"""
+    }
+
+    private fun localReactionsJson(localReactions: List<String>?): String {
+        if (localReactions == null) return "null"
+        val items = localReactions.joinToString(",") {
+            val escaped = it.replace("\\", "\\\\").replace("\"", "\\\"")
+            "\"$escaped\""
+        }
+        return """{"localReactions":[$items]}"""
+    }
+
+    /**
+     * Seed a chat-message file in DriveMainIndex with optional pre-existing
+     * localReactions and reactionPreview. Returns the message uniqueId.
+     */
+    private suspend fun seedMessage(
+        initialLocalReactions: List<String>? = null,
+        initialReactionPreview: Map<String, Int>? = null,
+        id: Uuid = Uuid.random(),
+        fileId: Uuid = Uuid.random(),
+        senderDomain: String = testDomain,
+    ): Uuid {
+        val now = Clock.System.now().epochSeconds
+        val previewJson = previewJson(initialReactionPreview.orEmpty())
+        val localAppDataJson = localReactionsJson(initialLocalReactions)
+
+        val jsonHeader = """{
+          "fileId": "$fileId",
+          "driveId": "$chatDriveId",
+          "fileState": "active",
+          "fileSystemType": "standard",
+          "serverFileIsEncrypted": "false",
+          "keyHeader": {
+            "iv": [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],
+            "aesKey": {"bytes": [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]}
+          },
+          "fileMetadata": {
+            "globalTransitId": "${Uuid.random()}",
+            "created": ${now}000,
+            "updated": ${now}000,
+            "transitCreated": ${now}000,
+            "transitUpdated": 0,
+            "isEncrypted": false,
+            "senderOdinId": "$senderDomain",
+            "originalAuthor": "$senderDomain",
+            "appData": {
+              "uniqueId": "$id",
+              "tags": null,
+              "fileType": ${ChatProtocol.MessageFileType},
+              "dataType": 0,
+              "groupId": "${Uuid.random()}",
+              "userDate": ${now}000,
+              "content": "",
+              "previewThumbnail": null,
+              "archivalStatus": 0
+            },
+            "localAppData": $localAppDataJson,
+            "referencedFile": null,
+            "reactionPreview": $previewJson,
+            "versionTag": "${Uuid.random()}",
+            "payloads": [],
+            "dataSource": null
+          },
+          "serverMetadata": {
+            "accessControlList": {
+              "requiredSecurityGroup": "owner",
+              "circleIdList": null,
+              "odinIdList": null
+            },
+            "doNotIndex": false,
+            "allowDistribution": true,
+            "fileSystemType": "standard",
+            "fileByteCount": 50,
+            "originalRecipientCount": 1,
+            "transferHistory": null
+          },
+          "priority": 300,
+          "fileByteCount": 50
+        }"""
+
+        val header = OdinSystemSerializer.deserialize<HomebaseFile>(jsonHeader)
+        val processor = MainIndexMetaHelpers.HomebaseFileProcessor(dbm)
+        val record = processor.convertFileHeaderToDriveMainIndexRecord(
+            testIdentityId, chatDriveId, header
+        )
+        MainIndexMetaHelpers.upsertDriveMainIndex(dbm, record)
+        return id
+    }
+
+    private suspend fun readBack(uniqueId: Uuid): HomebaseFile = assertNotNull(
+        dbm.driveMainIndex.selectHomebaseFileByUnique(testIdentityId, chatDriveId, uniqueId),
+        "expected row for $uniqueId",
+    )
+
+    private fun emojiJson(emoji: String): String =
+        """{"emoji":"$emoji"}"""
+
+    private val going = emojiJson("✅")
+    private val maybe = emojiJson("🤔")
+    private val notGoing = emojiJson("❌")
+
+    private fun rowKey(messageId: Uuid) = Md5.toGuidId("reaction-set:$messageId:rsvp")
+
+    private suspend fun pendingCount(): Long = dbm.outbox.count()
+
+    private suspend fun pendingRow(rowKey: Uuid): Outbox =
+        assertNotNull(dbm.outbox.selectByDriveAndUnique(chatDriveId, rowKey), "expected outbox row $rowKey")
+
+    private fun HomebaseFile.previewCounts(): Map<String, Int> =
+        fileMetadata.reactionPreview?.reactions.orEmpty().values
+            .associate { it.reactionContent to it.count }
+
+    @Test
+    fun set_replaces_siblings_locally_and_queues_one_row() = runTest {
+        setUp()
+        val messageId = seedMessage(
+            initialLocalReactions = listOf(maybe),
+            initialReactionPreview = mapOf(maybe to 2, going to 1),
+        )
+
+        val outcome = writer.setReactions(
+            chatDriveId, messageId, rowKey(messageId),
+            add = setOf(notGoing), remove = setOf(going, maybe),
+        ) { listOf(OdinId("frodo.test")) }
+
+        assertEquals(MutationOutcome.Queued, outcome)
+        val updated = readBack(messageId)
+        assertEquals(listOf(notGoing), updated.fileMetadata.localAppData?.localReactions)
+        assertEquals(mapOf(maybe to 1, going to 1, notGoing to 1), updated.previewCounts())
+
+        assertEquals(1L, pendingCount())
+        val row = pendingRow(rowKey(messageId))
+        assertEquals(DriveOutboxUploader.SetReactions, row.uploadType)
+        assertEquals(messageId, row.dependencyUniqueId)
+        val request = OdinSystemSerializer.deserialize<SetReactionsOutboxRequest>(row.json.decodeToString())
+        assertEquals(listOf(notGoing), request.add)
+        assertEquals(setOf(going, maybe), request.remove.toSet())
+        assertEquals(listOf(OdinId("frodo.test")), request.recipients)
+    }
+
+    @Test
+    fun reapplying_the_same_state_is_a_local_noop() = runTest {
+        setUp()
+        val messageId = seedMessage(
+            initialLocalReactions = listOf(going),
+            initialReactionPreview = mapOf(going to 1),
+        )
+
+        writer.setReactions(
+            chatDriveId, messageId, rowKey(messageId),
+            add = setOf(going), remove = setOf(maybe, notGoing),
+        ) { emptyList() }
+
+        val updated = readBack(messageId)
+        assertEquals(listOf(going), updated.fileMetadata.localAppData?.localReactions)
+        assertEquals(mapOf(going to 1), updated.previewCounts())
+    }
+
+    @Test
+    fun retract_clears_only_the_users_own_share_of_the_preview() = runTest {
+        setUp()
+        val messageId = seedMessage(
+            initialLocalReactions = listOf(going),
+            initialReactionPreview = mapOf(going to 3, maybe to 1),
+        )
+
+        writer.setReactions(
+            chatDriveId, messageId, rowKey(messageId),
+            add = emptySet(), remove = setOf(going, maybe, notGoing),
+        ) { emptyList() }
+
+        val updated = readBack(messageId)
+        assertEquals(emptyList(), updated.fileMetadata.localAppData?.localReactions)
+        assertEquals(mapOf(going to 2, maybe to 1), updated.previewCounts())
+    }
+
+    @Test
+    fun a_newer_tap_replaces_the_pending_row_for_the_same_scope() = runTest {
+        setUp()
+        val messageId = seedMessage()
+
+        writer.setReactions(
+            chatDriveId, messageId, rowKey(messageId),
+            add = setOf(maybe), remove = setOf(going, notGoing),
+        ) { emptyList() }
+        writer.setReactions(
+            chatDriveId, messageId, rowKey(messageId),
+            add = setOf(notGoing), remove = setOf(going, maybe),
+        ) { emptyList() }
+
+        assertEquals(1L, pendingCount(), "rapid taps must coalesce into one pending row")
+        val request = OdinSystemSerializer.deserialize<SetReactionsOutboxRequest>(
+            pendingRow(rowKey(messageId)).json.decodeToString()
+        )
+        assertEquals(listOf(notGoing), request.add)
+        assertEquals(listOf(notGoing), readBack(messageId).fileMetadata.localAppData?.localReactions)
+    }
+
+    @Test
+    fun different_scopes_keep_separate_rows() = runTest {
+        setUp()
+        val messageId = seedMessage()
+
+        writer.setReactions(
+            chatDriveId, messageId, Md5.toGuidId("reaction-set:$messageId:slot:1"),
+            add = setOf(emojiJson("_1Y")), remove = setOf(emojiJson("_1N")),
+        ) { emptyList() }
+        writer.setReactions(
+            chatDriveId, messageId, Md5.toGuidId("reaction-set:$messageId:slot:2"),
+            add = setOf(emojiJson("_2N")), remove = setOf(emojiJson("_2Y")),
+        ) { emptyList() }
+
+        assertEquals(2L, pendingCount())
+        assertEquals(
+            listOf(emojiJson("_1Y"), emojiJson("_2N")),
+            readBack(messageId).fileMetadata.localAppData?.localReactions,
+        )
+    }
+
+    @Test
+    fun missing_row_is_reported_and_nothing_is_queued() = runTest {
+        setUp()
+        val outcome = writer.setReactions(
+            chatDriveId, Uuid.random(), Uuid.random(),
+            add = setOf(going), remove = emptySet(),
+        ) { emptyList() }
+
+        assertEquals(MutationOutcome.NoRow, outcome)
+        assertEquals(0L, pendingCount())
+    }
+
+    @Test
+    fun recipient_resolution_failure_refuses_and_leaves_the_row_untouched() = runTest {
+        setUp()
+        val messageId = seedMessage(initialLocalReactions = listOf(maybe))
+
+        val outcome = writer.setReactions(
+            chatDriveId, messageId, rowKey(messageId),
+            add = setOf(going), remove = setOf(maybe, notGoing),
+        ) { error("no conversation") }
+
+        assertIs<MutationOutcome.Refused>(outcome)
+        assertEquals(listOf(maybe), readBack(messageId).fileMetadata.localAppData?.localReactions)
+        assertEquals(0L, pendingCount())
+        assertNull(dbm.outbox.selectByDriveAndUnique(chatDriveId, rowKey(messageId)))
+    }
+}


### PR DESCRIPTION
Fixes #1475.

## Problem

Event RSVP, Groodle and Poll votes all recorded a vote through the group-reactions `toggle` endpoint, as a clear-then-set pair of independent outbox rows. Toggle decides add-vs-remove on the server at drain time, and the outbox retries, so a retried row flipped back and an out-of-order pair could set two answers at once (a user ended up with both Maybe and No on one Event).

## Change

Each tap now declares the whole state of the scope it touches as **one** `SetReactions` outbox row: an explicit `remove` list (deleted first) plus an explicit `add` list, via the existing idempotent add/delete endpoints. No server API change.

- **Scopes**: the Event's RSVP (add chosen, delete the other two; retract deletes all three), one Groodle slot (only that slot's codes), a single-choice poll (all option codes), or one option of a multi-select poll (idempotent add or delete of that code only).
- **Per-scope coalescing**: the row's uniqueId is derived from `(message, scope)` and enqueued with `replaceEnqueue`, so a newer tap supersedes a still-pending or backed-off row instead of queueing behind it. Rapid taps converge on the last tapped state; a stale retry can never replay over a fresh vote.
- **In-flight serialization**: the outbox drains with up to 3 parallel workers, so `DriveOutboxUploader` holds a per-file mutex around a set-state row. Without it two overlapping rows could interleave and the older one's add could land last.
- **Server semantics** (odin-core `GroupReactionService`): DELETE of an absent reaction is a 200 no-op; ADD of a present reaction is a 400 `Cannot add duplicate reaction`. The uploader treats that specific 400 as applied so a replayed row converges rather than dropping. Any other 400 still fails the row.
- The optimistic local mirror (`localReactions` + `reactionPreview`) only counts reactions that actually change, so re-applying the same state is a no-op there too.
- The event self-reminder is now reconciled only when the vote was actually queued.
- Upload type id is **12**: 10 and 11 already belong to `ScheduledPushOutboxUploader` and `CompositeOutboxUploader` routes on the id. `OutboxUploadTypeIdsTest` pins the ids disjoint.

Out of scope: the generic emoji-reaction picker keeps the toggle path, and pending `ToggleReaction` rows from older builds still drain.

## Tests

- `EventRsvpChangeTest`, `GroodleVoteTest`, `PollVoteTest`: change-set logic per vote kind (siblings cleared, other slots untouched, multi-select independence, retract).
- `OptimisticWriterReactionSetTest`: local state, one row per scope, replacement on a second tap, separate scopes keep separate rows, NoRow, refusal leaves the row untouched.
- `DriveOutboxUploaderSetReactionsTest` (MockEngine): deletes before adds, duplicate-add 400 tolerated, other 400s propagate.
- Full `homebase-api:jvmTest` and `homebase-chat:jvmTest` green; both modules compile on Android and wasm.

Note: `homebase-chat:compileTestKotlinWasmJs` fails on `MediaAttachmentEditorToolsetTest.kt` (String vs File); verified it fails identically on clean main, so it is pre-existing and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018oaD6R9dVELCdBePha3MHH
