### PR TITLE
History tile: on when any device reported recently; viewer-friendly off hint; AGP 9.4.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "9.3.2"
+agp = "9.4.0"
 android-compileSdk = "36"
 android-minSdk = "28"
 android-targetSdk = "36"

--- a/homebase-common/src/commonMain/composeResources/values-da/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values-da/strings.xml
@@ -1434,6 +1434,8 @@
     <string name="location_tile_emergency_stale">%1$d uden signal i over 2 dage</string>
     <string name="location_tile_emergency_stale_cd">Advarsel: %1$d kontakter uden sporingssignal i mere end 2 dage</string>
     <string name="location_tile_history_status">%1$d punkter i dag · %2$d enheder</string>
+    <string name="location_tile_history_tracked_by">Spores af %1$s · %2$d punkter i dag</string>
+    <string name="location_tile_history_viewer_off">Slå sporing til på din telefon</string>
     <string name="location_tile_live_status">Deler med %1$d · %2$d deler med dig</string>
     <string name="location_tile_live_off">Ingen deler lige nu</string>
     <string name="location_tile_settings_status">Kort: %1$s</string>

--- a/homebase-common/src/commonMain/composeResources/values-da/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values-da/strings.xml
@@ -1351,7 +1351,7 @@
     <string name="location_perm_open_settings">Åbn indstillinger</string>
     <string name="location_perm_always_hint">Kræves for at optage din placering, når appen er i baggrunden eller lukket.</string>
     <string name="location_perm_always_settings_hint">Android spørger ikke igen — tryk på Åbn indstillinger, og vælg derefter "Tillad altid" for Placering.</string>
-    <string name="location_status_section">Status</string>
+    <string name="location_status_section">Status på denne enhed</string>
     <string name="location_status_last_fix">Seneste position</string>
     <string name="location_status_points_today">Punkter i dag</string>
     <string name="location_status_pending">Venter på upload</string>
@@ -1430,7 +1430,7 @@
     <string name="location_tile_on">Til</string>
     <string name="location_tile_off">Fra</string>
     <string name="location_tile_badge_count">%1$d</string>
-    <string name="location_tile_emergency_status">%1$d kan lokalisere dig · du kan lokalisere %2$d</string>
+    <string name="location_tile_emergency_status">Du kan lokalisere %1$d · %2$d kan lokalisere dig</string>
     <string name="location_tile_emergency_stale">%1$d uden signal i over 2 dage</string>
     <string name="location_tile_emergency_stale_cd">Advarsel: %1$d kontakter uden sporingssignal i mere end 2 dage</string>
     <string name="location_tile_history_status">%1$d punkter i dag · %2$d enheder</string>

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -1700,6 +1700,8 @@
     <string name="location_tile_emergency_stale">%1$d without a signal for over 2 days</string>
     <string name="location_tile_emergency_stale_cd">Warning: %1$d contacts without a tracking signal for more than 2 days</string>
     <string name="location_tile_history_status">%1$d points today · %2$d devices</string>
+    <string name="location_tile_history_tracked_by">Tracked by %1$s · %2$d points today</string>
+    <string name="location_tile_history_viewer_off">Turn on tracking on your phone</string>
     <string name="location_tile_live_status">Sharing with %1$d · %2$d sharing with you</string>
     <string name="location_tile_live_off">No one is sharing right now</string>
     <string name="location_tile_settings_status">Map: %1$s</string>

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -1606,7 +1606,7 @@
     <string name="location_perm_open_settings">Open settings</string>
     <string name="location_perm_always_hint">Needed to record your location when the app is in the background or closed.</string>
     <string name="location_perm_always_settings_hint">Android won't ask again — tap Open settings, then choose "Allow all the time" for Location.</string>
-    <string name="location_status_section">Status</string>
+    <string name="location_status_section">Status on this device</string>
     <string name="location_status_last_fix">Last fix</string>
     <string name="location_status_points_today">Points today</string>
     <string name="location_status_pending">Waiting to upload</string>
@@ -1696,7 +1696,7 @@
     <string name="location_tile_on">On</string>
     <string name="location_tile_off">Off</string>
     <string name="location_tile_badge_count">%1$d</string>
-    <string name="location_tile_emergency_status">%1$d can locate you · you can locate %2$d</string>
+    <string name="location_tile_emergency_status">You can locate %1$d · %2$d can locate you</string>
     <string name="location_tile_emergency_stale">%1$d without a signal for over 2 days</string>
     <string name="location_tile_emergency_stale_cd">Warning: %1$d contacts without a tracking signal for more than 2 days</string>
     <string name="location_tile_history_status">%1$d points today · %2$d devices</string>

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationEmergencyScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationEmergencyScreen.kt
@@ -1,5 +1,7 @@
 package id.homebase.core.ui.screens.location
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -20,6 +22,8 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.CloudOff
+import androidx.compose.material.icons.filled.ExpandLess
+import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material.icons.filled.LinkOff
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
@@ -39,12 +43,14 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import id.homebase.api.common.OdinId
 import id.homebase.chat.data.ContactUiModel
 import id.homebase.core.avatars.AvatarOptions
 import id.homebase.core.avatars.PublicAvatar
@@ -55,6 +61,7 @@ import id.homebase.resources.MR
 import id.homebase.resources.cancel
 import id.homebase.resources.live_location_age_minutes
 import id.homebase.resources.location_emergency_access_manage
+import id.homebase.resources.location_emergency_access_more
 import id.homebase.resources.location_emergency_access_none
 import id.homebase.resources.location_emergency_access_section
 import id.homebase.resources.location_emergency_helper
@@ -177,11 +184,14 @@ fun LocationEmergencyScreen(
                 val pendingIds = remember(uiState.whoCanLocateMePending) {
                     uiState.whoCanLocateMePending.map { it.odinId }.toSet()
                 }
+                // Collapsed to a facepile by default: the reason to open this screen is the
+                // health of the people YOU can locate, listed above.
                 PeopleListBody(
                     loaded = uiState.whoCanLocateMeLoaded,
                     members = (uiState.whoCanLocateMe + uiState.whoCanLocateMePending)
                         .distinctBy { it.odinId },
                     emptyText = stringResource(MR.string.location_emergency_access_none),
+                    collapsible = true,
                     rowTrailing = { member ->
                         EmergencyContactTrailing(
                             name = member.name,
@@ -253,7 +263,10 @@ private fun PeopleListBody(
     rowTrailing: (@Composable (ContactUiModel) -> Unit)? = null,
     /** Per-member tap action; return null for an inert row (no ripple, no handler). */
     memberClick: ((ContactUiModel) -> (() -> Unit)?)? = null,
+    /** Start as a facepile that expands to the named rows on tap. */
+    collapsible: Boolean = false,
 ) {
+    var expanded by rememberSaveable { mutableStateOf(!collapsible) }
     when {
         !loaded -> Box(
             modifier = Modifier.fillMaxWidth().padding(24.dp),
@@ -270,8 +283,30 @@ private fun PeopleListBody(
         )
 
         else -> Column {
+            if (collapsible) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable { expanded = !expanded }
+                        .padding(horizontal = 16.dp, vertical = 12.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    AvatarStackRow(
+                        items = members.map { AvatarStackItem(it.odinId, it.avatarInitials) },
+                        modifier = Modifier.weight(1f),
+                    )
+                    Icon(
+                        imageVector = if (expanded) Icons.Default.ExpandLess else Icons.Default.ExpandMore,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+            AnimatedVisibility(visible = expanded) {
+                Column {
             members.forEachIndexed { index, member ->
-                if (index > 0) HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
+                if (index > 0 || collapsible) HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
                 val onClick = memberClick?.invoke(member)
                 Row(
                     modifier = Modifier
@@ -296,6 +331,58 @@ private fun PeopleListBody(
                     )
                     rowTrailing?.invoke(member)
                 }
+            }
+                }
+            }
+        }
+    }
+}
+
+private data class AvatarStackItem(val odinId: OdinId, val initials: String)
+
+@Composable
+private fun AvatarStackRow(
+    items: List<AvatarStackItem>,
+    modifier: Modifier = Modifier,
+    maxVisible: Int = 6,
+) {
+    val visible = items.take(maxVisible)
+    val overflow = items.size - visible.size
+    val avatarSize = 36.dp
+    val ringSize = avatarSize + 4.dp
+    Row(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.spacedBy(-(avatarSize / 3)),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        visible.forEach { item ->
+            Box(
+                modifier = Modifier
+                    .size(ringSize)
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.surface),
+                contentAlignment = Alignment.Center,
+            ) {
+                PublicAvatar(
+                    odinId = item.odinId,
+                    initials = item.initials,
+                    options = AvatarOptions(size = avatarSize),
+                )
+            }
+        }
+        if (overflow > 0) {
+            Box(
+                modifier = Modifier
+                    .size(ringSize)
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.surfaceContainerHigh),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(
+                    text = stringResource(MR.string.location_emergency_access_more, overflow),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
             }
         }
     }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationTileHomeContent.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationTileHomeContent.kt
@@ -41,13 +41,17 @@ import id.homebase.resources.location_tile_emergency_stale
 import id.homebase.resources.location_tile_emergency_stale_cd
 import id.homebase.resources.location_tile_emergency_status
 import id.homebase.resources.location_tile_emergency_title
+import id.homebase.resources.location_device_unnamed
 import id.homebase.resources.location_tile_history_status
+import id.homebase.resources.location_tile_history_tracked_by
+import id.homebase.resources.location_tile_history_viewer_off
 import id.homebase.resources.location_tile_live_off
 import id.homebase.resources.location_tile_live_status
 import id.homebase.resources.location_tile_press_to_activate
 import id.homebase.resources.location_tile_press_to_set_up
 import id.homebase.resources.location_tile_settings_status
 import id.homebase.resources.location_tile_settings_title
+import kotlin.time.Clock
 import org.jetbrains.compose.resources.stringResource
 
 @Composable
@@ -59,7 +63,7 @@ fun LocationTileHomeContent(
     onOpenLiveSharing: () -> Unit,
     onOpenSettings: () -> Unit,
 ) {
-    val tiles = deriveLocationTiles(uiState)
+    val tiles = deriveLocationTiles(uiState, Clock.System.now().toEpochMilliseconds())
     val pressToSetUp = stringResource(MR.string.location_tile_press_to_set_up)
     Column(
         modifier = Modifier
@@ -130,14 +134,21 @@ fun LocationTileHomeContent(
                     icon = Icons.Outlined.History,
                     title = stringResource(MR.string.location_dashboard_history_section),
                     on = tiles.historyOn,
-                    statusText = if (tiles.historyOn) {
-                        stringResource(
+                    statusText = when {
+                        tiles.trackedDevice != null -> stringResource(
+                            MR.string.location_tile_history_tracked_by,
+                            tiles.trackedDevice.name
+                                ?: stringResource(MR.string.location_device_unnamed, tiles.trackedDevice.shortId),
+                            tiles.pointsToday,
+                        )
+                        tiles.historyOn -> stringResource(
                             MR.string.location_tile_history_status,
                             tiles.pointsToday,
                             tiles.deviceCount,
                         )
-                    } else {
-                        stringResource(MR.string.location_tile_press_to_activate)
+                        // Viewer devices can never track; don't invite a tap that leads nowhere.
+                        uiState.trackingAvailable -> stringResource(MR.string.location_tile_press_to_activate)
+                        else -> stringResource(MR.string.location_tile_history_viewer_off)
                     },
                     onClick = onOpenHistory,
                     modifier = Modifier.weight(1f).aspectRatio(1f),

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationTileHomeContent.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationTileHomeContent.kt
@@ -116,8 +116,8 @@ fun LocationTileHomeContent(
                             stringResource(MR.string.location_tile_emergency_stale, tiles.staleCount)
                         tiles.emergencyOn -> stringResource(
                             MR.string.location_tile_emergency_status,
-                            tiles.canLocateMeCount,
                             tiles.canLocateCount,
+                            tiles.canLocateMeCount,
                         )
                         else -> pressToSetUp
                     },

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationTileState.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/location/LocationTileState.kt
@@ -1,5 +1,8 @@
 package id.homebase.core.ui.screens.location
 
+import id.homebase.core.contactbook.LOCATE_STALE_WARN_MS
+import id.homebase.core.ui.screens.location.devices.LocationDeviceInfo
+
 data class LocationTiles(
     val emergencyOn: Boolean,
     val canLocateMeCount: Int,
@@ -8,22 +11,32 @@ data class LocationTiles(
     val historyOn: Boolean,
     val pointsToday: Int,
     val deviceCount: Int,
+    /** The device with the freshest recent fix when THIS device isn't tracking (viewer devices,
+     *  or a phone with its switch off while another phone records) — null when this device tracks. */
+    val trackedDevice: LocationDeviceInfo?,
     val liveOn: Boolean,
     val outgoingCount: Int,
     val incomingCount: Int,
     val settingsOn: Boolean,
 )
 
-fun deriveLocationTiles(s: LocationUiState): LocationTiles {
+fun deriveLocationTiles(s: LocationUiState, nowMs: Long): LocationTiles {
     val canLocateMe = (s.whoCanLocateMe + s.whoCanLocateMePending).distinctBy { it.odinId }.size
+    // History is "on" whenever any device of this identity reported within the stale window —
+    // read from the local index, no server call — not only when this device's switch is on.
+    val recentDevice = s.devices
+        .filter { device -> device.lastFix?.let { nowMs - it.t <= LOCATE_STALE_WARN_MS } == true }
+        .maxByOrNull { it.lastFix!!.t }
     return LocationTiles(
         emergencyOn = canLocateMe > 0 || s.whoICanLocate.isNotEmpty(),
         canLocateMeCount = canLocateMe,
         canLocateCount = s.whoICanLocate.size,
         staleCount = s.staleLocatableCount,
-        historyOn = s.allowLocationHistory,
-        pointsToday = s.pointsToday,
+        historyOn = s.allowLocationHistory || recentDevice != null,
+        // This device's own count only covers its own hour files; the day traces cover every device.
+        pointsToday = maxOf(s.pointsToday, s.todayTraces.sumOf { it.pointCount }),
         deviceCount = s.devices.size,
+        trackedDevice = recentDevice.takeIf { !s.allowLocationHistory },
         liveOn = s.outgoingShares.isNotEmpty() || s.incomingShares.isNotEmpty(),
         outgoingCount = s.outgoingShares.size,
         incomingCount = s.incomingShares.size,

--- a/homebase-core/src/jvmTest/kotlin/id/homebase/core/ui/screens/location/LocationTileStateTest.kt
+++ b/homebase-core/src/jvmTest/kotlin/id/homebase/core/ui/screens/location/LocationTileStateTest.kt
@@ -1,7 +1,11 @@
 package id.homebase.core.ui.screens.location
 
 import id.homebase.api.common.OdinId
+import id.homebase.api.sync.database.BufferedLocationPoint
 import id.homebase.chat.data.ContactUiModel
+import id.homebase.core.contactbook.LOCATE_STALE_WARN_MS
+import id.homebase.core.ui.screens.location.devices.LocationDeviceInfo
+import id.homebase.core.ui.screens.location.history.DeviceTrace
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -19,55 +23,99 @@ class LocationTileStateTest {
 
     private val alice = contact("alice.example")
     private val bob = contact("bob.example")
+    private val now = 30L * 24 * 60 * 60_000L
+
+    private fun point(t: Long) = BufferedLocationPoint(t = t, lat = 0.0, lon = 0.0, acc = null, src = "gps", fg = true)
+
+    private fun device(name: String, lastFixMs: Long?, thisDevice: Boolean = false) = LocationDeviceInfo(
+        deviceId = Uuid.random(),
+        name = name,
+        platform = "android",
+        lastFix = lastFixMs?.let(::point),
+        isThisDevice = thisDevice,
+    )
 
     @Test
     fun emergencyOffOnlyWhenAllListsEmpty() {
-        assertFalse(deriveLocationTiles(LocationUiState()).emergencyOn)
-        assertTrue(deriveLocationTiles(LocationUiState(whoCanLocateMe = listOf(alice))).emergencyOn)
-        assertTrue(deriveLocationTiles(LocationUiState(whoCanLocateMePending = listOf(alice))).emergencyOn)
-        assertTrue(deriveLocationTiles(LocationUiState(whoICanLocate = listOf(alice))).emergencyOn)
+        assertFalse(deriveLocationTiles(LocationUiState(), now).emergencyOn)
+        assertTrue(deriveLocationTiles(LocationUiState(whoCanLocateMe = listOf(alice)), now).emergencyOn)
+        assertTrue(deriveLocationTiles(LocationUiState(whoCanLocateMePending = listOf(alice)), now).emergencyOn)
+        assertTrue(deriveLocationTiles(LocationUiState(whoICanLocate = listOf(alice)), now).emergencyOn)
     }
 
     @Test
     fun canLocateMeCountDedupsRealAndPending() {
-        val tiles = deriveLocationTiles(
-            LocationUiState(whoCanLocateMe = listOf(alice), whoCanLocateMePending = listOf(alice, bob)),
-        )
+        val tiles = deriveLocationTiles(LocationUiState(whoCanLocateMe = listOf(alice), whoCanLocateMePending = listOf(alice, bob)), now)
         assertEquals(2, tiles.canLocateMeCount)
     }
 
     @Test
     fun historyFollowsTrackingSwitch() {
-        assertFalse(deriveLocationTiles(LocationUiState(allowLocationHistory = false)).historyOn)
-        assertTrue(deriveLocationTiles(LocationUiState(allowLocationHistory = true)).historyOn)
+        assertFalse(deriveLocationTiles(LocationUiState(allowLocationHistory = false), now).historyOn)
+        assertTrue(deriveLocationTiles(LocationUiState(allowLocationHistory = true), now).historyOn)
+    }
+
+    @Test
+    fun anotherDeviceReportingRecentlyTurnsHistoryOn() {
+        val phone = device("Pixel", lastFixMs = now - 60_000L)
+        val tiles = deriveLocationTiles(LocationUiState(allowLocationHistory = false, devices = listOf(phone)), now)
+        assertTrue(tiles.historyOn)
+        assertEquals(phone, tiles.trackedDevice)
+    }
+
+    @Test
+    fun freshestDeviceWins() {
+        val older = device("Tablet", lastFixMs = now - 3_600_000L)
+        val newer = device("Pixel", lastFixMs = now - 60_000L)
+        val tiles = deriveLocationTiles(LocationUiState(devices = listOf(older, newer)), now)
+        assertEquals(newer, tiles.trackedDevice)
+    }
+
+    @Test
+    fun staleDeviceFixKeepsHistoryOff() {
+        val quiet = device("Pixel", lastFixMs = now - LOCATE_STALE_WARN_MS - 1)
+        val tiles = deriveLocationTiles(LocationUiState(devices = listOf(quiet, device("Old", null))), now)
+        assertFalse(tiles.historyOn)
+        assertEquals(null, tiles.trackedDevice)
+    }
+
+    @Test
+    fun thisDeviceTrackingReportsNoTrackedDevice() {
+        val phone = device("Pixel", lastFixMs = now - 60_000L)
+        val tiles = deriveLocationTiles(LocationUiState(allowLocationHistory = true, devices = listOf(phone)), now)
+        assertTrue(tiles.historyOn)
+        assertEquals(null, tiles.trackedDevice)
+    }
+
+    @Test
+    fun pointsTodayCoversEveryDevice() {
+        val trace = DeviceTrace(Uuid.random(), segments = listOf(listOf(point(now - 1), point(now - 2)), listOf(point(now - 3))))
+        assertEquals(3, deriveLocationTiles(LocationUiState(pointsToday = 0, todayTraces = listOf(trace)), now).pointsToday)
+        assertEquals(7, deriveLocationTiles(LocationUiState(pointsToday = 7, todayTraces = listOf(trace)), now).pointsToday)
     }
 
     @Test
     fun liveOnForEitherDirection() {
         val outgoing = OutgoingShareRow("bob.example", "Bob", "B", untilMs = 1L)
         val incoming = IncomingShareRow("bob.example", "Bob", "B", ageMs = 0L)
-        assertFalse(deriveLocationTiles(LocationUiState()).liveOn)
-        assertTrue(deriveLocationTiles(LocationUiState(outgoingShares = listOf(outgoing))).liveOn)
-        assertTrue(deriveLocationTiles(LocationUiState(incomingShares = listOf(incoming))).liveOn)
+        assertFalse(deriveLocationTiles(LocationUiState(), now).liveOn)
+        assertTrue(deriveLocationTiles(LocationUiState(outgoingShares = listOf(outgoing)), now).liveOn)
+        assertTrue(deriveLocationTiles(LocationUiState(incomingShares = listOf(incoming)), now).liveOn)
     }
 
     @Test
     fun settingsOnForViewersAndFullGrants() {
-        assertTrue(deriveLocationTiles(LocationUiState(trackingAvailable = false)).settingsOn)
+        assertTrue(deriveLocationTiles(LocationUiState(trackingAvailable = false), now).settingsOn)
         assertTrue(
-            deriveLocationTiles(
-                LocationUiState(trackingAvailable = true, whileInUseGranted = true, alwaysGranted = true),
-            ).settingsOn,
+            deriveLocationTiles(LocationUiState(trackingAvailable = true, whileInUseGranted = true, alwaysGranted = true), now).settingsOn,
         )
         assertFalse(
-            deriveLocationTiles(
-                LocationUiState(trackingAvailable = true, whileInUseGranted = true, alwaysGranted = false),
-            ).settingsOn,
+            deriveLocationTiles(LocationUiState(trackingAvailable = true, whileInUseGranted = true, alwaysGranted = false), now).settingsOn,
         )
     }
 
     @Test
     fun staleCountMirrorsState() {
-        assertEquals(3, deriveLocationTiles(LocationUiState(staleLocatableCount = 3)).staleCount)
+        assertEquals(3, deriveLocationTiles(LocationUiState(staleLocatableCount = 3), now).staleCount)
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to #1477.

**History tile on viewer devices.** The tile keyed on this device's tracking switch, so a desktop or web viewer always read "Off · Press to activate" while the phone was recording and the overview behind the tile showed today's route. The tile home already loads the device list and today's traces from the local index (no server call), so the tile now:

- counts as **on** when this device tracks **or** any device of this identity has a fix inside the two-day stale window (`LOCATE_STALE_WARN_MS`, the same threshold the emergency badge uses);
- when this device isn't tracking, names the freshest reporting device: `Tracked by Pixel 8 · 412 points today`;
- counts today's points across every device (this device's own count only covers its own hour files);
- on a viewer device that has nothing recent, says `Turn on tracking on your phone` instead of `Press to activate`, which can't do anything there. Phones keep `Press to activate`.

**AGP 9.4.0** (second commit): catalog bump from 9.3.2.

## Verification

- `LocationTileStateTest`: another device reporting recently turns the tile on and is named; the freshest device wins; a fix older than two days keeps it off; this device tracking reports no tracked device; points today cover every device.
- Konsist `ArchitectureTest` and `:homebase-core:compileAndroidMain` green locally under AGP 9.4.0.
- Two new strings in `values` and `values-da`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018oaD6R9dVELCdBePha3MHH
