### PR TITLE
Media settings screen with opt-in auto-save of incoming chat media (#1154)

### DIFF
--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -17,6 +17,8 @@
         android:name="android.permission.WRITE_EXTERNAL_STORAGE"
         android:maxSdkVersion="28" />
     <uses-permission android:name="android.permission.INTERNET" />
+    <!-- Metered-vs-unmetered for the "only on Wi-Fi" auto-save guard. -->
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <!--    <uses-permission android:name="android.permission.CAMERA" />-->
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/AutoSavedMediaWrapper.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/AutoSavedMediaWrapper.kt
@@ -1,0 +1,23 @@
+package id.homebase.api.sync.database
+
+import app.cash.sqldelight.db.SqlDriver
+
+class AutoSavedMediaWrapper(
+    driver: SqlDriver,
+    private val databaseManager: DatabaseManager,
+) {
+    private val delegate = AutoSavedMediaQueries(driver)
+
+    suspend fun isSaved(fileId: String, payloadKey: String): Boolean =
+        databaseManager.readValue("autoSavedMedia.isSaved") {
+            (delegate.isSaved(fileId, payloadKey).executeAsOneOrNull() ?: 0L) > 0L
+        }
+
+    suspend fun markSaved(fileId: String, payloadKey: String) {
+        databaseManager.withWriteValue { delegate.markSaved(fileId, payloadKey) }
+    }
+
+    suspend fun deleteAll() {
+        databaseManager.withWriteValue { delegate.deleteAll() }
+    }
+}

--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/DatabaseManager.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/sync/database/DatabaseManager.kt
@@ -232,6 +232,7 @@ class DatabaseManager(
         // on logout — exactly the class of bug that leaks Outbox rows across sessions.
         internal val TABLE_NAMES = listOf(
             "AppNotifications",
+            "AutoSavedMedia",
             "ChatReadCount",
             "ConnectionCache",
             "DriveLocalTagIndex",
@@ -319,6 +320,9 @@ class DatabaseManager(
         }
     }
 
+    val autoSavedMedia: AutoSavedMediaWrapper by lazy {
+        AutoSavedMediaWrapper(driver, this)
+    }
     val appNotifications: AppNotificationsWrapper by lazy {
         AppNotificationsWrapper(
             driver,

--- a/homebase-api/src/commonMain/sqldelight/id/homebase/api/sync/database/AutoSavedMedia.sq
+++ b/homebase-api/src/commonMain/sqldelight/id/homebase/api/sync/database/AutoSavedMedia.sq
@@ -1,0 +1,20 @@
+-- One row per payload the chat media auto-save has already written to the device album.
+-- Required, not an optimisation: BatchReceived re-fires for edits, reactions and delivery-status
+-- fan-out, and a re-sync replays the whole window, so without a durable marker a reaction to an
+-- old photo re-saves it and a re-sync duplicates the album.
+CREATE TABLE IF NOT EXISTS AutoSavedMedia(
+  fileId TEXT NOT NULL,
+  payloadKey TEXT NOT NULL,
+  PRIMARY KEY(fileId, payloadKey)
+);
+
+markSaved:
+INSERT OR IGNORE INTO AutoSavedMedia(fileId, payloadKey)
+VALUES (?, ?);
+
+isSaved:
+SELECT COUNT(*) FROM AutoSavedMedia
+WHERE fileId = ? AND payloadKey = ?;
+
+deleteAll:
+DELETE FROM AutoSavedMedia;

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMediaAutoSaveRules.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMediaAutoSaveRules.kt
@@ -1,0 +1,58 @@
+package id.homebase.chat.services
+
+import id.homebase.api.client.drives.files.DescriptorContent
+import id.homebase.api.client.drives.files.PayloadDescriptor
+
+const val HLS_PLAYLIST_CONTENT_TYPE = "application/vnd.apple.mpegurl"
+
+/**
+ * Whether one payload of one chat message should be downloaded and written to the device album.
+ * Pure so the policy can be tested without Compose, a database or a network.
+ */
+fun shouldAutoSave(
+    payload: PayloadDescriptor,
+    isIncoming: Boolean,
+    isSoftDeleted: Boolean,
+    autoSaveEnabled: Boolean,
+    unmeteredOnly: Boolean,
+    isUnmetered: Boolean,
+    alreadySaved: Boolean,
+    messageTimestampMs: Long,
+    enabledSinceMs: Long,
+): Boolean {
+    if (!autoSaveEnabled) return false
+    if (unmeteredOnly && !isUnmetered) return false
+    if (!isIncoming || isSoftDeleted || alreadySaved) return false
+    // Only what arrived after the switch was flipped: the recent-message window the sync lane
+    // rescans still holds older media the user never asked to have copied into their album.
+    if (messageTimestampMs < enabledSinceMs) return false
+    if (isNonMediaPayloadKey(payload.key)) return false
+
+    val contentType = payload.contentType ?: return false
+    return when {
+        contentType.startsWith("image/") ->
+            (payload.descriptorInfo() as? DescriptorContent.ImageFile)?.isSticker != true
+
+        // ponytail: segmented video is skipped rather than remuxed. Saving it needs
+        // MediaDownloadHandler.downloadAndRemuxHlsToMp4, whose concurrent ffmpeg_execute calls
+        // crash on iOS — put the remux behind a single-permit semaphore before enabling it here.
+        contentType == HLS_PLAYLIST_CONTENT_TYPE -> false
+
+        contentType.startsWith("video/") ->
+            (payload.descriptorInfo() as? DescriptorContent.VideoFile)?.isSegmented != true
+
+        else -> false
+    }
+}
+
+/**
+ * Payload keys that carry app plumbing rather than a photo the user would want in their album:
+ * the message body overflow and event cover photos (`chat_web` keys), link and location previews
+ * (both of which carry an image content type), and the two descriptor slots.
+ */
+private fun isNonMediaPayloadKey(key: String): Boolean =
+    key == ChatProtocol.DefaultPayloadKey ||
+        key == ChatProtocol.PAYLOAD_KEY_LINKS ||
+        key == ChatProtocol.PAYLOAD_KEY_LOCATION ||
+        key.startsWith(ChatProtocol.PAYLOAD_KEY_MESSAGE_WEB) ||
+        key.startsWith(ChatProtocol.DEFAULT_PAYLOAD_DESCRIPTOR_KEY)

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMediaAutoSaveService.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMediaAutoSaveService.kt
@@ -1,0 +1,163 @@
+package id.homebase.chat.services
+
+import co.touchlab.kermit.Logger
+import id.homebase.api.client.KeyHeader
+import id.homebase.api.client.auth.CredentialsManager
+import id.homebase.api.client.drives.FileStateFilter
+import id.homebase.api.client.drives.HomebaseFile
+import id.homebase.api.client.drives.QueryBatchSortField
+import id.homebase.api.client.drives.QueryBatchSortOrder
+import id.homebase.api.client.drives.files.ExportDestination
+import id.homebase.api.client.drives.files.PayloadDescriptor
+import id.homebase.api.client.drives.files.PayloadDownloadService
+import id.homebase.api.client.eventbus.BackendEvent
+import id.homebase.api.client.eventbus.EventBus
+import id.homebase.api.coroutines.ioDispatcher
+import id.homebase.api.coroutines.supervisedScope
+import id.homebase.api.file.FileOperationsProvider
+import id.homebase.api.sync.database.DatabaseManager
+import id.homebase.api.sync.database.QueryBatch
+import id.homebase.core.config.chatTargetDrive
+import id.homebase.core.settings.UserPreferences
+import id.homebase.core.util.AlbumAccessDeniedException
+import id.homebase.core.util.AlbumSaver
+import id.homebase.core.util.NetworkMonitor
+import id.homebase.core.util.extensionForMimeType
+import id.homebase.core.util.saveAwait
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.io.files.Path
+import kotlin.io.encoding.Base64
+
+private const val TAG = "ChatMediaAutoSave"
+
+/** Newest messages re-examined after a silent DriveSync round. */
+private const val RECENT_SCAN_LIMIT = 200
+
+/**
+ * Downloads incoming chat photos and videos in the background and writes them to the device
+ * album, so the album is complete without the user opening anything.
+ *
+ * Listens on both receive lanes, because either alone misses most media: live WS pushes arrive as
+ * [BackendEvent.DataEvent.BatchReceived], while everything that landed while the app was closed
+ * comes in through the deliberately silent REST DriveSync, which only announces
+ * [BackendEvent.DriveEvent.Stopped].
+ */
+class ChatMediaAutoSaveService(
+    private val credentialsManager: CredentialsManager,
+    private val dbm: DatabaseManager,
+    private val eventBus: EventBus,
+    private val payloadDownloadService: PayloadDownloadService,
+    private val fileOperationsProvider: FileOperationsProvider,
+    private val albumSaver: AlbumSaver,
+    private val networkMonitor: NetworkMonitor,
+    private val userPreferences: UserPreferences,
+) {
+    private val scope = supervisedScope("chat-media-autosave", ioDispatcher)
+    private val chatDrive = chatTargetDrive.alias
+
+    // One run at a time: overlapping runs would race the marker read/write and duplicate saves.
+    private val runLock = Mutex()
+
+    init {
+        scope.launch {
+            eventBus.events.collect { event ->
+                when (event) {
+                    is BackendEvent.DataEvent.BatchReceived -> {
+                        if (event.driveId != chatDrive) return@collect
+                        scope.launch { saveAll(event.batchData) }
+                    }
+
+                    is BackendEvent.DriveEvent.Stopped -> {
+                        if (event.driveId != chatDrive || event.totalCount == 0) return@collect
+                        scope.launch { saveRecent() }
+                    }
+
+                    else -> {}
+                }
+            }
+        }
+    }
+
+    private suspend fun saveRecent() {
+        if (!userPreferences.autoSaveIncomingMedia) return
+        val identityId = credentialsManager.getActiveCredentials()?.getIdentityId() ?: return
+        val result = QueryBatch(identityId).queryBatchAsync(
+            dbm = dbm,
+            driveId = chatDrive,
+            noOfItems = RECENT_SCAN_LIMIT,
+            sortOrder = QueryBatchSortOrder.NewestFirst,
+            sortField = QueryBatchSortField.UserDate,
+            fileSystemType = 0,
+            fileState = FileStateFilter.Active,
+            filetypesAnyOf = listOf(ChatProtocol.MessageFileType),
+        )
+        saveAll(result.records)
+    }
+
+    private suspend fun saveAll(files: List<HomebaseFile>) = runLock.withLock {
+        val enabled = userPreferences.autoSaveIncomingMedia
+        if (!enabled) return@withLock
+        val self = credentialsManager.getActiveCredentials()?.domain ?: return@withLock
+        val unmeteredOnly = userPreferences.autoSaveOnUnmeteredOnly
+        val unmetered = networkMonitor.isUnmetered()
+        val enabledSince = userPreferences.autoSaveIncomingMediaSince
+
+        try {
+            for (file in files) {
+                if (file.fileMetadata.appData.fileType != ChatProtocol.MessageFileType) continue
+                val author = file.fileMetadata.originalAuthor
+                // A null author is a self-authored row the server never stamped.
+                val isIncoming = author != null && author != self
+                for (payload in file.fileMetadata.payloads.orEmpty()) {
+                    val alreadySaved =
+                        dbm.autoSavedMedia.isSaved(file.fileId.toString(), payload.key)
+                    val save = shouldAutoSave(
+                        payload = payload,
+                        isIncoming = isIncoming,
+                        isSoftDeleted = file.isSoftDeleted(),
+                        autoSaveEnabled = enabled,
+                        unmeteredOnly = unmeteredOnly,
+                        isUnmetered = unmetered,
+                        alreadySaved = alreadySaved,
+                        messageTimestampMs = file.fileMetadata.appData.userDate
+                            ?: file.fileMetadata.created.milliseconds,
+                        enabledSinceMs = enabledSince,
+                    )
+                    if (save) saveOne(file, payload)
+                }
+            }
+        } catch (e: AlbumAccessDeniedException) {
+            Logger.w(tag = TAG) { "Album not writable, abandoning this batch: ${e.message}" }
+        }
+    }
+
+    private suspend fun saveOne(file: HomebaseFile, payload: PayloadDescriptor) {
+        val iv = payload.iv ?: return
+        val extension = payload.contentType?.let { extensionForMimeType(it) } ?: "bin"
+        val name = "homebase_${file.fileId}_${payload.key}.$extension"
+
+        val path = payloadDownloadService.exportToTemp(
+            driveId = chatDrive,
+            fileId = file.fileId,
+            key = payload.key,
+            keyHeader = KeyHeader(Base64.decode(iv), file.keyHeader.aesKey),
+            destination = ExportDestination.CacheRoot("hbautosave_", ".$extension"),
+        ) ?: return
+
+        try {
+            // The export lands in cacheDir, which the CacheSweeper reaps — hand it straight over
+            // and drop it, rather than treating it as the saved copy.
+            val location = albumSaver.saveAwait(Path(path), name)
+            dbm.autoSavedMedia.markSaved(file.fileId.toString(), payload.key)
+            Logger.d(tag = TAG) { "Saved ${payload.key} of ${file.fileId} to $location" }
+        } catch (e: AlbumAccessDeniedException) {
+            throw e
+        } catch (e: Exception) {
+            Logger.w(throwable = e, tag = TAG) { "Auto-save failed for ${payload.key}" }
+        } finally {
+            runCatching { fileOperationsProvider.deleteTempFile(path) }
+        }
+    }
+}

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMediaAutoSaveRulesTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMediaAutoSaveRulesTest.kt
@@ -1,0 +1,123 @@
+package id.homebase.chat.services
+
+import id.homebase.api.client.drives.files.PayloadDescriptor
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ChatMediaAutoSaveRulesTest {
+
+    private val photo = PayloadDescriptor(key = "chat_img0", contentType = "image/jpeg")
+
+    private fun decide(
+        payload: PayloadDescriptor = photo,
+        isIncoming: Boolean = true,
+        isSoftDeleted: Boolean = false,
+        autoSaveEnabled: Boolean = true,
+        unmeteredOnly: Boolean = true,
+        isUnmetered: Boolean = true,
+        alreadySaved: Boolean = false,
+        messageTimestampMs: Long = 2_000L,
+        enabledSinceMs: Long = 1_000L,
+    ) = shouldAutoSave(
+        payload = payload,
+        isIncoming = isIncoming,
+        isSoftDeleted = isSoftDeleted,
+        autoSaveEnabled = autoSaveEnabled,
+        unmeteredOnly = unmeteredOnly,
+        isUnmetered = isUnmetered,
+        alreadySaved = alreadySaved,
+        messageTimestampMs = messageTimestampMs,
+        enabledSinceMs = enabledSinceMs,
+    )
+
+    @Test
+    fun incomingPhotoIsSaved() = assertTrue(decide())
+
+    @Test
+    fun incomingVideoIsSaved() =
+        assertTrue(decide(payload = PayloadDescriptor(key = "chat_vid0", contentType = "video/mp4")))
+
+    @Test
+    fun settingOffSavesNothing() = assertFalse(decide(autoSaveEnabled = false))
+
+    @Test
+    fun nonMediaContentTypeIsSkipped() =
+        assertFalse(decide(payload = PayloadDescriptor(key = "chat_doc0", contentType = "application/pdf")))
+
+    @Test
+    fun missingContentTypeIsSkipped() =
+        assertFalse(decide(payload = PayloadDescriptor(key = "chat_img0", contentType = null)))
+
+    @Test
+    fun messageBodyOverflowIsSkipped() =
+        assertFalse(decide(payload = PayloadDescriptor(key = "chat_web0", contentType = "image/jpeg")))
+
+    @Test
+    fun linkPreviewIsSkipped() =
+        assertFalse(decide(payload = PayloadDescriptor(key = "chat_links", contentType = "image/jpeg")))
+
+    @Test
+    fun locationPreviewIsSkipped() =
+        assertFalse(decide(payload = PayloadDescriptor(key = "chat_loc", contentType = "image/jpeg")))
+
+    @Test
+    fun defaultPayloadKeyIsSkipped() =
+        assertFalse(decide(payload = PayloadDescriptor(key = "dflt_key", contentType = "image/jpeg")))
+
+    @Test
+    fun payloadDescriptorKeyIsSkipped() =
+        assertFalse(decide(payload = PayloadDescriptor(key = "pld_desc0", contentType = "image/jpeg")))
+
+    @Test
+    fun stickerIsSkipped() = assertFalse(
+        decide(
+            payload = PayloadDescriptor(
+                key = "chat_img0",
+                contentType = "image/png",
+                descriptorContent = """{"isSticker":true}""",
+            )
+        )
+    )
+
+    @Test
+    fun ownOutgoingMessageIsSkipped() = assertFalse(decide(isIncoming = false))
+
+    @Test
+    fun softDeletedMessageIsSkipped() = assertFalse(decide(isSoftDeleted = true))
+
+    @Test
+    fun alreadySavedPayloadIsSkipped() = assertFalse(decide(alreadySaved = true))
+
+    @Test
+    fun hlsPlaylistIsSkipped() = assertFalse(
+        decide(payload = PayloadDescriptor(key = "chat_vid0", contentType = HLS_PLAYLIST_CONTENT_TYPE))
+    )
+
+    @Test
+    fun segmentedVideoIsSkipped() = assertFalse(
+        decide(
+            payload = PayloadDescriptor(
+                key = "chat_vid0",
+                contentType = "video/mp4",
+                descriptorContent = """{"mimeType":"video/mp4","isSegmented":true}""",
+            )
+        )
+    )
+
+    @Test
+    fun meteredNetworkIsSkippedWhileTheWifiGuardIsOn() =
+        assertFalse(decide(unmeteredOnly = true, isUnmetered = false))
+
+    @Test
+    fun meteredNetworkIsSavedOnceTheWifiGuardIsOff() =
+        assertTrue(decide(unmeteredOnly = false, isUnmetered = false))
+
+    @Test
+    fun mediaOlderThanTheSwitchIsNotBackfilled() =
+        assertFalse(decide(messageTimestampMs = 999L, enabledSinceMs = 1_000L))
+
+    @Test
+    fun mediaAtTheMomentOfEnablingIsSaved() =
+        assertTrue(decide(messageTimestampMs = 1_000L, enabledSinceMs = 1_000L))
+}

--- a/homebase-common/src/androidMain/kotlin/id/homebase/core/util/AlbumSaver.android.kt
+++ b/homebase-common/src/androidMain/kotlin/id/homebase/core/util/AlbumSaver.android.kt
@@ -13,6 +13,7 @@ import kotlinx.io.files.Path
 import java.io.File
 
 private const val TAG = "AndroidAlbumSaver"
+private const val ALBUM_FOLDER = "Homebase"
 
 class AndroidAlbumSaver(private val context: Context) : AlbumSaver {
 
@@ -63,10 +64,11 @@ class AndroidAlbumSaver(private val context: Context) : AlbumSaver {
                                     Environment.DIRECTORY_DOWNLOADS
                     }
 
+                    val relativePath = "$directory/$ALBUM_FOLDER"
                     val values = ContentValues().apply {
                         put(MediaStore.MediaColumns.DISPLAY_NAME, safeName)
                         put(MediaStore.MediaColumns.MIME_TYPE, mimeType)
-                        put(MediaStore.MediaColumns.RELATIVE_PATH, directory)
+                        put(MediaStore.MediaColumns.RELATIVE_PATH, relativePath)
                         put(MediaStore.MediaColumns.IS_PENDING, 1)
                     }
 
@@ -88,7 +90,7 @@ class AndroidAlbumSaver(private val context: Context) : AlbumSaver {
                         throw e
                     }
 
-                    onSuccess(directory)
+                    onSuccess(relativePath)
                 } else {
                     // API 27-28 — legacy external storage
                     val hasPermission = ContextCompat.checkSelfPermission(
@@ -107,8 +109,11 @@ class AndroidAlbumSaver(private val context: Context) : AlbumSaver {
                         else -> Environment.DIRECTORY_DOWNLOADS
                     }
 
+                    val relativePath = "$directory/$ALBUM_FOLDER"
+
                     @Suppress("DEPRECATION")
-                    val destDir = Environment.getExternalStoragePublicDirectory(directory)
+                    val publicDir = Environment.getExternalStoragePublicDirectory(directory)
+                    val destDir = File(publicDir, ALBUM_FOLDER)
                     destDir.mkdirs()
                     val destFile = File(destDir, safeName)
                     destFile.outputStream().use { out ->
@@ -122,7 +127,7 @@ class AndroidAlbumSaver(private val context: Context) : AlbumSaver {
                         null,
                     )
 
-                    onSuccess(directory)
+                    onSuccess(relativePath)
                 }
             } catch (e: Exception) {
                 Logger.e(throwable = e, tag = TAG) { "Failed to save file: ${e.message}" }

--- a/homebase-common/src/androidMain/kotlin/id/homebase/core/util/AlbumSaver.android.kt
+++ b/homebase-common/src/androidMain/kotlin/id/homebase/core/util/AlbumSaver.android.kt
@@ -1,0 +1,133 @@
+package id.homebase.core.util
+
+import android.content.ContentValues
+import android.content.Context
+import android.media.MediaScannerConnection
+import android.os.Build
+import android.os.Environment
+import android.provider.MediaStore
+import androidx.core.content.ContextCompat
+import androidx.core.net.toUri
+import co.touchlab.kermit.Logger
+import kotlinx.io.files.Path
+import java.io.File
+
+private const val TAG = "AndroidAlbumSaver"
+
+class AndroidAlbumSaver(private val context: Context) : AlbumSaver {
+
+    override fun save(
+        file: Path,
+        suggestedName: String,
+        onSuccess: (String) -> Unit,
+        onError: (Throwable) -> Unit,
+    ) {
+        val safeName = suggestedName
+            .replace('/', '_')
+            .replace('\\', '_')
+            .replace('\u0000', '_')
+
+        // kotlinx.io.files.Path collapses `content://` to `content:/`; restore it.
+        val rawPath = file.toString()
+        val sourceUri = when {
+            rawPath.startsWith("content://") -> rawPath.toUri()
+            rawPath.startsWith("content:/") ->
+                "content://${rawPath.removePrefix("content:/")}".toUri()
+
+            else -> null
+        }
+
+        Thread {
+            try {
+                fun openSource(): java.io.InputStream = if (sourceUri != null) {
+                    context.contentResolver.openInputStream(sourceUri)
+                        ?: throw Exception("Failed to open source URI: $sourceUri")
+                } else {
+                    File(rawPath).inputStream()
+                }
+                val mimeType = detectContentTypeFromExtensionOrHint(safeName)
+
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                    // API 29+ — use MediaStore (no permission needed)
+                    val (collection, directory) = when {
+                        mimeType.startsWith("image/") ->
+                            MediaStore.Images.Media.getContentUri(MediaStore.VOLUME_EXTERNAL_PRIMARY) to
+                                    Environment.DIRECTORY_PICTURES
+
+                        mimeType.startsWith("video/") ->
+                            MediaStore.Video.Media.getContentUri(MediaStore.VOLUME_EXTERNAL_PRIMARY) to
+                                    Environment.DIRECTORY_MOVIES
+
+                        else ->
+                            MediaStore.Downloads.getContentUri(MediaStore.VOLUME_EXTERNAL_PRIMARY) to
+                                    Environment.DIRECTORY_DOWNLOADS
+                    }
+
+                    val values = ContentValues().apply {
+                        put(MediaStore.MediaColumns.DISPLAY_NAME, safeName)
+                        put(MediaStore.MediaColumns.MIME_TYPE, mimeType)
+                        put(MediaStore.MediaColumns.RELATIVE_PATH, directory)
+                        put(MediaStore.MediaColumns.IS_PENDING, 1)
+                    }
+
+                    val resolver = context.contentResolver
+                    val uri = resolver.insert(collection, values)
+                        ?: throw Exception("Failed to create MediaStore entry")
+
+                    try {
+                        resolver.openOutputStream(uri)?.use { outputStream ->
+                            openSource().use { it.copyTo(outputStream) }
+                        } ?: throw Exception("Failed to open output stream")
+
+                        values.clear()
+                        values.put(MediaStore.MediaColumns.IS_PENDING, 0)
+                        resolver.update(uri, values, null, null)
+                    } catch (e: Exception) {
+                        // Clean up orphaned MediaStore entry on failure
+                        resolver.delete(uri, null, null)
+                        throw e
+                    }
+
+                    onSuccess(directory)
+                } else {
+                    // API 27-28 — legacy external storage
+                    val hasPermission = ContextCompat.checkSelfPermission(
+                        context,
+                        android.Manifest.permission.WRITE_EXTERNAL_STORAGE
+                    ) == android.content.pm.PackageManager.PERMISSION_GRANTED
+
+                    if (!hasPermission) {
+                        onError(AlbumAccessDeniedException("WRITE_EXTERNAL_STORAGE not granted"))
+                        return@Thread
+                    }
+
+                    val directory = when {
+                        mimeType.startsWith("image/") -> Environment.DIRECTORY_PICTURES
+                        mimeType.startsWith("video/") -> Environment.DIRECTORY_MOVIES
+                        else -> Environment.DIRECTORY_DOWNLOADS
+                    }
+
+                    @Suppress("DEPRECATION")
+                    val destDir = Environment.getExternalStoragePublicDirectory(directory)
+                    destDir.mkdirs()
+                    val destFile = File(destDir, safeName)
+                    destFile.outputStream().use { out ->
+                        openSource().use { it.copyTo(out) }
+                    }
+
+                    MediaScannerConnection.scanFile(
+                        context,
+                        arrayOf(destFile.absolutePath),
+                        arrayOf(mimeType),
+                        null,
+                    )
+
+                    onSuccess(directory)
+                }
+            } catch (e: Exception) {
+                Logger.e(throwable = e, tag = TAG) { "Failed to save file: ${e.message}" }
+                onError(e)
+            }
+        }.start()
+    }
+}

--- a/homebase-common/src/androidMain/kotlin/id/homebase/core/util/FileUtilities.android.kt
+++ b/homebase-common/src/androidMain/kotlin/id/homebase/core/util/FileUtilities.android.kt
@@ -1,16 +1,10 @@
 package id.homebase.core.util
 
-import android.content.ContentValues
 import android.content.Intent
-import android.media.MediaScannerConnection
-import android.os.Build
-import android.os.Environment
-import android.provider.MediaStore
 import androidx.browser.customtabs.CustomTabsIntent
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
-import androidx.core.content.ContextCompat
 import androidx.core.content.FileProvider
 import androidx.core.net.toUri
 import co.touchlab.kermit.Logger
@@ -24,6 +18,7 @@ actual fun getUriHandler(): FileSystemHandler {
     val context = LocalContext.current
 
     return remember {
+        val albumSaver = AndroidAlbumSaver(context)
         object : FileSystemHandler {
             override fun openUrl(url: String, onError: (Throwable) -> Unit) {
                 val customTabsIntent =
@@ -102,114 +97,9 @@ actual fun getUriHandler(): FileSystemHandler {
                 suggestedName: String,
                 onSuccess: (String) -> Unit,
                 onError: (Throwable) -> Unit,
-            ) {
-                val safeName = suggestedName
-                    .replace('/', '_')
-                    .replace('\\', '_')
-                    .replace('\u0000', '_')
-
-                // kotlinx.io.files.Path collapses `content://` to `content:/`; restore it.
-                val rawPath = file.toString()
-                val sourceUri = when {
-                    rawPath.startsWith("content://") -> rawPath.toUri()
-                    rawPath.startsWith("content:/") ->
-                        "content://${rawPath.removePrefix("content:/")}".toUri()
-                    else -> null
-                }
-
-                Thread {
-                    try {
-                        fun openSource(): java.io.InputStream = if (sourceUri != null) {
-                            context.contentResolver.openInputStream(sourceUri)
-                                ?: throw Exception("Failed to open source URI: $sourceUri")
-                        } else {
-                            File(rawPath).inputStream()
-                        }
-                        val mimeType = detectContentTypeFromExtensionOrHint(safeName)
-
-                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                            // API 29+ — use MediaStore (no permission needed)
-                            val (collection, directory) = when {
-                                mimeType.startsWith("image/") ->
-                                    MediaStore.Images.Media.getContentUri(MediaStore.VOLUME_EXTERNAL_PRIMARY) to
-                                            Environment.DIRECTORY_PICTURES
-
-                                mimeType.startsWith("video/") ->
-                                    MediaStore.Video.Media.getContentUri(MediaStore.VOLUME_EXTERNAL_PRIMARY) to
-                                            Environment.DIRECTORY_MOVIES
-
-                                else ->
-                                    MediaStore.Downloads.getContentUri(MediaStore.VOLUME_EXTERNAL_PRIMARY) to
-                                            Environment.DIRECTORY_DOWNLOADS
-                            }
-
-                            val values = ContentValues().apply {
-                                put(MediaStore.MediaColumns.DISPLAY_NAME, safeName)
-                                put(MediaStore.MediaColumns.MIME_TYPE, mimeType)
-                                put(MediaStore.MediaColumns.RELATIVE_PATH, directory)
-                                put(MediaStore.MediaColumns.IS_PENDING, 1)
-                            }
-
-                            val resolver = context.contentResolver
-                            val uri = resolver.insert(collection, values)
-                                ?: throw Exception("Failed to create MediaStore entry")
-
-                            try {
-                                resolver.openOutputStream(uri)?.use { outputStream ->
-                                    openSource().use { it.copyTo(outputStream) }
-                                } ?: throw Exception("Failed to open output stream")
-
-                                values.clear()
-                                values.put(MediaStore.MediaColumns.IS_PENDING, 0)
-                                resolver.update(uri, values, null, null)
-                            } catch (e: Exception) {
-                                // Clean up orphaned MediaStore entry on failure
-                                resolver.delete(uri, null, null)
-                                throw e
-                            }
-
-                            onSuccess(directory)
-                        } else {
-                            // API 27-28 — legacy external storage
-                            val hasPermission = ContextCompat.checkSelfPermission(
-                                context,
-                                android.Manifest.permission.WRITE_EXTERNAL_STORAGE
-                            ) == android.content.pm.PackageManager.PERMISSION_GRANTED
-
-                            if (!hasPermission) {
-                                // Fall back to share sheet if no write permission
-                                shareFile(file, onError)
-                                return@Thread
-                            }
-
-                            val directory = when {
-                                mimeType.startsWith("image/") -> Environment.DIRECTORY_PICTURES
-                                mimeType.startsWith("video/") -> Environment.DIRECTORY_MOVIES
-                                else -> Environment.DIRECTORY_DOWNLOADS
-                            }
-
-                            @Suppress("DEPRECATION")
-                            val destDir = Environment.getExternalStoragePublicDirectory(directory)
-                            destDir.mkdirs()
-                            val destFile = File(destDir, safeName)
-                            destFile.outputStream().use { out ->
-                                openSource().use { it.copyTo(out) }
-                            }
-
-                            MediaScannerConnection.scanFile(
-                                context,
-                                arrayOf(destFile.absolutePath),
-                                arrayOf(mimeType),
-                                null,
-                            )
-
-                            onSuccess(directory)
-                        }
-                    } catch (e: Exception) {
-                        Logger.e(throwable = e, tag = TAG) { "Failed to save file: ${e.message}" }
-                        onError(e)
-                    }
-                }.start()
+            ) = albumSaver.save(file, suggestedName, onSuccess) { e ->
+                // API 28 without WRITE_EXTERNAL_STORAGE has no album to write to.
+                if (e is AlbumAccessDeniedException) shareFile(file, onError) else onError(e)
             }
 
             override fun shareText(text: String, onError: (Throwable) -> Unit) {

--- a/homebase-common/src/androidMain/kotlin/id/homebase/core/util/NetworkMonitor.android.kt
+++ b/homebase-common/src/androidMain/kotlin/id/homebase/core/util/NetworkMonitor.android.kt
@@ -1,0 +1,15 @@
+package id.homebase.core.util
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
+import androidx.core.content.getSystemService
+
+class AndroidNetworkMonitor(private val context: Context) : NetworkMonitor {
+
+    override fun isUnmetered(): Boolean {
+        val manager = context.getSystemService<ConnectivityManager>() ?: return false
+        val capabilities = manager.getNetworkCapabilities(manager.activeNetwork) ?: return false
+        return capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_METERED)
+    }
+}

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -1434,6 +1434,8 @@
     <string name="video_web_large_playback_unsupported">Large videos can't be played in the browser yet</string>
 
     <!-- Media quality -->
+    <string name="settings_media">Media</string>
+    <string name="settings_media_desc">Quality and auto-saving</string>
     <string name="settings_media_quality">Media quality</string>
     <string name="settings_data_storage">Data and storage</string>
     <string name="settings_media_quality_header">Quality for photos and videos you send</string>
@@ -1446,6 +1448,13 @@
     <string name="cd_media_quality_high_on">High quality is on. Tap to send smaller photos and videos.</string>
     <string name="cd_media_quality_high_off">High quality is off. Tap to send photos and videos at full quality.</string>
     <string name="cd_media_quality_hd_badge">Sent in high quality</string>
+
+    <!-- Auto-save incoming media -->
+    <string name="settings_media_autosave_header">Saving what you receive</string>
+    <string name="settings_media_autosave">Save incoming media to my photo album</string>
+    <string name="settings_media_autosave_description">Photos and videos people send you are downloaded in the background and added to your album.</string>
+    <string name="settings_media_autosave_unmetered">Only on Wi-Fi</string>
+    <string name="settings_media_autosave_unmetered_description">Wait for an unmetered network instead of using mobile data.</string>
 
     <!-- Settings hub -->
     <string name="settings_category_general">General</string>

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/settings/UserPreferences.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/settings/UserPreferences.kt
@@ -4,6 +4,7 @@ import com.russhwolf.settings.Settings
 import id.homebase.api.image.MediaQuality
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlin.time.Clock
 import kotlin.uuid.Uuid
 
 class UserPreferences(private val settings: Settings) {
@@ -13,6 +14,8 @@ class UserPreferences(private val settings: Settings) {
             hapticsEnabled = hapticsEnabled,
             showDeveloperMenu = showDeveloperMenu,
             mediaQuality = mediaQuality,
+            autoSaveIncomingMedia = autoSaveIncomingMedia,
+            autoSaveOnUnmeteredOnly = autoSaveOnUnmeteredOnly,
         )
     )
     val preferenceState: StateFlow<PreferenceState> = _preferenceState
@@ -68,6 +71,34 @@ class UserPreferences(private val settings: Settings) {
         set(value) {
             settings.putString("media_quality", value.code)
             _preferenceState.value = _preferenceState.value.copy(mediaQuality = value)
+        }
+
+    /**
+     * Auto-save incoming chat photos and videos to the device album. Off by default — it writes
+     * to storage the user never asked us to fill.
+     */
+    var autoSaveIncomingMedia: Boolean
+        get() = settings.getBoolean("auto_save_incoming_media", false)
+        set(value) {
+            // Stamped on the way on so the first sync after enabling doesn't backfill the album
+            // with every photo still in the recent-message window.
+            if (value && !autoSaveIncomingMedia) {
+                settings.putLong("auto_save_incoming_media_since", Clock.System.now().toEpochMilliseconds())
+            }
+            settings.putBoolean("auto_save_incoming_media", value)
+            _preferenceState.value = _preferenceState.value.copy(autoSaveIncomingMedia = value)
+        }
+
+    /** Epoch ms at which [autoSaveIncomingMedia] was last switched on; 0 when it never was. */
+    val autoSaveIncomingMediaSince: Long
+        get() = settings.getLong("auto_save_incoming_media_since", 0L)
+
+    /** Guard on [autoSaveIncomingMedia]: skip the download while the network is metered. */
+    var autoSaveOnUnmeteredOnly: Boolean
+        get() = settings.getBoolean("auto_save_unmetered_only", true)
+        set(value) {
+            settings.putBoolean("auto_save_unmetered_only", value)
+            _preferenceState.value = _preferenceState.value.copy(autoSaveOnUnmeteredOnly = value)
         }
 
     var preferredUserReactions: List<String>
@@ -156,6 +187,8 @@ data class PreferenceState(
     val hapticsEnabled: Boolean,
     val showDeveloperMenu: Boolean = false,
     val mediaQuality: MediaQuality = MediaQuality.STANDARD,
+    val autoSaveIncomingMedia: Boolean = false,
+    val autoSaveOnUnmeteredOnly: Boolean = true,
 )
 
 enum class ThemeState {

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/ui/navigation/Routes.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/ui/navigation/Routes.kt
@@ -104,6 +104,10 @@ sealed class Route {
     data object StorageSettings : Route()
 
     @Serializable
+    @SerialName("media-settings")
+    data object MediaSettings : Route()
+
+    @Serializable
     @SerialName("defragmenter")
     data object Defragmenter : Route()
 

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/util/AlbumSaver.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/util/AlbumSaver.kt
@@ -1,0 +1,35 @@
+package id.homebase.core.util
+
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.io.files.Path
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+
+/**
+ * The platform "save this file where the user keeps their photos" implementation, reachable from a
+ * plain coroutine — [FileSystemHandler] is only obtainable from a Composable, so background callers
+ * (auto-save) cannot use it.
+ */
+interface AlbumSaver {
+    /** [onSuccess] receives a human-readable location name (e.g. "Downloads", "Photos"). */
+    fun save(
+        file: Path,
+        suggestedName: String,
+        onSuccess: (String) -> Unit = {},
+        onError: (Throwable) -> Unit = {},
+    )
+}
+
+/** The album is not writable for us. Retrying or re-prompting won't change that. */
+class AlbumAccessDeniedException(message: String) : Exception(message)
+
+/** Suspends until the save completes, so the caller can delete its temp file afterwards. */
+suspend fun AlbumSaver.saveAwait(file: Path, suggestedName: String): String =
+    suspendCancellableCoroutine { continuation ->
+        save(
+            file = file,
+            suggestedName = suggestedName,
+            onSuccess = { continuation.resume(it) },
+            onError = { continuation.resumeWithException(it) },
+        )
+    }

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/util/NetworkMonitor.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/util/NetworkMonitor.kt
@@ -1,0 +1,10 @@
+package id.homebase.core.util
+
+/**
+ * Metered-vs-unmetered for the active network. The WebSocket-derived
+ * `AuthConnectionCoordinator.isOnline` only answers "connected at all".
+ */
+fun interface NetworkMonitor {
+    /** True only when the active network is known to be unmetered. Unknown counts as metered. */
+    fun isUnmetered(): Boolean
+}

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/widget/SettingsRow.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/widget/SettingsRow.kt
@@ -150,7 +150,7 @@ fun SettingsRow(
             Text(text = title, maxLines = 2, overflow = TextOverflow.Ellipsis)
         },
         supportingContent = supportingText?.let { supporting ->
-            { Text(text = supporting, maxLines = 2, overflow = TextOverflow.Ellipsis) }
+            { Text(text = supporting) }
         },
         leadingContent = {
             Icon(imageVector = icon, contentDescription = null, modifier = Modifier.size(24.dp))

--- a/homebase-common/src/commonTest/kotlin/id/homebase/core/settings/AutoSaveMediaPreferenceTest.kt
+++ b/homebase-common/src/commonTest/kotlin/id/homebase/core/settings/AutoSaveMediaPreferenceTest.kt
@@ -1,0 +1,32 @@
+package id.homebase.core.settings
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class AutoSaveMediaPreferenceTest {
+
+    @Test
+    fun autoSaveIsOffAndTheWifiGuardIsOnByDefault() {
+        val prefs = UserPreferences(InMemorySettings())
+
+        assertFalse(prefs.autoSaveIncomingMedia)
+        assertTrue(prefs.autoSaveOnUnmeteredOnly)
+        assertFalse(prefs.preferenceState.value.autoSaveIncomingMedia)
+        assertTrue(prefs.preferenceState.value.autoSaveOnUnmeteredOnly)
+    }
+
+    @Test
+    fun bothRoundTripAndMirrorIntoPreferenceState() {
+        val prefs = UserPreferences(InMemorySettings())
+
+        prefs.autoSaveIncomingMedia = true
+        prefs.autoSaveOnUnmeteredOnly = false
+
+        assertTrue(prefs.autoSaveIncomingMedia)
+        assertFalse(prefs.autoSaveOnUnmeteredOnly)
+        // The settings screen and the background service both read the mirrored flow.
+        assertTrue(prefs.preferenceState.value.autoSaveIncomingMedia)
+        assertFalse(prefs.preferenceState.value.autoSaveOnUnmeteredOnly)
+    }
+}

--- a/homebase-common/src/jvmMain/kotlin/id/homebase/core/util/AlbumSaver.jvm.kt
+++ b/homebase-common/src/jvmMain/kotlin/id/homebase/core/util/AlbumSaver.jvm.kt
@@ -1,0 +1,33 @@
+package id.homebase.core.util
+
+import kotlinx.io.files.Path
+import java.io.File
+
+/** Desktop has no photo library; the user's Pictures / Downloads folder is the closest thing. */
+class JvmAlbumSaver : AlbumSaver {
+
+    override fun save(
+        file: Path,
+        suggestedName: String,
+        onSuccess: (String) -> Unit,
+        onError: (Throwable) -> Unit,
+    ) {
+        try {
+            val mimeType = detectContentTypeFromExtensionOrHint(suggestedName)
+            val folder = if (mimeType.startsWith("image/") || mimeType.startsWith("video/")) {
+                "Pictures"
+            } else {
+                "Downloads"
+            }
+            val destDir = File(System.getProperty("user.home"), folder).apply { mkdirs() }
+            val safeName = suggestedName
+                .replace('/', '_')
+                .replace('\\', '_')
+                .replace(' ', '_')
+            File(file.toString()).copyTo(File(destDir, safeName), overwrite = true)
+            onSuccess(folder)
+        } catch (e: Exception) {
+            onError(e)
+        }
+    }
+}

--- a/homebase-common/src/nativeMain/kotlin/id/homebase/core/util/AlbumSaver.native.kt
+++ b/homebase-common/src/nativeMain/kotlin/id/homebase/core/util/AlbumSaver.native.kt
@@ -1,0 +1,216 @@
+package id.homebase.core.util
+
+import co.touchlab.kermit.Logger
+import id.homebase.api.lib.image.ImageFormatDetector
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.ObjCObjectVar
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.alloc
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.ptr
+import kotlinx.cinterop.usePinned
+import kotlinx.cinterop.value
+import kotlinx.io.files.Path
+import platform.Foundation.NSData
+import platform.Foundation.NSDocumentDirectory
+import platform.Foundation.NSError
+import platform.Foundation.NSFileManager
+import platform.Foundation.NSSearchPathForDirectoriesInDomains
+import platform.Foundation.NSURL
+import platform.Foundation.NSUserDomainMask
+import platform.Foundation.dataWithContentsOfURL
+import platform.Photos.PHAccessLevelAddOnly
+import platform.Photos.PHAssetChangeRequest
+import platform.Photos.PHAssetCreationRequest
+import platform.Photos.PHAssetResourceTypePhoto
+import platform.Photos.PHAuthorizationStatusAuthorized
+import platform.Photos.PHAuthorizationStatusLimited
+import platform.Photos.PHAuthorizationStatusNotDetermined
+import platform.Photos.PHPhotoLibrary
+import platform.UIKit.UIImage
+import platform.UIKit.UIImageJPEGRepresentation
+import platform.posix.memcpy
+
+private const val TAG = "IosAlbumSaver"
+
+object IosAlbumSaver : AlbumSaver {
+
+    @OptIn(ExperimentalForeignApi::class, kotlinx.cinterop.BetaInteropApi::class)
+    override fun save(
+        file: Path,
+        suggestedName: String,
+        onSuccess: (String) -> Unit,
+        onError: (Throwable) -> Unit,
+    ) {
+        val fileUrl = NSURL.fileURLWithPath(file.toString())
+        val extension = suggestedName.substringAfterLast('.', "").lowercase()
+        val isImage =
+            extension in setOf("jpg", "jpeg", "png", "gif", "heic", "heif", "webp", "bmp", "tiff")
+        val isVideo = extension in setOf("mp4", "mov", "m4v", "avi", "mkv", "webm", "3gp")
+
+        if (isImage || isVideo) {
+            // Save to Photos library (add-only access)
+            when (PHPhotoLibrary.authorizationStatusForAccessLevel(PHAccessLevelAddOnly)) {
+                PHAuthorizationStatusAuthorized, PHAuthorizationStatusLimited ->
+                    saveToPhotoLibrary(fileUrl, isVideo, onSuccess, onError)
+
+                // Only NotDetermined may prompt. A prior denial must fail fast instead, or
+                // background auto-save re-asks on every incoming photo.
+                PHAuthorizationStatusNotDetermined ->
+                    PHPhotoLibrary.requestAuthorizationForAccessLevel(PHAccessLevelAddOnly) { newStatus ->
+                        if (newStatus == PHAuthorizationStatusAuthorized ||
+                            newStatus == PHAuthorizationStatusLimited
+                        ) {
+                            saveToPhotoLibrary(fileUrl, isVideo, onSuccess, onError)
+                        } else {
+                            onError(
+                                AlbumAccessDeniedException(
+                                    "Photo library access denied. Please enable in Settings."
+                                )
+                            )
+                        }
+                    }
+
+                else -> onError(
+                    AlbumAccessDeniedException(
+                        "Photo library access denied. Please enable in Settings."
+                    )
+                )
+            }
+        } else {
+            // Save other files to Documents directory
+            val scoped = fileUrl.startAccessingSecurityScopedResource()
+            try {
+                val safeName = suggestedName
+                    .replace('/', '_')
+                    .replace('\\', '_')
+                    .replace('\u0000', '_')
+                val fileManager = NSFileManager.defaultManager
+                val paths = NSSearchPathForDirectoriesInDomains(
+                    NSDocumentDirectory,
+                    NSUserDomainMask,
+                    true,
+                )
+                val documentsDir = paths.firstOrNull() as? String
+                    ?: throw Exception("Could not find Documents directory")
+                val destPath = "$documentsDir/$safeName"
+                val sourcePath = fileUrl.path
+                    ?: throw Exception("Source URL has no filesystem path: $fileUrl")
+
+                memScoped {
+                    // Remove existing file if present
+                    if (fileManager.fileExistsAtPath(destPath)) {
+                        val removeErr = alloc<ObjCObjectVar<NSError?>>()
+                        if (!fileManager.removeItemAtPath(destPath, removeErr.ptr)) {
+                            val msg = removeErr.value?.localizedDescription ?: "unknown error"
+                            throw Exception("Failed to remove existing file at $destPath: $msg")
+                        }
+                    }
+                    val copyErr = alloc<ObjCObjectVar<NSError?>>()
+                    if (!fileManager.copyItemAtPath(sourcePath, destPath, copyErr.ptr)) {
+                        val msg = copyErr.value?.localizedDescription ?: "unknown error"
+                        throw Exception("Failed to copy file to $destPath: $msg")
+                    }
+                }
+                // "Files" (not "Documents") — the saved file shows up in the
+                // Files app under On My iPhone > Homebase, which is where this
+                // points the user. Requires the Info.plist file-sharing keys.
+                onSuccess("Files")
+            } catch (e: Exception) {
+                onError(e)
+            } finally {
+                if (scoped) fileUrl.stopAccessingSecurityScopedResource()
+            }
+        }
+    }
+
+    @OptIn(ExperimentalForeignApi::class)
+    private fun saveToPhotoLibrary(
+        fileUrl: NSURL,
+        isVideo: Boolean,
+        onSuccess: (String) -> Unit,
+        onError: (Throwable) -> Unit,
+    ) {
+        val scoped = fileUrl.startAccessingSecurityScopedResource()
+
+        // Some image formats this platform serves (notably WebP, also AVIF)
+        // can be *displayed* by iOS but are rejected by the Photos library on
+        // import with PHPhotosError 3302 (invalidResource) — the cause of the
+        // "couldn't save photo" failures. UIImage can still decode them, so
+        // re-encode such files to JPEG and add them as raw photo-resource
+        // data. JPEG/PNG/GIF/HEIC import losslessly via the original file URL.
+        val reencodedJpeg: NSData? = if (isVideo) null else jpegForUnsupportedPhotoFormat(fileUrl)
+
+        PHPhotoLibrary.sharedPhotoLibrary().performChanges(
+            changeBlock = {
+                when {
+                    isVideo ->
+                        PHAssetChangeRequest.creationRequestForAssetFromVideoAtFileURL(fileUrl)
+
+                    reencodedJpeg != null ->
+                        PHAssetCreationRequest.creationRequestForAsset()
+                            .addResourceWithType(
+                                type = PHAssetResourceTypePhoto,
+                                data = reencodedJpeg,
+                                options = null,
+                            )
+
+                    else ->
+                        PHAssetChangeRequest.creationRequestForAssetFromImageAtFileURL(fileUrl)
+                }
+            },
+            completionHandler = { success, error ->
+                if (scoped) fileUrl.stopAccessingSecurityScopedResource()
+                if (success) {
+                    onSuccess("Photos")
+                } else {
+                    onError(Exception(error?.localizedDescription ?: "Failed to save to Photos"))
+                }
+            },
+        )
+    }
+
+    /**
+     * If [fileUrl] points to an image in a format the Photos library can't
+     * import (WebP/AVIF/BMP/unknown — anything other than JPEG/PNG/GIF/HEIC),
+     * decode it with UIImage and return JPEG bytes suitable for
+     * [PHAssetCreationRequest.addResourceWithType]. Returns null for formats
+     * Photos accepts directly (so the original bytes are preserved) or when
+     * the file can't be read/decoded (so Photos still gets to try the
+     * original and surface its own error).
+     */
+    @OptIn(ExperimentalForeignApi::class)
+    private fun jpegForUnsupportedPhotoFormat(fileUrl: NSURL): NSData? {
+        val data = NSData.dataWithContentsOfURL(fileUrl) ?: return null
+        val format = ImageFormatDetector.detectFormat(data.headerBytes(16))
+        val importsDirectly = format in setOf(
+            "image/jpeg", "image/png", "image/gif", "image/heic", "image/heif",
+        )
+        if (importsDirectly) return null
+
+        Logger.d(tag = TAG) {
+            "saveToPhotoLibrary: re-encoding $format to JPEG (Photos cannot import it directly)"
+        }
+        val uiImage = UIImage.imageWithData(data)
+        if (uiImage == null) {
+            Logger.w(tag = TAG) {
+                "saveToPhotoLibrary: UIImage could not decode $format; letting Photos try the original"
+            }
+            return null
+        }
+        return UIImageJPEGRepresentation(uiImage, 0.95)
+    }
+
+    /** Copy up to [count] leading bytes of this [NSData] into a [ByteArray]. */
+    @OptIn(ExperimentalForeignApi::class)
+    private fun NSData.headerBytes(count: Int): ByteArray {
+        val n = minOf(count.toULong(), length).toInt()
+        val out = ByteArray(n)
+        if (n > 0) {
+            out.usePinned { pinned ->
+                memcpy(pinned.addressOf(0), bytes, n.toULong())
+            }
+        }
+        return out
+    }
+}

--- a/homebase-common/src/nativeMain/kotlin/id/homebase/core/util/FileUtilities.native.kt
+++ b/homebase-common/src/nativeMain/kotlin/id/homebase/core/util/FileUtilities.native.kt
@@ -1,37 +1,12 @@
 package id.homebase.core.util
 
 import androidx.compose.runtime.Composable
-import co.touchlab.kermit.Logger
-import id.homebase.api.lib.image.ImageFormatDetector
 import kotlinx.cinterop.ExperimentalForeignApi
-import kotlinx.cinterop.ObjCObjectVar
-import kotlinx.cinterop.addressOf
-import kotlinx.cinterop.alloc
-import kotlinx.cinterop.memScoped
-import kotlinx.cinterop.ptr
-import kotlinx.cinterop.usePinned
-import kotlinx.cinterop.value
 import kotlinx.io.files.Path
-import platform.Foundation.NSData
-import platform.Foundation.NSDocumentDirectory
-import platform.Foundation.NSError
 import platform.Foundation.NSFileManager
-import platform.Foundation.NSSearchPathForDirectoriesInDomains
 import platform.Foundation.NSURL
-import platform.Foundation.NSUserDomainMask
-import platform.Foundation.dataWithContentsOfURL
-import platform.Photos.PHAccessLevelAddOnly
-import platform.Photos.PHAssetChangeRequest
-import platform.Photos.PHAssetCreationRequest
-import platform.Photos.PHAssetResourceTypePhoto
-import platform.Photos.PHAuthorizationStatusAuthorized
-import platform.Photos.PHAuthorizationStatusLimited
-import platform.Photos.PHPhotoLibrary
 import platform.UIKit.UIActivityViewController
 import platform.UIKit.UIApplication
-import platform.UIKit.UIImage
-import platform.UIKit.UIImageJPEGRepresentation
-import platform.posix.memcpy
 
 @Composable
 actual fun getUriHandler(): FileSystemHandler {
@@ -119,168 +94,12 @@ actual fun getUriHandler(): FileSystemHandler {
             }
         }
 
-        @OptIn(ExperimentalForeignApi::class, kotlinx.cinterop.BetaInteropApi::class)
         override fun saveFile(
             file: Path,
             suggestedName: String,
             onSuccess: (String) -> Unit,
             onError: (Throwable) -> Unit,
-        ) {
-            val fileUrl = NSURL.fileURLWithPath(file.toString())
-            val extension = suggestedName.substringAfterLast('.', "").lowercase()
-            val isImage = extension in setOf("jpg", "jpeg", "png", "gif", "heic", "heif", "webp", "bmp", "tiff")
-            val isVideo = extension in setOf("mp4", "mov", "m4v", "avi", "mkv", "webm", "3gp")
-
-            if (isImage || isVideo) {
-                // Save to Photos library (add-only access)
-                val status = PHPhotoLibrary.authorizationStatusForAccessLevel(PHAccessLevelAddOnly)
-                if (status != PHAuthorizationStatusAuthorized && status != PHAuthorizationStatusLimited) {
-                    PHPhotoLibrary.requestAuthorizationForAccessLevel(PHAccessLevelAddOnly) { newStatus ->
-                        if (newStatus == PHAuthorizationStatusAuthorized || newStatus == PHAuthorizationStatusLimited) {
-                            saveToPhotoLibrary(fileUrl, isVideo, onSuccess, onError)
-                        } else {
-                            onError(Exception("Photo library access denied. Please enable in Settings."))
-                        }
-                    }
-                } else {
-                    saveToPhotoLibrary(fileUrl, isVideo, onSuccess, onError)
-                }
-            } else {
-                // Save other files to Documents directory
-                val scoped = fileUrl.startAccessingSecurityScopedResource()
-                try {
-                    val safeName = suggestedName
-                        .replace('/', '_')
-                        .replace('\\', '_')
-                        .replace('\u0000', '_')
-                    val fileManager = NSFileManager.defaultManager
-                    val paths = NSSearchPathForDirectoriesInDomains(
-                        NSDocumentDirectory,
-                        NSUserDomainMask,
-                        true,
-                    )
-                    val documentsDir = paths.firstOrNull() as? String
-                        ?: throw Exception("Could not find Documents directory")
-                    val destPath = "$documentsDir/$safeName"
-                    val sourcePath = fileUrl.path
-                        ?: throw Exception("Source URL has no filesystem path: $fileUrl")
-
-                    memScoped {
-                        // Remove existing file if present
-                        if (fileManager.fileExistsAtPath(destPath)) {
-                            val removeErr = alloc<ObjCObjectVar<NSError?>>()
-                            if (!fileManager.removeItemAtPath(destPath, removeErr.ptr)) {
-                                val msg = removeErr.value?.localizedDescription ?: "unknown error"
-                                throw Exception("Failed to remove existing file at $destPath: $msg")
-                            }
-                        }
-                        val copyErr = alloc<ObjCObjectVar<NSError?>>()
-                        if (!fileManager.copyItemAtPath(sourcePath, destPath, copyErr.ptr)) {
-                            val msg = copyErr.value?.localizedDescription ?: "unknown error"
-                            throw Exception("Failed to copy file to $destPath: $msg")
-                        }
-                    }
-                    // "Files" (not "Documents") — the saved file shows up in the
-                    // Files app under On My iPhone > Homebase, which is where this
-                    // points the user. Requires the Info.plist file-sharing keys.
-                    onSuccess("Files")
-                } catch (e: Exception) {
-                    onError(e)
-                } finally {
-                    if (scoped) fileUrl.stopAccessingSecurityScopedResource()
-                }
-            }
-        }
-
-        @OptIn(ExperimentalForeignApi::class)
-        private fun saveToPhotoLibrary(
-            fileUrl: NSURL,
-            isVideo: Boolean,
-            onSuccess: (String) -> Unit,
-            onError: (Throwable) -> Unit,
-        ) {
-            val scoped = fileUrl.startAccessingSecurityScopedResource()
-
-            // Some image formats this platform serves (notably WebP, also AVIF)
-            // can be *displayed* by iOS but are rejected by the Photos library on
-            // import with PHPhotosError 3302 (invalidResource) — the cause of the
-            // "couldn't save photo" failures. UIImage can still decode them, so
-            // re-encode such files to JPEG and add them as raw photo-resource
-            // data. JPEG/PNG/GIF/HEIC import losslessly via the original file URL.
-            val reencodedJpeg: NSData? = if (isVideo) null else jpegForUnsupportedPhotoFormat(fileUrl)
-
-            PHPhotoLibrary.sharedPhotoLibrary().performChanges(
-                changeBlock = {
-                    when {
-                        isVideo ->
-                            PHAssetChangeRequest.creationRequestForAssetFromVideoAtFileURL(fileUrl)
-
-                        reencodedJpeg != null ->
-                            PHAssetCreationRequest.creationRequestForAsset()
-                                .addResourceWithType(
-                                    type = PHAssetResourceTypePhoto,
-                                    data = reencodedJpeg,
-                                    options = null,
-                                )
-
-                        else ->
-                            PHAssetChangeRequest.creationRequestForAssetFromImageAtFileURL(fileUrl)
-                    }
-                },
-                completionHandler = { success, error ->
-                    if (scoped) fileUrl.stopAccessingSecurityScopedResource()
-                    if (success) {
-                        onSuccess("Photos")
-                    } else {
-                        onError(Exception(error?.localizedDescription ?: "Failed to save to Photos"))
-                    }
-                },
-            )
-        }
-
-        /**
-         * If [fileUrl] points to an image in a format the Photos library can't
-         * import (WebP/AVIF/BMP/unknown — anything other than JPEG/PNG/GIF/HEIC),
-         * decode it with UIImage and return JPEG bytes suitable for
-         * [PHAssetCreationRequest.addResourceWithType]. Returns null for formats
-         * Photos accepts directly (so the original bytes are preserved) or when
-         * the file can't be read/decoded (so Photos still gets to try the
-         * original and surface its own error).
-         */
-        @OptIn(ExperimentalForeignApi::class)
-        private fun jpegForUnsupportedPhotoFormat(fileUrl: NSURL): NSData? {
-            val data = NSData.dataWithContentsOfURL(fileUrl) ?: return null
-            val format = ImageFormatDetector.detectFormat(data.headerBytes(16))
-            val importsDirectly = format in setOf(
-                "image/jpeg", "image/png", "image/gif", "image/heic", "image/heif",
-            )
-            if (importsDirectly) return null
-
-            Logger.d(tag = "FileUtilities") {
-                "saveToPhotoLibrary: re-encoding $format to JPEG (Photos cannot import it directly)"
-            }
-            val uiImage = UIImage.imageWithData(data)
-            if (uiImage == null) {
-                Logger.w(tag = "FileUtilities") {
-                    "saveToPhotoLibrary: UIImage could not decode $format; letting Photos try the original"
-                }
-                return null
-            }
-            return UIImageJPEGRepresentation(uiImage, 0.95)
-        }
-
-        /** Copy up to [count] leading bytes of this [NSData] into a [ByteArray]. */
-        @OptIn(ExperimentalForeignApi::class)
-        private fun NSData.headerBytes(count: Int): ByteArray {
-            val n = minOf(count.toULong(), length).toInt()
-            val out = ByteArray(n)
-            if (n > 0) {
-                out.usePinned { pinned ->
-                    memcpy(pinned.addressOf(0), bytes, n.toULong())
-                }
-            }
-            return out
-        }
+        ) = IosAlbumSaver.save(file, suggestedName, onSuccess, onError)
 
         override fun shareText(text: String, onError: (Throwable) -> Unit) {
             try {

--- a/homebase-common/src/nativeMain/kotlin/id/homebase/core/util/NetworkMonitor.native.kt
+++ b/homebase-common/src/nativeMain/kotlin/id/homebase/core/util/NetworkMonitor.native.kt
@@ -1,0 +1,38 @@
+package id.homebase.core.util
+
+import kotlinx.atomicfu.atomic
+import kotlinx.cinterop.ExperimentalForeignApi
+import platform.Network.nw_path_get_status
+import platform.Network.nw_path_is_constrained
+import platform.Network.nw_path_is_expensive
+import platform.Network.nw_path_monitor_create
+import platform.Network.nw_path_monitor_set_queue
+import platform.Network.nw_path_monitor_set_update_handler
+import platform.Network.nw_path_monitor_start
+import platform.Network.nw_path_status_satisfied
+import platform.darwin.DISPATCH_QUEUE_PRIORITY_DEFAULT
+import platform.darwin.dispatch_get_global_queue
+
+/** NWPathMonitor pushes; [isUnmetered] reads the latest push, so it never blocks the caller. */
+@OptIn(ExperimentalForeignApi::class)
+class IosNetworkMonitor : NetworkMonitor {
+
+    private val unmetered = atomic(false)
+
+    init {
+        val monitor = nw_path_monitor_create()
+        nw_path_monitor_set_queue(
+            monitor,
+            dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT.toLong(), 0u),
+        )
+        nw_path_monitor_set_update_handler(monitor) { path ->
+            unmetered.value = path != null &&
+                nw_path_get_status(path) == nw_path_status_satisfied &&
+                !nw_path_is_expensive(path) &&
+                !nw_path_is_constrained(path)
+        }
+        nw_path_monitor_start(monitor)
+    }
+
+    override fun isUnmetered(): Boolean = unmetered.value
+}

--- a/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/util/AlbumSaver.web.kt
+++ b/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/util/AlbumSaver.web.kt
@@ -1,0 +1,12 @@
+package id.homebase.core.util
+
+import kotlinx.io.files.Path
+
+object WebAlbumSaver : AlbumSaver {
+    override fun save(
+        file: Path,
+        suggestedName: String,
+        onSuccess: (String) -> Unit,
+        onError: (Throwable) -> Unit,
+    ) = onError(AlbumAccessDeniedException("The browser has no photo album to write to"))
+}

--- a/homebase-core/src/androidMain/kotlin/id/homebase/core/di/AppModule.android.kt
+++ b/homebase-core/src/androidMain/kotlin/id/homebase/core/di/AppModule.android.kt
@@ -35,7 +35,11 @@ import id.homebase.core.settings.createSettings
 import id.homebase.core.share.ShareCacheStorage
 import id.homebase.core.updater.AndroidUpdateAppManager
 import id.homebase.core.updater.UpdateAppManager
+import id.homebase.core.util.AlbumSaver
+import id.homebase.core.util.AndroidAlbumSaver
+import id.homebase.core.util.AndroidNetworkMonitor
 import id.homebase.core.util.AndroidPlatformInfo
+import id.homebase.core.util.NetworkMonitor
 import id.homebase.core.diagnostics.AndroidDiagnosticsCrashTrigger
 import id.homebase.core.diagnostics.DiagnosticsCrashTrigger
 import id.homebase.core.util.PlatformInfo
@@ -46,6 +50,8 @@ import org.koin.dsl.module
 actual fun platformModule(): Module = module {
     single<FileOperationsProvider> { AndroidFileOperationsProvider(androidContext()) }
     single { ShareCacheStorage(androidContext()) }
+    single<AlbumSaver> { AndroidAlbumSaver(androidContext()) }
+    single<NetworkMonitor> { AndroidNetworkMonitor(androidContext()) }
     single { createSettings(androidContext()) }
     single<PlatformGalleryManager> { AndroidGalleryManager(androidContext()) }
     single(createdAtStart = true) {

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
@@ -61,6 +61,7 @@ import id.homebase.core.location.emergency.EmergencyLocateStore
 import id.homebase.chat.services.livelocation.LiveLocationReceiveStore
 import id.homebase.chat.services.ChatMessageActionService
 import id.homebase.chat.services.ChatMessageSenderService
+import id.homebase.chat.services.ChatMediaAutoSaveService
 import id.homebase.chat.services.ChatMessageStream
 import id.homebase.chat.services.ChatNotificationMessageResolver
 import id.homebase.chat.services.ChatProtocol
@@ -176,6 +177,7 @@ import id.homebase.core.ui.screens.feed.FeedViewModel
 import id.homebase.core.ui.screens.help.HelpViewModel
 import id.homebase.core.ui.screens.home.HomeViewModel
 import id.homebase.core.ui.screens.loading.AppLoadingViewModel
+import id.homebase.core.ui.screens.media.MediaSettingsViewModel
 import id.homebase.core.ui.screens.moments.MomentAudienceViewModel
 import id.homebase.core.ui.screens.moments.MomentComposeViewModel
 import id.homebase.core.ui.screens.moments.MomentDetailViewModel
@@ -637,6 +639,11 @@ val appModule = module {
                 get<FeedPermissionService>().reset()
                 get<FeedTimelineService>().start()
 
+                // An event collector with no UI referent, so nothing else constructs it. Resolved
+                // here and NOT createdAtStart: iOS starts Koin before the database, so its DB edge
+                // would kill every launch.
+                get<ChatMediaAutoSaveService>()
+
                 // Let ChatMessageStream skip messages for left conversations
                 get<ChatMessageStream>().isConversationLeft = { conversationId ->
                     conversationStream.getConversationById(conversationId)
@@ -818,6 +825,7 @@ val appModule = module {
         }
     }
     single<MessageLookup> { get<ChatMessageStream>() }
+    singleOf(::ChatMediaAutoSaveService)
     singleOf(::ShareSuggestionDonor)
     singleOf(::ChatMessageSenderService) bind StatusMessageSender::class
     singleOf(::HomebaseImageLoader)
@@ -1204,6 +1212,7 @@ val appModule = module {
     viewModelOf(::DeveloperMenuViewModel)
     viewModelOf(::DeveloperScheduledPushTestViewModel)
     viewModelOf(::AppearanceSettingsViewModel)
+    viewModelOf(::MediaSettingsViewModel)
     viewModelOf(::StorageSettingsViewModel)
     viewModelOf(::DefragmenterViewModel)
     viewModelOf(::HelpViewModel)

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
@@ -125,6 +125,7 @@ import id.homebase.core.ui.screens.feed.FeedTimelineScreen
 import id.homebase.core.ui.screens.feed.PostDetailScreen
 import id.homebase.core.ui.screens.home.HomeScreen
 import id.homebase.core.ui.screens.loading.AppLoadingScreen
+import id.homebase.core.ui.screens.media.MediaSettingsScreen
 import id.homebase.core.ui.screens.moments.CreateMomentGroupScreen
 import id.homebase.core.ui.screens.moments.MomentAudienceScreen
 import id.homebase.core.ui.screens.moments.MomentComposeScreen
@@ -1568,6 +1569,9 @@ fun AppNavHost(
                                         onAppearance = {
                                             navController.navigate(Route.AppearanceSettings)
                                         },
+                                        onMedia = {
+                                            navController.navigate(Route.MediaSettings)
+                                        },
                                         onStorage = {
                                             navController.navigate(Route.StorageSettings)
                                         },
@@ -2153,6 +2157,14 @@ fun AppNavHost(
                         composable<Route.DevScheduledPushTest> {
                             if (isAuthenticated) {
                                 DeveloperScheduledPushTestScreen(
+                                    viewModel = koinViewModel(),
+                                    onBackClick = { navController.popBackStack() })
+                            }
+                        }
+
+                        composable<Route.MediaSettings> {
+                            if (isAuthenticated) {
+                                MediaSettingsScreen(
                                     viewModel = koinViewModel(),
                                     onBackClick = { navController.popBackStack() })
                             }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/media/MediaSettingsScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/media/MediaSettingsScreen.kt
@@ -1,0 +1,138 @@
+package id.homebase.core.ui.screens.media
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.consumeWindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.selection.selectableGroup
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.SaveAlt
+import androidx.compose.material.icons.outlined.Wifi
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import id.homebase.api.image.MediaQuality
+import id.homebase.core.widget.SettingsOptionRow
+import id.homebase.core.widget.SettingsRow
+import id.homebase.core.widget.SettingsRowAction
+import id.homebase.core.widget.SettingsSectionHeader
+import id.homebase.core.widget.SettingsTopBar
+import id.homebase.resources.MR
+import id.homebase.resources.settings_media
+import id.homebase.resources.settings_media_autosave
+import id.homebase.resources.settings_media_autosave_description
+import id.homebase.resources.settings_media_autosave_header
+import id.homebase.resources.settings_media_autosave_unmetered
+import id.homebase.resources.settings_media_autosave_unmetered_description
+import id.homebase.resources.settings_media_quality_footer
+import id.homebase.resources.settings_media_quality_header
+import org.jetbrains.compose.resources.stringResource
+
+@Composable
+fun MediaSettingsScreen(
+    viewModel: MediaSettingsViewModel,
+    onBackClick: () -> Unit,
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    MediaSettingsUi(
+        uiState = uiState,
+        onAction = viewModel::onAction,
+        onBackClick = onBackClick,
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun MediaSettingsUi(
+    uiState: MediaSettingsUiState,
+    onAction: (MediaSettingsUiAction) -> Unit,
+    onBackClick: () -> Unit,
+) {
+    val scrollState = rememberScrollState()
+
+    Scaffold(
+        topBar = {
+            SettingsTopBar(
+                title = stringResource(MR.string.settings_media),
+                onBack = onBackClick,
+            )
+        },
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .consumeWindowInsets(innerPadding)
+                .padding(innerPadding)
+                .verticalScroll(scrollState),
+        ) {
+            SettingsSectionHeader(
+                title = stringResource(MR.string.settings_media_quality_header),
+                modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 20.dp, bottom = 8.dp),
+            )
+            Column(modifier = Modifier.selectableGroup()) {
+                MediaQuality.entries.forEach { quality ->
+                    SettingsOptionRow(
+                        modifier = Modifier.testTag(quality.code),
+                        label = stringResource(quality.label),
+                        supportingText = stringResource(quality.description),
+                        selected = quality == uiState.mediaQuality,
+                        onClick = { onAction(MediaSettingsUiAction.SetMediaQuality(quality)) },
+                    )
+                }
+            }
+            Text(
+                text = stringResource(MR.string.settings_media_quality_footer),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+            )
+
+            SettingsSectionHeader(
+                title = stringResource(MR.string.settings_media_autosave_header),
+                modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 20.dp, bottom = 8.dp),
+            )
+            SettingsRow(
+                modifier = Modifier.testTag("autoSaveToggle"),
+                icon = Icons.Outlined.SaveAlt,
+                title = stringResource(MR.string.settings_media_autosave),
+                supportingText = stringResource(MR.string.settings_media_autosave_description),
+                action = SettingsRowAction.Toggle(
+                    checked = uiState.autoSaveIncomingMedia,
+                    onCheckedChange = {
+                        onAction(MediaSettingsUiAction.SetAutoSaveIncomingMedia(it))
+                    },
+                ),
+            )
+            AnimatedVisibility(visible = uiState.autoSaveIncomingMedia) {
+                SettingsRow(
+                    modifier = Modifier.testTag("autoSaveUnmeteredToggle"),
+                    icon = Icons.Outlined.Wifi,
+                    title = stringResource(MR.string.settings_media_autosave_unmetered),
+                    supportingText =
+                        stringResource(MR.string.settings_media_autosave_unmetered_description),
+                    action = SettingsRowAction.Toggle(
+                        checked = uiState.autoSaveOnUnmeteredOnly,
+                        onCheckedChange = {
+                            onAction(MediaSettingsUiAction.SetAutoSaveOnUnmeteredOnly(it))
+                        },
+                    ),
+                )
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
+        }
+    }
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/media/MediaSettingsUiState.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/media/MediaSettingsUiState.kt
@@ -1,0 +1,33 @@
+package id.homebase.core.ui.screens.media
+
+import id.homebase.api.image.MediaQuality
+import id.homebase.resources.MR
+import id.homebase.resources.settings_media_quality_high
+import id.homebase.resources.settings_media_quality_high_description
+import id.homebase.resources.settings_media_quality_standard
+import id.homebase.resources.settings_media_quality_standard_description
+import org.jetbrains.compose.resources.StringResource
+
+data class MediaSettingsUiState(
+    val mediaQuality: MediaQuality = MediaQuality.STANDARD,
+    val autoSaveIncomingMedia: Boolean = false,
+    val autoSaveOnUnmeteredOnly: Boolean = true,
+)
+
+sealed interface MediaSettingsUiAction {
+    data class SetMediaQuality(val quality: MediaQuality) : MediaSettingsUiAction
+    data class SetAutoSaveIncomingMedia(val enabled: Boolean) : MediaSettingsUiAction
+    data class SetAutoSaveOnUnmeteredOnly(val enabled: Boolean) : MediaSettingsUiAction
+}
+
+val MediaQuality.label: StringResource
+    get() = when (this) {
+        MediaQuality.STANDARD -> MR.string.settings_media_quality_standard
+        MediaQuality.HIGH -> MR.string.settings_media_quality_high
+    }
+
+val MediaQuality.description: StringResource
+    get() = when (this) {
+        MediaQuality.STANDARD -> MR.string.settings_media_quality_standard_description
+        MediaQuality.HIGH -> MR.string.settings_media_quality_high_description
+    }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/media/MediaSettingsViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/media/MediaSettingsViewModel.kt
@@ -1,0 +1,49 @@
+package id.homebase.core.ui.screens.media
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import id.homebase.core.settings.UserPreferences
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+class MediaSettingsViewModel(
+    private val userPreferences: UserPreferences,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(MediaSettingsUiState())
+    val uiState: StateFlow<MediaSettingsUiState> = _uiState.asStateFlow()
+
+    init {
+        // The composer's HD chip writes the same preference, so follow the mirrored flow.
+        viewModelScope.launch {
+            userPreferences.preferenceState.collect { prefs ->
+                _uiState.update {
+                    it.copy(
+                        mediaQuality = prefs.mediaQuality,
+                        autoSaveIncomingMedia = prefs.autoSaveIncomingMedia,
+                        autoSaveOnUnmeteredOnly = prefs.autoSaveOnUnmeteredOnly,
+                    )
+                }
+            }
+        }
+    }
+
+    fun onAction(action: MediaSettingsUiAction) {
+        when (action) {
+            is MediaSettingsUiAction.SetMediaQuality -> {
+                userPreferences.mediaQuality = action.quality
+            }
+
+            is MediaSettingsUiAction.SetAutoSaveIncomingMedia -> {
+                userPreferences.autoSaveIncomingMedia = action.enabled
+            }
+
+            is MediaSettingsUiAction.SetAutoSaveOnUnmeteredOnly -> {
+                userPreferences.autoSaveOnUnmeteredOnly = action.enabled
+            }
+        }
+    }
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/settings/SettingsActions.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/settings/SettingsActions.kt
@@ -8,6 +8,7 @@ data class SettingsActions(
     val onBack: () -> Unit,
     val onNotifications: () -> Unit,
     val onAppearance: () -> Unit,
+    val onMedia: () -> Unit,
     val onStorage: () -> Unit,
     val onHelp: () -> Unit,
     val onMomentsSettings: () -> Unit,

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/settings/SettingsPaneCategory.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/settings/SettingsPaneCategory.kt
@@ -14,6 +14,7 @@ import androidx.compose.material.icons.outlined.Lock
 import androidx.compose.material.icons.outlined.MailOutline
 import androidx.compose.material.icons.outlined.Notifications
 import androidx.compose.material.icons.outlined.People
+import androidx.compose.material.icons.outlined.PermMedia
 import androidx.compose.material.icons.outlined.Storage
 import androidx.compose.material.icons.outlined.Tune
 import androidx.compose.material3.Icon
@@ -35,6 +36,7 @@ import id.homebase.resources.settings_appearance
 import id.homebase.resources.settings_category_general
 import id.homebase.resources.settings_data_storage
 import id.homebase.resources.settings_help
+import id.homebase.resources.settings_media
 import id.homebase.resources.settings_notifications
 import id.homebase.resources.vault_settings_section
 import org.jetbrains.compose.resources.StringResource
@@ -49,6 +51,7 @@ internal enum class SettingsCategory(
     General(MR.string.settings_category_general, Icons.Outlined.Tune),
     Notifications(MR.string.settings_notifications, Icons.Outlined.Notifications),
     Appearance(MR.string.settings_appearance, Icons.Outlined.Brightness6),
+    Media(MR.string.settings_media, Icons.Outlined.PermMedia),
     Moments(MR.string.moments_settings_section, Icons.Outlined.AutoAwesome),
     Vault(MR.string.vault_settings_section, Icons.Outlined.Lock),
     Email(MR.string.email_settings_section, Icons.Outlined.MailOutline),

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/settings/SettingsPaneHost.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/settings/SettingsPaneHost.kt
@@ -29,6 +29,7 @@ import id.homebase.core.ui.screens.appearance.AppearanceSettingsScreen
 import id.homebase.core.ui.screens.contactbook.settings.ContactBookSettingsScreen
 import id.homebase.core.ui.screens.email.settings.EmailSettingsScreen
 import id.homebase.core.ui.screens.help.HelpScreen
+import id.homebase.core.ui.screens.media.MediaSettingsScreen
 import id.homebase.core.ui.screens.moments.MomentsSettingsScreen
 import id.homebase.core.ui.screens.notifications.NotificationSettingsScreen
 import id.homebase.core.ui.screens.profile.ProfileAvatarEditScreen
@@ -162,6 +163,7 @@ private fun CategoryPage(
                 onBack = onDismiss,
                 onNotifications = { onSelectCategory(SettingsCategory.Notifications) },
                 onAppearance = { onSelectCategory(SettingsCategory.Appearance) },
+                onMedia = { onSelectCategory(SettingsCategory.Media) },
                 onStorage = { onSelectCategory(SettingsCategory.Storage) },
                 onHelp = { onSelectCategory(SettingsCategory.Help) },
                 onMomentsSettings = { onSelectCategory(SettingsCategory.Moments) },
@@ -181,6 +183,11 @@ private fun CategoryPage(
         )
 
         SettingsCategory.Appearance -> AppearanceSettingsScreen(
+            viewModel = koinViewModel(),
+            onBackClick = onDismiss,
+        )
+
+        SettingsCategory.Media -> MediaSettingsScreen(
             viewModel = koinViewModel(),
             onBackClick = onDismiss,
         )

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/settings/SettingsScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/settings/SettingsScreen.kt
@@ -35,6 +35,7 @@ import androidx.compose.material.icons.outlined.Redeem
 import androidx.compose.material.icons.outlined.LocationOn
 import androidx.compose.material.icons.outlined.Notifications
 import androidx.compose.material.icons.outlined.People
+import androidx.compose.material.icons.outlined.PermMedia
 import androidx.compose.material.icons.outlined.PhotoCamera
 import androidx.compose.material.icons.outlined.Security
 import androidx.compose.material.icons.outlined.Storage
@@ -106,6 +107,8 @@ import id.homebase.resources.settings_location_desc
 import id.homebase.resources.settings_logout
 import id.homebase.resources.settings_logout_desc
 import id.homebase.resources.settings_logout_in_progress
+import id.homebase.resources.settings_media
+import id.homebase.resources.settings_media_desc
 import id.homebase.resources.settings_moments_desc
 import id.homebase.resources.settings_native_feed
 import id.homebase.resources.settings_notifications
@@ -323,6 +326,15 @@ fun SettingsUi(
                         uiState.theme.getStringResourceForTheme(),
                     ),
                     action = SettingsRowAction.Navigate(actions.onAppearance),
+                )
+            }
+            item {
+                SettingsRow(
+                    modifier = Modifier.testTag("mediaButton"),
+                    icon = Icons.Outlined.PermMedia,
+                    title = stringResource(MR.string.settings_media),
+                    supportingText = stringResource(MR.string.settings_media_desc),
+                    action = SettingsRowAction.Navigate(actions.onMedia),
                 )
             }
 
@@ -590,6 +602,7 @@ fun SettingsUiPreview() {
                 onBack = {},
                 onNotifications = {},
                 onAppearance = {},
+                onMedia = {},
                 onStorage = {},
                 onHelp = {},
                 onMomentsSettings = {},

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/storage/StorageSettingsScreen.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/storage/StorageSettingsScreen.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
@@ -39,24 +38,18 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import id.homebase.api.image.MediaQuality
 import id.homebase.api.client.cache.CacheStats
 import id.homebase.common.util.formatBytes
 import id.homebase.core.diagnostics.DiagnosticsCrashTrigger
 import id.homebase.core.diagnostics.NoOpDiagnosticsCrashTrigger
-import id.homebase.core.widget.SettingsOptionRow
 import id.homebase.core.widget.SettingsSectionHeader
 import id.homebase.core.widget.SettingsTopBar
 import id.homebase.resources.MR
-import id.homebase.resources.settings_media_quality_footer
-import id.homebase.resources.settings_media_quality
 import id.homebase.resources.settings_data_storage
-import id.homebase.resources.settings_storage
 import id.homebase.resources.storage_orphan_coil_body
 import id.homebase.resources.storage_orphan_coil_title
 import id.homebase.resources.storage_cache_coil_memory
@@ -150,30 +143,6 @@ fun StorageSettingsUi(
                 .verticalScroll(scrollState),
             verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
-            SettingsSectionHeader(
-                title = stringResource(MR.string.settings_media_quality),
-                modifier = Modifier.padding(horizontal = 4.dp),
-            )
-            Column {
-                Column(modifier = Modifier.selectableGroup()) {
-                    MediaQuality.entries.forEach { quality ->
-                        SettingsOptionRow(
-                            modifier = Modifier.testTag(quality.code),
-                            label = stringResource(quality.label),
-                            supportingText = stringResource(quality.description),
-                            selected = quality == uiState.mediaQuality,
-                            onClick = { onAction(StorageSettingsUiAction.SetMediaQuality(quality)) },
-                        )
-                    }
-                }
-                Text(
-                    text = stringResource(MR.string.settings_media_quality_footer),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.padding(horizontal = 4.dp, vertical = 8.dp),
-                )
-            }
-
             SettingsSectionHeader(
                 title = stringResource(MR.string.storage_caches_header),
                 modifier = Modifier.padding(horizontal = 4.dp),

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/storage/StorageSettingsUiState.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/storage/StorageSettingsUiState.kt
@@ -1,16 +1,8 @@
 package id.homebase.core.ui.screens.storage
 
-import id.homebase.api.image.MediaQuality
-import id.homebase.resources.MR
-import id.homebase.resources.settings_media_quality_high
-import id.homebase.resources.settings_media_quality_high_description
-import id.homebase.resources.settings_media_quality_standard
-import id.homebase.resources.settings_media_quality_standard_description
-import org.jetbrains.compose.resources.StringResource
 import kotlin.uuid.Uuid
 
 data class StorageSettingsUiState(
-    val mediaQuality: MediaQuality = MediaQuality.STANDARD,
     val caches: List<CacheRowState> = emptyList(),
     val coilMemoryCache: CacheRowState? = null,
     val drives: List<DriveRowState> = emptyList(),
@@ -50,20 +42,7 @@ data class DriveRowState(
 sealed interface StorageSettingsUiAction {
     data object Refresh : StorageSettingsUiAction
     data object ClearCachesClicked : StorageSettingsUiAction
-    data class SetMediaQuality(val quality: MediaQuality) : StorageSettingsUiAction
 }
-
-val MediaQuality.label: StringResource
-    get() = when (this) {
-        MediaQuality.STANDARD -> MR.string.settings_media_quality_standard
-        MediaQuality.HIGH -> MR.string.settings_media_quality_high
-    }
-
-val MediaQuality.description: StringResource
-    get() = when (this) {
-        MediaQuality.STANDARD -> MR.string.settings_media_quality_standard_description
-        MediaQuality.HIGH -> MR.string.settings_media_quality_high_description
-    }
 
 sealed interface StorageSettingsUiEvent {
     data object CachesCleared : StorageSettingsUiEvent

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/storage/StorageSettingsViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/storage/StorageSettingsViewModel.kt
@@ -18,7 +18,6 @@ import id.homebase.api.sync.DriveSyncManager
 import id.homebase.api.sync.database.DatabaseManager
 import id.homebase.core.sync.DriveRegistry
 import id.homebase.api.sync.database.DatabaseSizeProbe
-import id.homebase.core.settings.UserPreferences
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -40,7 +39,6 @@ class StorageSettingsViewModel(
     private val databaseSizeProbe: DatabaseSizeProbe,
     private val fileOperationsProvider: FileOperationsProvider,
     private val driveRegistry: DriveRegistry,
-    private val userPreferences: UserPreferences,
 ) : ViewModel() {
 
     private val fileSystem = systemFileSystem
@@ -50,21 +48,12 @@ class StorageSettingsViewModel(
 
     init {
         load()
-        // The composer's HD chip writes the same preference, so follow the mirrored flow.
-        viewModelScope.launch {
-            userPreferences.preferenceState.collect { prefs ->
-                _uiState.update { it.copy(mediaQuality = prefs.mediaQuality) }
-            }
-        }
     }
 
     fun onAction(action: StorageSettingsUiAction) {
         when (action) {
             StorageSettingsUiAction.Refresh -> load()
             StorageSettingsUiAction.ClearCachesClicked -> clearCaches()
-            is StorageSettingsUiAction.SetMediaQuality -> {
-                userPreferences.mediaQuality = action.quality
-            }
         }
     }
 

--- a/homebase-core/src/commonTest/kotlin/id/homebase/core/ui/screens/media/MediaSettingsUiTest.kt
+++ b/homebase-core/src/commonTest/kotlin/id/homebase/core/ui/screens/media/MediaSettingsUiTest.kt
@@ -1,0 +1,124 @@
+package id.homebase.core.ui.screens.media
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsSelected
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.runComposeUiTest
+import id.homebase.api.image.MediaQuality
+import id.homebase.core.test.setTestLocale
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalTestApi::class)
+class MediaSettingsUiTest {
+
+    @Test
+    fun showsTitleAndBothQualities() = runComposeUiTest {
+        setTestLocale("en-US")
+        setContent {
+            MaterialTheme {
+                MediaSettingsUi(
+                    uiState = MediaSettingsUiState(),
+                    onAction = {},
+                    onBackClick = {},
+                )
+            }
+        }
+        onNodeWithText("Media").assertExists()
+        onNodeWithText("Standard").assertExists()
+        onNodeWithText("High").assertExists()
+    }
+
+    @Test
+    fun currentQualityRendersSelected() = runComposeUiTest {
+        setTestLocale("en-US")
+        setContent {
+            MaterialTheme {
+                MediaSettingsUi(
+                    uiState = MediaSettingsUiState(mediaQuality = MediaQuality.HIGH),
+                    onAction = {},
+                    onBackClick = {},
+                )
+            }
+        }
+        onNodeWithTag(MediaQuality.HIGH.code).assertIsSelected()
+    }
+
+    @Test
+    fun selectingHighEmitsTheAction() = runComposeUiTest {
+        setTestLocale("en-US")
+        var selected: MediaQuality? = null
+        setContent {
+            MaterialTheme {
+                MediaSettingsUi(
+                    uiState = MediaSettingsUiState(mediaQuality = MediaQuality.STANDARD),
+                    onAction = { action ->
+                        if (action is MediaSettingsUiAction.SetMediaQuality) selected = action.quality
+                    },
+                    onBackClick = {},
+                )
+            }
+        }
+        onNodeWithTag(MediaQuality.HIGH.code).performClick()
+        assertEquals(MediaQuality.HIGH, selected)
+    }
+
+    @Test
+    fun theWifiGuardRowAppearsOnlyWhileAutoSaveIsOn() = runComposeUiTest {
+        setTestLocale("en-US")
+        setContent {
+            MaterialTheme {
+                MediaSettingsUi(
+                    uiState = MediaSettingsUiState(autoSaveIncomingMedia = false),
+                    onAction = {},
+                    onBackClick = {},
+                )
+            }
+        }
+        onNodeWithTag("autoSaveToggle").assertExists()
+        onNodeWithTag("autoSaveUnmeteredToggle").assertDoesNotExist()
+    }
+
+    @Test
+    fun togglingAutoSaveEmitsTheAction() = runComposeUiTest {
+        setTestLocale("en-US")
+        var enabled: Boolean? = null
+        setContent {
+            MaterialTheme {
+                MediaSettingsUi(
+                    uiState = MediaSettingsUiState(autoSaveIncomingMedia = false),
+                    onAction = { action ->
+                        if (action is MediaSettingsUiAction.SetAutoSaveIncomingMedia) {
+                            enabled = action.enabled
+                        }
+                    },
+                    onBackClick = {},
+                )
+            }
+        }
+        onNodeWithTag("autoSaveToggle").performClick()
+        assertEquals(true, enabled)
+    }
+
+    @Test
+    fun backClickFires() = runComposeUiTest {
+        setTestLocale("en-US")
+        var backClicked = false
+        setContent {
+            MaterialTheme {
+                MediaSettingsUi(
+                    uiState = MediaSettingsUiState(),
+                    onAction = {},
+                    onBackClick = { backClicked = true },
+                )
+            }
+        }
+        onNodeWithContentDescription("Back").performClick()
+        assertTrue(backClicked)
+    }
+}

--- a/homebase-core/src/commonTest/kotlin/id/homebase/core/ui/screens/settings/SettingsUiTest.kt
+++ b/homebase-core/src/commonTest/kotlin/id/homebase/core/ui/screens/settings/SettingsUiTest.kt
@@ -29,6 +29,7 @@ class SettingsUiTest {
             onBack = { fired += "back" },
             onNotifications = { fired += "notifications" },
             onAppearance = { fired += "appearance" },
+            onMedia = { fired += "media" },
             onStorage = { fired += "storage" },
             onHelp = { fired += "help" },
             onMomentsSettings = { fired += "moments" },
@@ -85,6 +86,7 @@ class SettingsUiTest {
         val expected = listOf(
             "notificationsButton" to "notifications",
             "appearanceButton" to "appearance",
+            "mediaButton" to "media",
             "momentsSettingsButton" to "moments",
             "vaultSettingsButton" to "vault",
             "locationSettingsButton" to "location",

--- a/homebase-core/src/jvmMain/kotlin/id/homebase/core/di/AppModule.desktop.kt
+++ b/homebase-core/src/jvmMain/kotlin/id/homebase/core/di/AppModule.desktop.kt
@@ -33,7 +33,10 @@ import id.homebase.core.settings.createSettings
 import id.homebase.core.share.ShareCacheStorage
 import id.homebase.core.updater.JvmUpdateAppManager
 import id.homebase.core.updater.UpdateAppManager
+import id.homebase.core.util.AlbumSaver
+import id.homebase.core.util.JvmAlbumSaver
 import id.homebase.core.util.JvmPlatformInfo
+import id.homebase.core.util.NetworkMonitor
 import id.homebase.core.diagnostics.DiagnosticsCrashTrigger
 import id.homebase.core.diagnostics.NoOpDiagnosticsCrashTrigger
 import id.homebase.core.util.PlatformInfo
@@ -43,6 +46,9 @@ import org.koin.dsl.module
 actual fun platformModule(): Module = module {
     single<FileOperationsProvider> { JvmFileOperationsProvider() }
     single { ShareCacheStorage() }
+    single<AlbumSaver> { JvmAlbumSaver() }
+    // Desktop is assumed to be on a wired/Wi-Fi link; there is no metered signal to read.
+    single<NetworkMonitor> { NetworkMonitor { true } }
     single { createSettings() }
     single<PlatformGalleryManager> { JvmGalleryManager() }
     single { GalleryCache(get<PlatformGalleryManager>()) }

--- a/homebase-core/src/nativeMain/kotlin/id/homebase/core/di/AppModule.native.kt
+++ b/homebase-core/src/nativeMain/kotlin/id/homebase/core/di/AppModule.native.kt
@@ -35,7 +35,11 @@ import id.homebase.core.settings.createSettings
 import id.homebase.core.share.ShareCacheStorage
 import id.homebase.core.updater.IOSUpdateAppManager
 import id.homebase.core.updater.UpdateAppManager
+import id.homebase.core.util.AlbumSaver
 import id.homebase.core.util.IOSPlatformInfo
+import id.homebase.core.util.IosAlbumSaver
+import id.homebase.core.util.IosNetworkMonitor
+import id.homebase.core.util.NetworkMonitor
 import id.homebase.core.diagnostics.DiagnosticsCrashTrigger
 import id.homebase.core.diagnostics.IosDiagnosticsCrashTrigger
 import id.homebase.core.util.PlatformInfo
@@ -45,6 +49,8 @@ import org.koin.dsl.module
 actual fun platformModule(): Module = module {
     single<FileOperationsProvider> { IOSFileOperationsProvider() }
     single { ShareCacheStorage() }
+    single<AlbumSaver> { IosAlbumSaver }
+    single<NetworkMonitor> { IosNetworkMonitor() }
     single { createSettings() }
     single<PlatformGalleryManager> { IOSGalleryManager() }
     single { GalleryCache(get<PlatformGalleryManager>()) }

--- a/homebase-core/src/wasmJsMain/kotlin/id/homebase/core/di/AppModule.web.kt
+++ b/homebase-core/src/wasmJsMain/kotlin/id/homebase/core/di/AppModule.web.kt
@@ -26,7 +26,10 @@ import id.homebase.core.notifications.NotificationBackend
 import id.homebase.core.settings.createSettings
 import id.homebase.core.share.ShareCacheStorage
 import id.homebase.core.updater.UpdateAppManager
+import id.homebase.core.util.AlbumSaver
+import id.homebase.core.util.NetworkMonitor
 import id.homebase.core.util.PlatformInfo
+import id.homebase.core.util.WebAlbumSaver
 import org.koin.core.module.Module
 import org.koin.dsl.module
 
@@ -34,6 +37,8 @@ actual fun platformModule(): Module = module {
     single { createSettings() }
     single<FileOperationsProvider> { WebFileOperationsProvider() }
     single { ShareCacheStorage() }
+    single<AlbumSaver> { WebAlbumSaver }
+    single<NetworkMonitor> { NetworkMonitor { true } }
     single<NotificationBackend> { NoopNotificationBackend() }
 
     // Web stubs (see WebPlatformStubs.kt) — inert browser implementations so the Koin graph


### PR DESCRIPTION
Closes #1154.

## What

A new **Media** settings screen. The media-quality section moves into it out of Data and storage, and the new auto-save toggle hangs off the same screen rather than becoming a third place to look for a media setting.

**Auto-save**: incoming chat photos and videos are downloaded in the background and written to the device photo album. Default **off**, with an unmetered-only sub-toggle that defaults **on** and is hidden while auto-save is off.

Scope decisions taken with @Seifert69's thread in mind: eager download (so the album is complete without opening anything), photos and video under one toggle, chat only. No per-conversation override and no Moments — deliberately not built, per the "global and local settings are hard for users to find" concern in the issue.

## The parts that weren't a flag flip

**The receive path has two lanes and only one is obvious.** Live WebSocket pushes emit `BatchReceived`; the REST `DriveSync` lane is deliberately silent and only reports `DriveEvent.Stopped`. Hooking the WebSocket worker alone would have missed every photo that arrived while the app was closed — i.e. most of them. The service listens to both, cloning the dual-lane shape `ChatMessageStream` already uses.

**Album saving had to leave Compose.** `FileSystemHandler.saveFile` was only reachable through `@Composable getUriHandler()`, so a background coroutine couldn't call it. The Android MediaStore body and the iOS `PHPhotoLibrary` body **move** into an injectable `AlbumSaver` (−118 / −183 lines from the two `FileUtilities`), and the composable `saveFile` now delegates — no duplicated platform logic.

**There was no connectivity detection anywhere in the repo.** Zero hits for `ConnectivityManager`, `NWPathMonitor`, `isMetered`; the existing `isOnline` is WebSocket-derived and binary. `NetworkMonitor` is new across all four targets (Android `NET_CAPABILITY_NOT_METERED`, iOS `nw_path_monitor`, JVM/wasm hardcoded unmetered), plus `ACCESS_NETWORK_STATE` in the manifest.

**Dedupe is mandatory, not an optimisation.** `BatchReceived` re-fires on edits, reactions and delivery-status fan-out, so without a durable marker a reaction to an old photo re-saves it and a re-sync duplicates the album. New `AutoSavedMedia` table keyed on `(fileId, payloadKey)`. `DATABASE_VERSION` is **not** bumped — `Schema.create()` runs on every open and creates missing tables, whereas a bump would rebuild the whole local DB.

**iOS permission behaviour is fixed as a side effect.** Only `NotDetermined` now requests authorization; `Denied`/`Restricted` fail fast, so a denial no longer re-prompts on every image. This also applies to the existing manual Save menu item — same error message, so no visible UX change, but the OS no longer gets a no-op request on that path.

## Auto-save applies from when you switch it on

The sync lane rescans a window of recent messages, so on the first `Stopped` after enabling, the naive version would download and dump up to 200 historical photos into the camera roll — a surprise, a large burst, and painful to undo by hand. A timestamp is stamped when the toggle flips on and older media is skipped. Say the word if you'd rather it backfill.

## Excluded from auto-save

Own outgoing messages, soft-deleted files, stickers, and the payload keys that carry plumbing rather than user photos: `dflt_key`, `chat_web*` (long-message bodies and event cover photos), `chat_links` and `chat_loc` — the last two carry an `image/*` content type but are link and location previews.

**Segmented HLS video is skipped**, with a one-line note naming the ceiling. Saving it needs `downloadAndRemuxHlsToMp4`, a large FFmpegKit bill on every incoming video, and its concurrent `ffmpeg_execute` calls are a known iOS crash class. Enabling it wants a single-permit semaphore first.

## Test

`shouldAutoSave(...)` is a pure function — 20 tests, no Compose, DB or network: setting off, non-media content type, each excluded payload key, sticker, own outgoing, already-saved, segmented HLS, metered-with-guard vs guard-off, and the two backfill-boundary cases. Plus `UserPreferences` round-trip tests and 6 `MediaSettingsUiTest` cases.

`./gradlew homebase-chat:jvmTest homebase-common:jvmTest homebase-core:jvmTest homebase-api:jvmTest` — 3820 tests, 0 failures (Konsist `ArchitectureTest` included). `:homebase-common:compileKotlinIosSimulatorArm64` green, as are the Android/JVM/wasm compiles for all four new platform files.

**Not device-verified.** End-to-end needs two identities and a real photo send. The album write itself is the same MediaStore/PHPhotoLibrary code the existing Save menu item already uses, now reached from a coroutine.


## Android media lands in a `Homebase` subfolder

Saved media no longer drops into the top-level `Pictures/`, `Movies/` and `Download/`, the way it did when the album code moved out of `FileUtilities`. It goes into the `Homebase` subfolder of each — `Pictures/Homebase`, `Movies/Homebase`, `Download/Homebase` — following the `Pictures/WhatsApp` convention. Both Android save paths are covered: `MediaStore.RELATIVE_PATH` on API 29+, and `File(publicDir, "Homebase")` on the API 27-28 legacy path, which is live at `minSdk 28`. `onSuccess` reports the relative path, so the existing `file_saved_to` snackbar reads "Saved to Pictures/Homebase".

iOS is deliberately unchanged. A named album needs `PHAccessLevelReadWrite` in place of the current add-only access, which is not worth the extra permission — it keeps saving to Recents.
