### PR TITLE
Scroll the chat list to top when the top conversation changed while away (#1341)

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListScreen.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListScreen.kt
@@ -63,6 +63,8 @@ import androidx.compose.ui.input.key.type
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LifecycleEventEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import co.touchlab.kermit.Logger
 import com.mohamedrejeb.richeditor.model.RichTextState
@@ -827,6 +829,20 @@ fun ConversationListUi(
         scaffoldNavigator.scaffoldValue[ListDetailPaneScaffoldRole.Detail] != PaneAdaptedValue.Hidden
     val showingOnlyDetail = isListPaneHidden && isDetailPaneVisible
 
+    // Record what the user last saw at the top, so the return can tell whether the list reordered
+    // while they were gone. ON_STOP runs inside the lifecycle callback; a coroutine would not be
+    // guaranteed to run before the OS kills a backgrounded process.
+    LifecycleEventEffect(Lifecycle.Event.ON_STOP) {
+        if (!isListPaneHidden) onUiAction(ConversationListUiAction.SnapshotListTop)
+    }
+    var listPaneWasVisible by remember { mutableStateOf(!isListPaneHidden) }
+    LaunchedEffect(isListPaneHidden) {
+        if (listPaneWasVisible && isListPaneHidden) {
+            onUiAction(ConversationListUiAction.SnapshotListTop)
+        }
+        listPaneWasVisible = !isListPaneHidden
+    }
+
     LaunchedEffect(isExpanded) {
         if (!isExpanded && scaffoldNavigator.currentDestination?.pane == ListDetailPaneScaffoldRole.Detail) {
             // Optional: If you want to force it back to list view when shrinking
@@ -907,6 +923,7 @@ fun ConversationListUi(
                         searchTextState = conversationSearchTextFieldState,
                         searchFocusRequester = conversationSearchFocusRequester,
                         archivedUiState = archivedConversationsUiState,
+                        listPaneVisible = !isListPaneHidden,
                         onProfileClick = onNavigateToSettingsScreen,
                         onUiAction = onUiAction,
                         onConversationSelected = {

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListTopAnchor.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListTopAnchor.kt
@@ -1,0 +1,24 @@
+package id.homebase.chat.conversationlist
+
+import kotlin.uuid.Uuid
+
+/**
+ * The most recently active conversation, not the first row: pinned conversations sit above the
+ * rest and rarely change, so anchoring on row order would mean a list with any pin almost never
+ * detects a reorder. Keying on the sort value instead covers both sections with one marker.
+ */
+internal fun resolveTopConversationId(items: List<ConversationListContentModel>): Uuid? =
+    items.mapNotNull { (it as? ConversationListContentModel.Conversation)?.conversation?.conversation }
+        .maxByOrNull { it.latestMessageTimestamp }
+        ?.id
+
+/** A null snapshot is a list the user has never seen (fresh install): landing at the top then
+ *  would be a scroll nobody asked for. */
+internal fun shouldScrollToTop(
+    snapshotTopId: Uuid?,
+    currentTopId: Uuid?,
+    isAtTop: Boolean,
+): Boolean {
+    if (isAtTop || snapshotTopId == null || currentTopId == null) return false
+    return snapshotTopId != currentTopId
+}

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiAction.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiAction.kt
@@ -26,6 +26,10 @@ sealed interface ConversationListUiAction {
     data object NewConversationClicked : ConversationListUiAction
     data object ClearSelection : ConversationListUiAction
 
+    /** Record the current #1 conversation as the one the user has seen. Dispatched whenever the
+     *  list leaves the screen, and once per return to it. */
+    data object SnapshotListTop : ConversationListUiAction
+
     /** The screen has handled [ConversationListUiState.closeDetailPaneRequest] (popped
      *  the scaffold detail pane); clear it so it doesn't fire again on next recompose. */
     data object CloseDetailPaneRequestConsumed : ConversationListUiAction

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiState.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiState.kt
@@ -67,6 +67,10 @@ data class ConversationListUiState(
      *  open conversation). The screen calls [closeDetailPaneRequestConsumed] when it
      *  has handled the request. */
     val closeDetailPaneRequest: Uuid? = null,
+    /** Id of the #1 conversation as of the last time the list was on screen, mirrored from
+     *  [id.homebase.core.settings.UserPreferences.conversationListTopId]. Compared against the
+     *  current #1 by [shouldScrollToTop] on every return to the list. */
+    val listTopSnapshotId: Uuid? = null,
 )
 
 @Immutable

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
@@ -197,7 +197,9 @@ class ConversationListViewModel(
     private val enricher = ConversationEnricher()
     val ownerSession = ownerSessionRepository.user
 
-    private val _uiState = MutableStateFlow(ConversationListUiState())
+    private val _uiState = MutableStateFlow(
+        ConversationListUiState(listTopSnapshotId = userPreferences.conversationListTopId)
+    )
     val uiState: StateFlow<ConversationListUiState> = _uiState.asStateFlow()
 
     private val events = ConversationListEvents()
@@ -1271,6 +1273,8 @@ class ConversationListViewModel(
                 sendEvent(NavigateToNewConversation)
             }
 
+            is ConversationListUiAction.SnapshotListTop -> snapshotListTop()
+
             is ConversationListUiAction.ClearSelection -> {
                 ActiveConversation.selectConversation(null)
                 currentConversationJob?.cancel()
@@ -1640,6 +1644,20 @@ class ConversationListViewModel(
                 currentSearchResultIndex = startIndex,
             )
         }
+    }
+
+    /**
+     * Search results share [ConversationListUiState.conversationsContent] with the conversation
+     * list, and their #1 row has nothing to do with the list's — never snapshot one.
+     */
+    private fun snapshotListTop() {
+        if (conversationSearchTextState.text.isNotEmpty()) return
+        val items =
+            _uiState.value.conversationsContent as? ConversationListContentState.Items ?: return
+        val topId = resolveTopConversationId(items.list) ?: return
+        if (topId == _uiState.value.listTopSnapshotId) return
+        userPreferences.conversationListTopId = topId
+        _uiState.update { it.copy(listTopSnapshotId = topId) }
     }
 
     private fun updateListContent() {

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationListPane.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationListPane.kt
@@ -76,9 +76,13 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LifecycleEventEffect
 import id.homebase.api.client.auth.initials
 import id.homebase.chat.conversationlist.ConversationListContentModel
 import id.homebase.chat.conversationlist.ConversationListContentState
+import id.homebase.chat.conversationlist.resolveTopConversationId
+import id.homebase.chat.conversationlist.shouldScrollToTop
 import id.homebase.chat.archivedconversations.ArchivedConversationsUiState
 import id.homebase.chat.conversationlist.ConversationListUiAction
 import id.homebase.chat.conversationlist.ConversationListUiState
@@ -117,6 +121,7 @@ fun ConversationListPane(
     searchTextState: TextFieldState,
     searchFocusRequester: FocusRequester? = null,
     archivedUiState: ArchivedConversationsUiState = ArchivedConversationsUiState(),
+    listPaneVisible: Boolean = true,
     onProfileClick: () -> Unit,
     onUiAction: (ConversationListUiAction) -> Unit,
     onConversationSelected: (conversationId: Uuid) -> Unit,
@@ -133,6 +138,34 @@ fun ConversationListPane(
     val focusRequesterNone = remember { FocusRequester() }
     val focusRequesterSearch = remember { FocusRequester() }
     var showMenu by remember { mutableStateOf(false) }
+
+    // Null while the LazyColumn is showing something other than the conversation list — the
+    // archived thread list or search results, whose #1 row is not comparable to the list's.
+    val topConversationId = if (searchActive || uiState.showArchived) {
+        null
+    } else {
+        (uiState.conversationsContent as? ConversationListContentState.Items)
+            ?.let { resolveTopConversationId(it.list) }
+    }
+
+    // The saved scroll position is an index, so a list that reordered while the user was away
+    // restores them onto a different conversation. Land at the top instead, once per return,
+    // whenever the #1 conversation is no longer the one they last saw.
+    var checkTopOnReturn by remember { mutableStateOf(true) }
+    LaunchedEffect(listPaneVisible) { if (listPaneVisible) checkTopOnReturn = true }
+    LifecycleEventEffect(Lifecycle.Event.ON_START) { checkTopOnReturn = true }
+    LaunchedEffect(checkTopOnReturn, listPaneVisible, topConversationId) {
+        if (!checkTopOnReturn || !listPaneVisible || topConversationId == null) {
+            return@LaunchedEffect
+        }
+        checkTopOnReturn = false
+        val isAtTop = listState.firstVisibleItemIndex == 0 &&
+                listState.firstVisibleItemScrollOffset == 0
+        if (shouldScrollToTop(uiState.listTopSnapshotId, topConversationId, isAtTop)) {
+            listState.scrollToItem(0)
+        }
+        onUiAction(ConversationListUiAction.SnapshotListTop)
+    }
 
     // Request focus on box element to prevent soft keyboard popping up
     LaunchedEffect(Unit) { focusRequesterNone.requestFocus() }

--- a/homebase-chat/src/commonTest/kotlin/id/homebase/chat/conversationlist/ConversationListTopAnchorTest.kt
+++ b/homebase-chat/src/commonTest/kotlin/id/homebase/chat/conversationlist/ConversationListTopAnchorTest.kt
@@ -1,0 +1,114 @@
+package id.homebase.chat.conversationlist
+
+import id.homebase.api.common.OdinId
+import id.homebase.chat.data.ConversationUiModel
+import id.homebase.chat.services.convo.EnrichedConversationUiModel
+import id.homebase.core.avatars.ConversationAvatarModel
+import id.homebase.resources.MR
+import id.homebase.resources.chat_search_result_conversations
+import id.homebase.resources.chat_search_result_pinned
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.time.Instant
+import kotlin.uuid.Uuid
+
+class ConversationListTopAnchorTest {
+
+    private fun row(id: Uuid, atMs: Long = 0L) = ConversationListContentModel.Conversation(
+        EnrichedConversationUiModel(
+            conversation = ConversationUiModel(
+                id = id,
+                name = "convo",
+                lastMessage = "",
+                latestMessageTimestamp = Instant.fromEpochMilliseconds(atMs),
+                avatarInitials = "",
+                avatarTiny = null,
+                lastRead = Instant.fromEpochMilliseconds(0),
+                avatarModel = ConversationAvatarModel(type = ConversationAvatarModel.Type.GroupFallback),
+                admins = emptySet(),
+                participants = listOf(OdinId("frodo.demo.rocks")),
+            ),
+            participants = emptyList(),
+            missingConnections = emptyList(),
+        )
+    )
+
+    private val john = Uuid.random()
+    private val jane = Uuid.random()
+
+    @Test
+    fun topUnchangedKeepsThePosition() {
+        assertFalse(shouldScrollToTop(john, john, isAtTop = false))
+    }
+
+    @Test
+    fun topChangedScrollsToTop() {
+        assertTrue(shouldScrollToTop(john, jane, isAtTop = false))
+    }
+
+    @Test
+    fun alreadyAtTopIsAlwaysANoOp() {
+        assertFalse(shouldScrollToTop(john, jane, isAtTop = true))
+        assertFalse(shouldScrollToTop(john, john, isAtTop = true))
+    }
+
+    @Test
+    fun noSnapshotYetDoesNotJump() {
+        assertFalse(shouldScrollToTop(null, jane, isAtTop = false))
+    }
+
+    @Test
+    fun emptyListDoesNotJump() {
+        assertFalse(shouldScrollToTop(john, null, isAtTop = false))
+        assertNull(resolveTopConversationId(emptyList()))
+    }
+
+    @Test
+    fun theTopIsTheMostRecentlyActiveConversationNotTheFirstListRow() {
+        val items = listOf(
+            ConversationListContentModel.Header(MR.string.chat_search_result_pinned),
+            row(john, atMs = 10),
+            row(jane, atMs = 20),
+        )
+        assertEquals(jane, resolveTopConversationId(items))
+    }
+
+    // A pinned row sits above everything and rarely changes; anchoring on row order would mean
+    // an inbound message never registers as a reorder for anyone who has pinned a conversation.
+    @Test
+    fun aStalePinnedRowDoesNotMaskActivityBelowIt() {
+        val pinned = Uuid.random()
+        val before = listOf(
+            ConversationListContentModel.Header(MR.string.chat_search_result_pinned),
+            row(pinned, atMs = 5),
+            ConversationListContentModel.Header(MR.string.chat_search_result_conversations),
+            row(john, atMs = 20),
+            row(jane, atMs = 10),
+        )
+        val after = listOf(
+            ConversationListContentModel.Header(MR.string.chat_search_result_pinned),
+            row(pinned, atMs = 5),
+            ConversationListContentModel.Header(MR.string.chat_search_result_conversations),
+            row(jane, atMs = 30),
+            row(john, atMs = 20),
+        )
+        assertTrue(
+            shouldScrollToTop(
+                resolveTopConversationId(before),
+                resolveTopConversationId(after),
+                isAtTop = false,
+            )
+        )
+    }
+
+    @Test
+    fun aHeaderOnlyListHasNoTopConversation() {
+        val items = listOf(
+            ConversationListContentModel.Header(MR.string.chat_search_result_conversations)
+        )
+        assertNull(resolveTopConversationId(items))
+    }
+}

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/settings/UserPreferences.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/settings/UserPreferences.kt
@@ -92,6 +92,25 @@ class UserPreferences(private val settings: Settings) {
         get() = settings.getBoolean("notification_include_muted_badge", false)
         set(value) = settings.putBoolean("notification_include_muted_badge", value)
 
+    /**
+     * Id of the conversation at the top of the chat list the last time the user was looking at it.
+     * Persisted rather than held in memory because process death is the case index-based scroll
+     * restore gets wrong.
+     */
+    var conversationListTopId: Uuid?
+        get() {
+            val raw = settings.getStringOrNull("conversationListTopId") ?: return null
+            return try {
+                Uuid.parse(raw)
+            } catch (_: IllegalArgumentException) {
+                null
+            }
+        }
+        set(value) {
+            if (value == null) settings.remove("conversationListTopId")
+            else settings.putString("conversationListTopId", value.toString())
+        }
+
    
     /**
      * Per-conversation scroll anchor — the uniqueId of the message the user

--- a/homebase-common/src/commonTest/kotlin/id/homebase/core/settings/ConversationListTopPreferenceTest.kt
+++ b/homebase-common/src/commonTest/kotlin/id/homebase/core/settings/ConversationListTopPreferenceTest.kt
@@ -1,0 +1,48 @@
+package id.homebase.core.settings
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.uuid.Uuid
+
+/**
+ * The marker only earns its keep by surviving process death, so the stored form has to survive a
+ * fresh [UserPreferences] over the same backing store.
+ */
+class ConversationListTopPreferenceTest {
+
+    @Test
+    fun unsetKeyReadsNull() {
+        assertNull(UserPreferences(InMemorySettings()).conversationListTopId)
+    }
+
+    @Test
+    fun roundTripsAcrossInstances() {
+        val settings = InMemorySettings()
+        val top = Uuid.random()
+
+        UserPreferences(settings).conversationListTopId = top
+
+        assertEquals(top, UserPreferences(settings).conversationListTopId)
+    }
+
+    @Test
+    fun nullClearsTheStoredMarker() {
+        val settings = InMemorySettings()
+        val prefs = UserPreferences(settings)
+        prefs.conversationListTopId = Uuid.random()
+
+        prefs.conversationListTopId = null
+
+        assertNull(prefs.conversationListTopId)
+        assertEquals(0, settings.size)
+    }
+
+    @Test
+    fun anUnparseableStoredValueReadsNull() {
+        val settings = InMemorySettings()
+        settings.putString("conversationListTopId", "not-a-uuid")
+
+        assertNull(UserPreferences(settings).conversationListTopId)
+    }
+}


### PR DESCRIPTION
Closes #1341.

## The bug

`ConversationListPane` used a plain `rememberLazyListState()`, which saves and restores scroll by `firstVisibleItemIndex` + offset. When the list reorders while you're away, the restored index points at a *different* conversation, so the promoted one is hidden above the fold. Both reported variants are the same defect:

- Scroll down, leave, someone messages you → they jump to #1 → reopen and they're above the fold.
- Scroll far down, open a conversation, send a message, press back → it's now #1 and you're staring at where it used to be.

## The rule

One condition: **the top conversation changed since you last saw the list → scroll to top; otherwise leave the position alone.** That covers inbound and own-send without special-casing either.

`listOnScreen` — the list pane visible **and** the app foregrounded — is the single signal. Its falling edge writes the marker, its rising edge evaluates. Back-nav, warm resume and cold start all fall out of that with no per-case branch. The marker persists via `UserPreferences` because process death is the main failing case.

## Change from the issue's literal wording

The issue says "snapshot the id of the **#1 conversation**". Implemented literally, that's the first *row* — and **pinned conversations sit above everything and rarely change**, so on any account with a pin the marker would essentially never move and the feature would almost never fire. (Easy to miss: it looks correct on a list with no pins.)

The marker is therefore the **most recently active** conversation — max `latestMessageTimestamp`, which is the list's own sort key and the issue's own suggested alternative. It's pin-independent, covers the pinned and unpinned sections with one value, and stays a single mechanism. A test pins the regression: a stale pinned row must not mask activity below it.

## The two known traps in this code

**`firstVisibleItemIndex` and the `Int.MAX_VALUE` sentinel** — deliberately not routed through `boundedFirstVisibleItemIndex`. The documented hazard is using the value as an *array index*; here it's only compared to `0`:

```kotlin
val isAtTop = listState.firstVisibleItemIndex == 0 && listState.firstVisibleItemScrollOffset == 0
```

Nothing indexes anything, and if the sentinel ever did appear it yields `isAtTop = false` — scroll to top, the safe direction. `canScrollBackward` was avoided on purpose: it needs a completed measure pass, and on cold start the restored index is in state *before* the first measure, which is exactly what makes the cold-start case work.

**`snapshotFlow`** — none added. `git diff | grep snapshotFlow` is empty.

## Why the snapshot and the check live in different files

`ConversationListScreen` stays composed whether or not `AnimatedPane` keeps a hidden pane's content alive, so the leave-write is reliable either way. The return-check needs the `LazyListState`, which lives in the Pane, and is gated on `listPaneVisible` so it works whether or not the Pane is disposed while hidden.

The trailing re-snapshot after each return matters: the marker then means "the top as of the last time the list was on screen" at both ends. Without it, a route-level departure (tapping through to Settings, where the pane isn't hidden and `ON_STOP` doesn't fire) would leave a stale marker and cause a spurious jump on return.

Archived and search lists are gated out — they share `conversationsContent`, so they can neither trigger a scroll nor overwrite the marker.

## Test

`ConversationListTopAnchorTest` (8) and `ConversationListTopPreferenceTest` (4): top changed → true, unchanged → false, already-at-top → false either way, no snapshot yet → false (no jump on a fresh install), empty list → false and no crash, the anchor is the most recently active conversation rather than the first row, a stale pinned row doesn't mask activity below it; plus the marker round-tripping through a fresh `UserPreferences`, `null` clearing the key, and garbage reading back as `null`.

`homebase-chat:jvmTest homebase-common:jvmTest homebase-core:jvmTest` — 2561 tests, 0 failures, Konsist `ArchitectureTest` included.

## Needs a device before merge

The decision and the storage are unit-tested; **none of the six acceptance criteria are**, because each depends on Compose wiring no JVM test exercises. Specifically worth checking on hardware: inbound reorder, own-send-then-back, no-change-preserves-position, cold start after process death (whether Android restores the saveable index, and how `ColdStartDetailGuard` interacts with the arming), notification-tap then back, and that the archived/search lists don't regress.

"Doesn't fight an in-progress user scroll" is reasoned rather than measured — the check fires on the return frame, before the user has touched anything.
