### PR TITLE
Stop a Kotlin exception in a web callback from trapping the Wasm module (#1485)

### DIFF
--- a/homebase-api/src/commonMain/kotlin/id/homebase/api/util/RepeatedErrorFilter.kt
+++ b/homebase-api/src/commonMain/kotlin/id/homebase/api/util/RepeatedErrorFilter.kt
@@ -1,0 +1,12 @@
+package id.homebase.api.util
+
+/** Accepts the first [limit] occurrences of a key and rejects every one after that. */
+internal class RepeatedErrorFilter(private val limit: Int = 3) {
+    private val counts = mutableMapOf<String, Int>()
+
+    fun accept(key: String): Boolean {
+        val seen = (counts[key] ?: 0) + 1
+        counts[key] = seen
+        return seen <= limit
+    }
+}

--- a/homebase-api/src/commonTest/kotlin/id/homebase/api/util/RepeatedErrorFilterTest.kt
+++ b/homebase-api/src/commonTest/kotlin/id/homebase/api/util/RepeatedErrorFilterTest.kt
@@ -1,0 +1,29 @@
+package id.homebase.api.util
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class RepeatedErrorFilterTest {
+
+    @Test
+    fun acceptsUpToTheLimitThenStopsForever() {
+        val filter = RepeatedErrorFilter(limit = 3)
+
+        assertTrue(filter.accept("a"))
+        assertTrue(filter.accept("a"))
+        assertTrue(filter.accept("a"))
+        assertFalse(filter.accept("a"))
+        repeat(500) { assertFalse(filter.accept("a")) }
+    }
+
+    @Test
+    fun countsEachKeyIndependently() {
+        val filter = RepeatedErrorFilter(limit = 1)
+
+        assertTrue(filter.accept("a"))
+        assertFalse(filter.accept("a"))
+        assertTrue(filter.accept("b"))
+        assertFalse(filter.accept("b"))
+    }
+}

--- a/homebase-api/src/wasmJsMain/kotlin/id/homebase/api/browser/JsCallbackGuard.kt
+++ b/homebase-api/src/wasmJsMain/kotlin/id/homebase/api/browser/JsCallbackGuard.kt
@@ -1,0 +1,30 @@
+package id.homebase.api.browser
+
+import co.touchlab.kermit.Logger
+import id.homebase.api.util.RepeatedErrorFilter
+import kotlinx.coroutines.CancellationException
+
+private const val TAG = "JsCallbackGuard"
+
+private val reported = RepeatedErrorFilter()
+
+/**
+ * Runs [block] as the body of a browser callback (DOM event, media event, timer, worker message).
+ *
+ * A Kotlin exception cannot unwind across the Wasm/JS boundary: it traps the whole module
+ * ("unreachable executed"), which kills whatever continuation the browser happened to be running.
+ * When that is Compose's FlushCoroutineDispatcher, every later resumption on it throws
+ * CoroutinesInternalError and no frame is ever scheduled again.
+ */
+fun guardJsCallback(tag: String, block: () -> Unit) {
+    try {
+        block()
+    } catch (e: CancellationException) {
+        // Swallowing cancellation would break structured concurrency in the caller's scope.
+        throw e
+    } catch (t: Throwable) {
+        if (reported.accept(tag)) {
+            Logger.e(tag = TAG, throwable = t) { "$tag threw; only the first few are logged" }
+        }
+    }
+}

--- a/homebase-api/src/wasmJsMain/kotlin/id/homebase/api/video/FFmpegBridge.web.kt
+++ b/homebase-api/src/wasmJsMain/kotlin/id/homebase/api/video/FFmpegBridge.web.kt
@@ -2,6 +2,7 @@
 
 package id.homebase.api.video
 
+import id.homebase.api.browser.guardJsCallback
 import kotlin.io.encoding.Base64
 import kotlin.js.Promise
 import kotlinx.coroutines.await
@@ -114,7 +115,9 @@ internal object FFmpegBridge {
      * [onProgress] receives 0..1 from ffmpeg.wasm's native progress event during the run.
      */
     suspend fun exec(args: List<String>, onProgress: ((Float) -> Unit)? = null): Int {
-        if (onProgress != null) ffSetProgress { d -> onProgress(d.toFloat()) }
+        if (onProgress != null) {
+            ffSetProgress { d -> guardJsCallback("ffmpeg.progress") { onProgress(d.toFloat()) } }
+        }
         try {
             return ffExec(toJsonArray(args)).await<JsString>().toString().toIntOrNull() ?: -1
         } finally {

--- a/homebase-chat/src/wasmJsMain/kotlin/id/homebase/chat/widget/video/LocalVideoPlayerSurface.web.kt
+++ b/homebase-chat/src/wasmJsMain/kotlin/id/homebase/chat/widget/video/LocalVideoPlayerSurface.web.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.layout.boundsInWindow
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalDensity
+import id.homebase.api.browser.guardJsCallback
 import id.homebase.api.file.systemFileSystem
 import id.homebase.api.util.isBlobUrl
 import kotlin.io.encoding.Base64
@@ -135,19 +136,23 @@ actual fun TrimmableVideoPlayerSurface(
         // No native controls — the trim screen draws its own scrubber.
         val el = createVideoOverlay(muted = false, controls = false)
         addVideoOverlayProgressListener(el) { currentSec, _ ->
-            val ms = (currentSec * 1000).toLong()
-            onPositionState.value(ms)
-            // Loop within [clipStart, clipEnd]: when playback runs past the clip end, jump back
-            // to the clip start (matches the native trim players' looping contract).
-            val end = clipEndState.value
-            if (end > 0L && ms >= end) {
-                setVideoOverlayCurrentTime(el, clipStartState.value / 1000.0)
+            guardJsCallback("trimVideo.progress") {
+                val ms = (currentSec * 1000).toLong()
+                onPositionState.value(ms)
+                // Loop within [clipStart, clipEnd]: when playback runs past the clip end, jump
+                // back to the clip start (matches the native trim players' looping contract).
+                val end = clipEndState.value
+                if (end > 0L && ms >= end) {
+                    setVideoOverlayCurrentTime(el, clipStartState.value / 1000.0)
+                }
             }
         }
         // Seek to the clip start once the first frame is decoded (assigning currentTime before
         // metadata is loaded is unreliable).
         addVideoOverlayLoadedListener(el) {
-            setVideoOverlayCurrentTime(el, clipStartState.value / 1000.0)
+            guardJsCallback("trimVideo.loaded") {
+                setVideoOverlayCurrentTime(el, clipStartState.value / 1000.0)
+            }
         }
         setVideoOverlaySrc(el, src.url)
         element = el

--- a/homebase-chat/src/wasmJsMain/kotlin/id/homebase/chat/widget/video/VideoPlayerSurface.web.kt
+++ b/homebase-chat/src/wasmJsMain/kotlin/id/homebase/chat/widget/video/VideoPlayerSurface.web.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.layout.boundsInWindow
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
+import id.homebase.api.browser.guardJsCallback
 import id.homebase.api.client.drives.files.DriveFileProvider
 import id.homebase.api.video.VideoContent
 import id.homebase.api.video.VideoPlayerData
@@ -110,8 +111,10 @@ actual fun VideoPlayerSurface(
                     val url = bytesToObjectUrl(Base64.encode(content.bytes), mime)
                     objectUrl = url
                     val el = createVideoOverlay(muted, controls = true)
-                    addVideoOverlayProgressListener(el) { _, _ -> onProgress(1f) }
-                    addVideoOverlayEndedListener(el) { onEnded() }
+                    addVideoOverlayProgressListener(el) { _, _ ->
+                        guardJsCallback("video.progress") { onProgress(1f) }
+                    }
+                    addVideoOverlayEndedListener(el) { guardJsCallback("video.ended") { onEnded() } }
                     setVideoOverlaySrc(el, url)
                     // NOTE: do NOT play here — the element has no on-screen bounds yet, so it
                     // would play through invisibly and end before it's ever shown. Play is kicked

--- a/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/audio/AudioPlayer.web.kt
+++ b/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/audio/AudioPlayer.web.kt
@@ -3,6 +3,7 @@
 package id.homebase.core.audio
 
 import co.touchlab.kermit.Logger
+import id.homebase.api.browser.guardJsCallback
 import id.homebase.api.file.readWebFileBytes
 import id.homebase.core.util.detectContentTypeFromExtensionOrHint
 import kotlin.io.encoding.Base64
@@ -33,13 +34,19 @@ private class WebAudioPlayer : AudioPlayer {
 
         val el = createAudioElement(url)
         addAudioProgressListener(el) { currentSec, durationSec ->
-            observer?.onProgressUpdate(currentSec.toWholeSeconds(), durationSec.toWholeSeconds())
+            guardJsCallback("audio.progress") {
+                observer?.onProgressUpdate(currentSec.toWholeSeconds(), durationSec.toWholeSeconds())
+            }
         }
-        addAudioEndedListener(el) { observer?.onComplete() }
-        addAudioErrorListener(el) { code -> Logger.e(tag = TAG) { "Audio element error $code" } }
+        addAudioEndedListener(el) { guardJsCallback("audio.ended") { observer?.onComplete() } }
+        addAudioErrorListener(el) { code ->
+            guardJsCallback("audio.error") { Logger.e(tag = TAG) { "Audio element error $code" } }
+        }
         element = el
 
-        playAudioElement(el) { reason -> Logger.w(tag = TAG) { "play() rejected: $reason" } }
+        playAudioElement(el) { reason ->
+            guardJsCallback("audio.play") { Logger.w(tag = TAG) { "play() rejected: $reason" } }
+        }
     }
 
     override fun jump(seconds: Int) {
@@ -49,7 +56,9 @@ private class WebAudioPlayer : AudioPlayer {
 
     override fun resume() {
         val el = element ?: return
-        playAudioElement(el) { reason -> Logger.w(tag = TAG) { "resume() rejected: $reason" } }
+        playAudioElement(el) { reason ->
+            guardJsCallback("audio.resume") { Logger.w(tag = TAG) { "resume() rejected: $reason" } }
+        }
     }
 
     override fun pause() {

--- a/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/auth/BrowserLauncher.web.kt
+++ b/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/auth/BrowserLauncher.web.kt
@@ -2,6 +2,7 @@
 
 package id.homebase.core.auth
 
+import id.homebase.api.browser.guardJsCallback
 import kotlinx.browser.window
 import org.w3c.dom.MessageEvent
 import org.w3c.dom.events.Event
@@ -25,14 +26,16 @@ actual object BrowserLauncher {
         // Drop any stale listener from a previous (cancelled) attempt.
         removeListener()
 
-        val handler: (Event) -> Unit = handler@{ event ->
-            val msg = event as? MessageEvent ?: return@handler
-            // Only trust messages from our own origin (the popup's callback page).
-            if (msg.origin != window.location.origin) return@handler
-            val callbackUrl = extractCallbackUrl(msg.data) ?: return@handler
-            // One-shot — tear down before delivering.
-            removeListener()
-            onCallbackUrl(callbackUrl)
+        val handler: (Event) -> Unit = { event ->
+            guardJsCallback("youauth.message") {
+                val msg = event as? MessageEvent ?: return@guardJsCallback
+                // Only trust messages from our own origin (the popup's callback page).
+                if (msg.origin != window.location.origin) return@guardJsCallback
+                val callbackUrl = extractCallbackUrl(msg.data) ?: return@guardJsCallback
+                // One-shot — tear down before delivering.
+                removeListener()
+                onCallbackUrl(callbackUrl)
+            }
         }
         listener = handler
         window.addEventListener("message", handler)

--- a/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/clipboard/ClipboardImagePasteEffect.web.kt
+++ b/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/clipboard/ClipboardImagePasteEffect.web.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.window.LocalActiveClipEventsTarget
 import co.touchlab.kermit.Logger
+import id.homebase.api.browser.guardJsCallback
 import kotlin.io.encoding.Base64
 import kotlin.js.Promise
 import kotlinx.coroutines.await
@@ -51,15 +52,17 @@ actual fun ClipboardImagePasteEffect(enabled: Boolean, onImagePasted: (ByteArray
         if (target == null) return@DisposableEffect onDispose { }
 
         val listener = EventListener { event ->
-            // clipboardData is only live for the duration of the dispatch, so pull the image out
-            // synchronously; only the byte read is deferred to the coroutine.
-            val pending = pastedImageBase64(event)
-            scope.launch {
-                val base64 = runCatching { pending.await<JsString>().toString() }
-                    .onFailure { Logger.w("Reading a pasted image failed", it) }
-                    .getOrNull()
-                    .orEmpty()
-                if (base64.isNotBlank()) currentOnImagePasted(Base64.decode(base64))
+            guardJsCallback("clipboard.paste") {
+                // clipboardData is only live for the duration of the dispatch, so pull the image
+                // out synchronously; only the byte read is deferred to the coroutine.
+                val pending = pastedImageBase64(event)
+                scope.launch {
+                    val base64 = runCatching { pending.await<JsString>().toString() }
+                        .onFailure { Logger.w("Reading a pasted image failed", it) }
+                        .getOrNull()
+                        .orEmpty()
+                    if (base64.isNotBlank()) currentOnImagePasted(Base64.decode(base64))
+                }
             }
         }
 

--- a/webApp/src/wasmJsMain/resources/index.html
+++ b/webApp/src/wasmJsMain/resources/index.html
@@ -181,7 +181,30 @@
     })();
 </script>
 <script type="application/javascript">
+    // A Kotlin exception cannot unwind into a JS callback: Wasm traps ("unreachable executed"),
+    // which kills Compose's frame dispatcher and then floods the console with cascade errors —
+    // pushing the first (the only informative one) out of the devtools buffer. Keep it here.
+    const homebaseErrors = {first: null, total: 0};
+    window.__homebaseErrors = homebaseErrors;
+    window.__homebaseFirstError = function () {
+        const first = homebaseErrors.first;
+        if (first == null) return "No uncaught error recorded.";
+        return first.message + "\n" + first.stack + "\n(" + homebaseErrors.total + " total)";
+    };
+
     const unhandledError = (event, error) => {
+        homebaseErrors.total++;
+        if (homebaseErrors.first == null) {
+            homebaseErrors.first = {
+                message: String((error && error.message) || error || (event && event.message) || event),
+                stack: (error && error.stack) || ""
+            };
+            console.error(
+                "[homebase] first uncaught error — re-read it with __homebaseFirstError()",
+                error || event
+            );
+        }
+
         if (error instanceof WebAssembly.CompileError) {
             window.__homebaseBootError(
                 "This browser can't run WebAssembly modules this app needs. " +


### PR DESCRIPTION
Fixes the boundary fragility behind #1485.

## The failure chain

A Kotlin exception cannot unwind across the Kotlin/Wasm → JS boundary. When one escapes a browser callback, the module **traps** (`unreachable executed`), and the trap kills whatever continuation the browser happened to be running:

1. Something throws inside a DOM event handler → `org.w3c.dom.events.__convertKotlinClosureToJsClosure_((Js)->Unit)` traps. **This is the original fault.**
2. The trap kills the in-flight continuation on Compose's `FlushCoroutineDispatcher` — the same dispatcher instance (`@1510514787`) appears in every subsequent error in the reported console dump.
3. Every later resumption on that dispatcher throws `CoroutinesInternalError` — `callWithFrameNanos`, `SharedFlowImpl.collect`, `BufferedChannel.receive`.
4. The final trap lands inside `requestAnimationFrame`, so no further frames are scheduled → UI frozen, 0% CPU, permanent.

Everything after step 1 is cascade. The fix here is step 1: make a Kotlin exception in a callback a logged error instead of a module trap.

## What changed

**`guardJsCallback(tag) { … }`** (`homebase-api/src/wasmJsMain/…/browser/JsCallbackGuard.kt`) wraps a callback body. It rethrows `CancellationException` (swallowing it would break structured concurrency in the caller's scope) and logs everything else through Kermit with the throwable, so the stack survives.

**`RepeatedErrorFilter`** (`homebase-api/src/commonMain/…/util/RepeatedErrorFilter.kt`) caps logging at the first few occurrences per tag. Without it a per-frame callback that throws every frame would trade a silent hang for a console flood. Covered by `RepeatedErrorFilterTest` (JVM, `homebase-api:jvmTest`).

### Boundaries hardened

Every place this codebase hands a Kotlin closure to a JS API:

| Site | Callback |
|---|---|
| `homebase-common/…/core/auth/BrowserLauncher.web.kt:29` | `window.addEventListener("message", …)` — YouAuth popup callback. **DOM event, exactly the `(Js)->Unit` shape in the reported stack.** |
| `homebase-common/…/core/clipboard/ClipboardImagePasteEffect.web.kt:54` | `paste` listener on Compose's clip-events target. **DOM event.** |
| `homebase-common/…/core/audio/AudioPlayer.web.kt:36,41,42,47,60` | `<audio>` `timeupdate`/`loadedmetadata`/`playing`/`seeked`, `ended`, `error`, and two `play()` promise rejections |
| `homebase-chat/…/video/LocalVideoPlayerSurface.web.kt:138,155` | `<video>` trim-surface progress + `loadeddata` |
| `homebase-chat/…/video/VideoPlayerSurface.web.kt:114,117` | `<video>` playback progress + `ended` |
| `homebase-api/…/video/FFmpegBridge.web.kt:119` | ffmpeg.wasm worker progress |

### Boundaries found and deliberately left alone

- **`homebase-api/…/sync/database/WebSqlDriver.kt:45`** — `odinInit().then(onOk, onErr)` resuming a `suspendCancellableCoroutine`. Guarding it would swallow the resume and leave boot suspended at the splash forever instead of failing loudly. It is one-shot, at boot, before Compose exists, so it cannot corrupt `FlushCoroutineDispatcher`.
- **Compose's own DOM and `requestAnimationFrame` listeners.** The second trap in the report is `org.w3c.dom.__convertKotlinClosureToJsClosure_((Double)->Unit)` inside `requestAnimationFrame_$external_fun` — that closure lives in the Compose Multiplatform runtime, not in this repo. We call `requestAnimationFrame` from Kotlin nowhere. It cannot be wrapped from here.
- The `js("…")` bridges in `BrowserVideoDecoder.kt`, `FFmpegUtils.web.kt`, `ClipboardImageReader.web.kt` and `HtmlVideoOverlay.web.kt` register **JS** closures, not Kotlin ones, and already `try`/`catch` internally. No trap risk.

### Console evidence keeper (`index.html`)

Because the Compose-internal listeners can't be wrapped, `index.html`'s existing `error`/`unhandledrejection` handler now records the **first** uncaught error on `window.__homebaseErrors` and prints it once with a marker. `window.__homebaseFirstError()` re-reads it plus the total count. That is the direct answer to the evidence problem in the issue: the hundreds of cascade errors push the only informative stack out of the devtools buffer, and now it survives regardless of buffer size.

## Acceptance criteria

- [ ] **1 — the original throwing site is identified from a captured first-error stack. NOT SATISFIED, and not satisfiable here.** The issue itself says the first-error stack was never captured, which is why it was left at normal priority. I have no reproduction and I will not name a root cause I cannot prove. `BrowserLauncher.web.kt`'s `message` listener is the one *candidate* in our own code that matches the `org.w3c.dom.events` `(Js)->Unit` shape, but it only runs during a YouAuth popup login, which does not match "hangs during use" — treat it as a candidate, not the cause. The likeliest source remains a Kotlin exception escaping Compose's own canvas event dispatch, which this PR cannot wrap but can now surface.
- [x] **2 — a Kotlin exception in a guarded callback no longer traps the module.** It is caught, logged with the throwable, and `FlushCoroutineDispatcher` is untouched.
- [x] **3 — the app stays usable after such an exception** at every guarded site. At the unguarded Compose-internal sites it still hangs, but now fails loudly once (first error kept and printed) instead of silently.
- [x] **4 — no `CoroutinesInternalError` cascade** from a guarded site: no trap, so no dead dispatcher. `RepeatedErrorFilter` also stops a repeating callback from logging hundreds of lines.

## Capturing the missing first-error stack next time

If the hang recurs, before doing anything else:

1. Firefox devtools → Console → settings gear → enable **Persist Logs**.
2. `about:config` → raise **`devtools.hud.loglimit`** well above its default (the cascade is hundreds of entries and evicts the first one).
3. Reproduce, then right-click the console → **Export Visible Messages To File**.
4. With this PR deployed there is a shortcut: run **`__homebaseFirstError()`** in the console. It returns the first uncaught error's message and stack plus the total error count, regardless of what the buffer dropped.

## Related

#1382 is the Desktop `CoroutinesInternalError` on `FlushCoroutineDispatcher` after a modal `FileDialog` re-entered the EDT — different trigger, same fatal pattern of one exception permanently poisoning Compose's dispatcher. This mitigation is web-only (the trap mechanism is specific to Wasm/JS) and does not address it; Desktop is out of scope here.

## Verification

Compiled, all passing:

```
./gradlew :homebase-api:compileKotlinWasmJs :homebase-api:compileKotlinJvm
./gradlew :webApp:compileKotlinWasmJs            # also builds homebase-common/chat/core wasmJs
./gradlew :homebase-api:compileKotlinIosSimulatorArm64 :homebase-api:compileTestKotlinWasmJs
./gradlew homebase-chat:jvmTest homebase-auth:jvmTest homebase-common:jvmTest homebase-api:jvmTest
```

`RepeatedErrorFilterTest` ran as part of `homebase-api:jvmTest` (2 tests, 0 failures).

**Not verified:** nothing was run in a browser. The hang was not reproduced, the guard was not exercised against a live Wasm trap, and `__homebaseFirstError()` was not exercised in devtools. Those need a real Firefox session against a deployed build.
