### PR TITLE
Drop the over-strict API 30 gate from ImageUtils (#1377)

### DIFF
--- a/homebase-api/src/androidMain/kotlin/id/homebase/api/image/ImageUtil.android.kt
+++ b/homebase-api/src/androidMain/kotlin/id/homebase/api/image/ImageUtil.android.kt
@@ -6,7 +6,6 @@ import android.graphics.BitmapFactory
 import android.graphics.ImageDecoder
 import android.graphics.Matrix
 import android.os.Build
-import androidx.annotation.RequiresApi
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.core.graphics.scale
@@ -151,8 +150,8 @@ actual object ImageUtils {
     }
 
     // WEBP_LOSSY landed in API 30 but minSdk is 28, and @RequiresApi emits no runtime guard —
-    // reading the field on 28/29 throws NoSuchFieldError, which took out every thumbnail encode
-    // on Android 9/10. The deprecated WEBP constant is lossy below quality 100.
+    // reading the field on 28/29 throws NoSuchFieldError. The deprecated WEBP constant is
+    // lossy below quality 100.
     @Suppress("DEPRECATION")
     private fun webpCompressFormat(): Bitmap.CompressFormat =
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
@@ -175,7 +174,6 @@ actual object ImageUtils {
         return stream.toByteArray()
     }
 
-    @RequiresApi(Build.VERSION_CODES.R)
     actual fun resizePreserveAspect(
         srcBytes: ByteArray,
         maxWidth: Int,
@@ -214,7 +212,6 @@ actual object ImageUtils {
         )
     }
 
-    @RequiresApi(Build.VERSION_CODES.R)
     actual fun compressOnly(
         srcBytes: ByteArray,
         outputFormat: ImageFormat,
@@ -233,7 +230,6 @@ actual object ImageUtils {
         return result
     }
 
-    @RequiresApi(Build.VERSION_CODES.R)
     actual fun crop(
         srcBytes: ByteArray,
         x: Int,
@@ -265,7 +261,6 @@ actual object ImageUtils {
         )
     }
 
-    @RequiresApi(Build.VERSION_CODES.R)
     actual fun rotate(
         srcBytes: ByteArray,
         degrees: Int,
@@ -357,7 +352,6 @@ actual object ImageUtils {
     /** Grid side length → ALPHA_PROBE_GRID² ≤ ~4096 samples regardless of image size. */
     private const val ALPHA_PROBE_GRID: Int = 64
 
-    @RequiresApi(Build.VERSION_CODES.R)
     actual fun warpAffine(
         srcBytes: ByteArray,
         matrix9: FloatArray,
@@ -526,7 +520,6 @@ actual object ImageUtils {
 
     private const val BLUR_RADIUS: Int = 25
 
-    @RequiresApi(Build.VERSION_CODES.R)
     actual suspend fun rasterizeSvg(
         svgBytes: ByteArray,
         maxDim: Int,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/image/StickerImageProcessor.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/image/StickerImageProcessor.kt
@@ -216,9 +216,10 @@ object StickerImageProcessor {
      * Downscale the segmenter's full-resolution cut-out to a `<= [STICKER_MAX_DIM]`px
      * **lossless PNG** (alpha preserved) for upload.
      *
-     * PNG, not WebP: the Android [ImageUtils] WebP branch is `WEBP_LOSSY` and gated to
-     * API 30+, but `minSdk` is 28 — WebP output would `NoSuchFieldError`-crash on API
-     * 28/29. PNG encodes on every API level and keeps cut-out edges alpha-perfect.
+     * PNG, not WebP: WebP is lossy on Android below API 30 (the deprecated `WEBP` constant
+     * is the only one there), and its fringe on near-opaque pixels is what
+     * [ImageUtils.hasNonOpaquePixels] already has to tolerate — a cut-out's alpha edge is
+     * exactly the signal a lossy re-encode would blur away.
      *
      * Never upscales (an already-small cut-out is just re-encoded). Defensive: returns
      * the original [cutOutBytes] unchanged if the re-encode fails or yields nothing, so a
@@ -227,10 +228,10 @@ object StickerImageProcessor {
      */
     suspend fun downscaleCutOut(cutOutBytes: ByteArray): ByteArray =
         withContext(Dispatchers.Default) {
-            // runCatching catches Throwable, so a resize failure — or, hypothetically, an
-            // API-gated encoder on an old device — degrades to the original cut-out instead
-            // of crashing. It wraps only the synchronous resize (not a suspension point), so
-            // it cannot swallow CancellationException; cancellation propagates via withContext.
+            // runCatching catches Throwable so a resize failure degrades to the original
+            // cut-out instead of crashing. It wraps only the synchronous resize (not a
+            // suspension point), so it cannot swallow CancellationException; cancellation
+            // propagates via withContext.
             runCatching {
                 ImageUtils.resizePreserveAspect(
                     srcBytes = cutOutBytes,

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/image/StickerImageProcessorTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/image/StickerImageProcessorTest.kt
@@ -36,7 +36,7 @@ class StickerImageProcessorTest {
         assertEquals(
             "image/png",
             ImageFormatDetector.detectFormat(out),
-            "must stay PNG — the Android ImageUtils WebP branch crashes on API 28/29",
+            "must stay PNG — a lossy WebP re-encode would blur the cut-out's alpha edge",
         )
         assertTrue(
             ImageUtils.hasNonOpaquePixels(out),
@@ -88,7 +88,7 @@ class StickerImageProcessorTest {
         assertEquals(
             "image/png",
             ImageFormatDetector.detectFormat(out),
-            "must stay PNG — the Android ImageUtils WebP branch crashes on API 28/29",
+            "must stay PNG — a lossy WebP re-encode would blur the cut-out's alpha edge",
         )
         assertTrue(
             ImageUtils.hasNonOpaquePixels(out),


### PR DESCRIPTION
Closes the two open checkboxes from #1377 that the `WEBP_LOSSY` runtime fallback left behind. The encode fix itself already shipped — this is the annotation audit and the stale rationale it left in `StickerImageProcessor`.

## The six `@RequiresApi(Build.VERSION_CODES.R)` sites

Audited each function body plus every private helper it transitively reaches (`decodeBitmap` → `convertHeicToJpeg` / `applyExifOrientation`, `encodeBitmap` → `webpCompressFormat`).

| Function | Highest API actually needed | Verdict |
| --- | --- | --- |
| `resizePreserveAspect` | 28 — `ImageDecoder` (28) via `decodeBitmap`'s HEIC branch; `Bitmap.scale` is an `androidx.core` extension with no floor | **Removed** |
| `compressOnly` | 28 — same `decodeBitmap` path, nothing else | **Removed** |
| `crop` | 1 — `Bitmap.createBitmap(src, x, y, w, h)` | **Removed** |
| `rotate` | 1 — `Matrix.postRotate` + `Bitmap.createBitmap(…, matrix, true)` | **Removed** |
| `warpAffine` | 1 — `Canvas`/`Paint`/`Matrix.setValues`, `Bitmap.Config.ARGB_8888` | **Removed** |
| `rasterizeSvg` | 1 — AndroidSVG 1.4 (`renderToCanvas`), `Bitmap.createBitmap` | **Removed** |

None warranted narrowing, so no annotation was replaced with a lower level and no new comment was added.

Specifically checked and not found in any of the six: `WEBP_LOSSY`/`WEBP_LOSSLESS` (30) — now only reachable through the `SDK_INT` check in `webpCompressFormat`; `RenderEffect` (31); `Bitmap.Config.HARDWARE` / `HardwareBuffer` (29/26). `blurAndroidBitmap` (the file's blur helper) is pure `getPixels`/`setPixels` + the in-house `stackBlur`, and none of the six reach it anyway — only `drawStrokes` and `blurBytes` do, and both were already unannotated.

## Blast radius

Nothing to unwind. `git grep` for `RequiresApi` and `SDK_INT >= …R` shows:

- **No caller-side guard or suppression existed.** Every `ImageUtils` call site is in `commonMain` (`ThumbnailGenerator`, `StandardQualityImage`, `StickerImageProcessor`, `MomentsPostSenderService`, `VaultUploaderService`, `ProfileAvatarEditViewModel`, `CropFinalizer`/`CropPreprocessor`/`DrawFinalizer`, `MessageActionsHandler`), which cannot express an Android annotation. Nothing else in the repo carried a `NewApi` suppression or a matching `R` guard.
- **The `commonMain` `expect` and the jvm/skia/native/wasmJs actuals** carry no companion annotations or API-30 comments — nothing stale to clean there.
- `HeicOrientationAndroidTest.imagePipeline_doesNotRotateTwice` keeps its `@SdkSuppress(minSdkVersion = R)` + `@RequiresApi(R)` pair. That is an unrelated reason — the HEIF fixture needs an API-30 device to decode reliably — so it was deliberately left alone.

## Sticker output format

**Left as PNG**; only the justification changed. The old comment cited the `NoSuchFieldError` crash, which the fallback fixed.

The reason that still holds is quality, not crashing: below API 30 the encoder is the deprecated lossy `WEBP` constant, and the fringe it leaves on near-opaque pixels is exactly what `ImageUtils.hasNonOpaquePixels` already has to tolerate (`ALPHA_OPAQUE_THRESHOLD = 250`, whose own comment names "the compression fringe that WebP/PNG lossy re-encode adds"). A cut-out's alpha edge is the signal that would get blurred, so lossless PNG stays. The two `StickerImageProcessorTest` assertion messages that repeated the obsolete crash reason were updated to match.

## Reproduction checkbox — still open

**The crash was not reproduced on API 28/29.** No emulator work was in scope for this PR, so nothing was booted, installed or exercised on Android 9/10. The first checkbox in #1377 stays open for whoever has access to real Android 9 / Android 10 hardware or is able to run an API 28/29 image.

Nothing here should be read as confirming the crash. The mechanism is still inferred from code alone, and the issue's own caveat stands: if image sending has demonstrably worked on Android 9/10 all along, the reasoning is wrong somewhere.

One thing this PR did establish, which is relevant to why the bug could ship unnoticed: **`./gradlew lint` — what `lint.yml` runs — does not analyze `homebase-api/src/androidMain` at all.** Only `androidApp` produces a lint report; the KMP library modules expose just `lintAnalyzeAndroidHostTest`, with no task covering `androidMain`. Verified by control: reverting `webpCompressFormat` to a bare unguarded `Bitmap.CompressFormat.WEBP_LOSSY` still gives `BUILD SUCCESSFUL`. So `NewApi` never policed this file, these annotations were never enforcing anything in CI, and removing them cannot introduce a lint break. Worth a separate issue.

## Verification

| Command | Result |
| --- | --- |
| `./gradlew :homebase-api:compileAndroidMain` | BUILD SUCCESSFUL |
| `./gradlew :homebase-api:compileKotlinJvm` | BUILD SUCCESSFUL |
| `./gradlew :homebase-api:compileKotlinIosSimulatorArm64` | BUILD SUCCESSFUL |
| `./gradlew :homebase-api:compileKotlinWasmJs` | BUILD SUCCESSFUL |
| `./gradlew :homebase-chat:compileAndroidMain` | BUILD SUCCESSFUL |
| `./gradlew :androidApp:compileDebugKotlin` | BUILD SUCCESSFUL |
| `./gradlew homebase-chat:jvmTest homebase-common:jvmTest homebase-api:jvmTest` | BUILD SUCCESSFUL |
| `./gradlew lint` | BUILD SUCCESSFUL (see the caveat above about what it actually covers) |
