### PR TITLE
Move web byte crossings off Base64 onto a linear-memory bridge

### DIFF
--- a/homebase-api/src/wasmJsMain/kotlin/id/homebase/api/util/WasmByteBridge.kt
+++ b/homebase-api/src/wasmJsMain/kotlin/id/homebase/api/util/WasmByteBridge.kt
@@ -1,0 +1,108 @@
+@file:OptIn(kotlin.js.ExperimentalWasmJsInterop::class, kotlin.wasm.unsafe.UnsafeWasmMemoryApi::class)
+
+package id.homebase.api.util
+
+import kotlin.wasm.unsafe.withScopedMemoryAllocator
+
+/*
+ * Bulk byte bridge to JS, replacing the Base64 idiom (~6x the payload in peak memory plus a
+ * synchronous per-byte `charCodeAt` loop on the main thread).
+ *
+ * Kotlin/Wasm is Wasm GC, so a ByteArray is a GC `(array i8)` with no address in `memory.buffer`
+ * and JS cannot view one directly — the Emscripten `HEAPU8.subarray()` trick does not apply here.
+ * `kotlin.wasm.unsafe` linear memory does have addresses, the module exports it as `memory`, and
+ * the compiler puts `wasmExports` in scope for `js()` bodies precisely so they can reach it
+ * (`compose.resources` moves its own bytes the same way). So bytes go through a staging window:
+ * an in-wasm store loop fills it, one typed-array view hands the window to JS.
+ *
+ * The window is fixed rather than payload-sized because linear memory never shrinks — staging a
+ * whole clip would grow the tab's heap by the clip size for the rest of the session.
+ *
+ * Not kotlinx-browser's `ByteArray.toInt8Array()`: that is an element-wise loop, so it costs one
+ * wasm->JS interop call per byte.
+ */
+private const val STAGING_WINDOW_BYTES = 1 shl 20
+
+/** Blob rather than a Uint8Array: the bytes land off the JS heap and may spill to disk. */
+fun ByteArray.toJsBlob(mimeType: String): JsAny {
+    val parts = newJsArray()
+    stageThroughLinearMemory { address, _, length -> appendBlobPart(parts, address, length) }
+    return blobFromParts(parts, mimeType)
+}
+
+/** The caller owns the revoke. */
+fun ByteArray.toBlobObjectUrl(mimeType: String): String = objectUrlFromBlob(toJsBlob(mimeType))
+
+fun ByteArray.toJsUint8Array(): JsAny {
+    val sink = newUint8Array(size)
+    stageThroughLinearMemory { address, offset, length ->
+        copyIntoUint8Array(sink, offset, address, length)
+    }
+    return sink
+}
+
+fun jsUint8ArrayToByteArray(source: JsAny): ByteArray {
+    val total = uint8ArrayLength(source)
+    val bytes = ByteArray(total)
+    if (total == 0) return bytes
+    withScopedMemoryAllocator { allocator ->
+        val window = minOf(STAGING_WINDOW_BYTES, total)
+        val base = allocator.allocate(window)
+        val address = base.address.toInt()
+        var offset = 0
+        while (offset < total) {
+            val length = minOf(window, total - offset)
+            copyFromUint8Array(source, offset, address, length)
+            for (i in 0 until length) bytes[offset + i] = (base + i).loadByte()
+            offset += length
+        }
+    }
+    return bytes
+}
+
+private inline fun ByteArray.stageThroughLinearMemory(
+    crossinline emit: (address: Int, offset: Int, length: Int) -> Unit,
+) {
+    if (isEmpty()) return
+    val source = this
+    withScopedMemoryAllocator { allocator ->
+        val window = minOf(STAGING_WINDOW_BYTES, source.size)
+        val base = allocator.allocate(window)
+        val address = base.address.toInt()
+        var offset = 0
+        while (offset < source.size) {
+            val length = minOf(window, source.size - offset)
+            for (i in 0 until length) (base + i).storeByte(source[offset + i])
+            emit(address, offset, length)
+            offset += length
+        }
+    }
+}
+
+// Every body re-reads `wasmExports.memory.buffer`; growing linear memory detaches the previous
+// ArrayBuffer, so a cached view would silently become unusable.
+
+private fun newJsArray(): JsAny = js("[]")
+
+private fun appendBlobPart(parts: JsAny, address: Int, length: Int): Unit = js(
+    "{ parts.push(new Blob([new Uint8Array(wasmExports.memory.buffer, address, length)])); }"
+)
+
+private fun blobFromParts(parts: JsAny, mimeType: String): JsAny =
+    js("new Blob(parts, { type: mimeType })")
+
+private fun objectUrlFromBlob(blob: JsAny): String = js("URL.createObjectURL(blob)")
+
+private fun newUint8Array(size: Int): JsAny = js("new Uint8Array(size)")
+
+private fun copyIntoUint8Array(sink: JsAny, offset: Int, address: Int, length: Int): Unit =
+    js("{ sink.set(new Uint8Array(wasmExports.memory.buffer, address, length), offset); }")
+
+private fun uint8ArrayLength(source: JsAny): Int = js("source.length")
+
+private fun copyFromUint8Array(source: JsAny, offset: Int, address: Int, length: Int): Unit = js(
+    """{
+        new Uint8Array(wasmExports.memory.buffer, address, length)
+            .set(source.subarray(offset, offset + length));
+    }"""
+)

--- a/homebase-api/src/wasmJsMain/kotlin/id/homebase/api/video/BrowserVideoDecoder.kt
+++ b/homebase-api/src/wasmJsMain/kotlin/id/homebase/api/video/BrowserVideoDecoder.kt
@@ -4,6 +4,7 @@ package id.homebase.api.video
 
 import id.homebase.api.file.systemFileSystem
 import id.homebase.api.util.isBlobUrl
+import id.homebase.api.util.toBlobObjectUrl
 import kotlin.io.encoding.Base64
 import kotlin.js.Promise
 import kotlinx.coroutines.await
@@ -24,8 +25,7 @@ import okio.Path.Companion.toPath
  *    read into wasm and nothing is base64'd. We do NOT revoke it; its owner (the attachment editor)
  *    does.
  *  - an okio path (e.g. an ffmpeg-produced file, or `FFmpegUtils.grabThumbnail`). We read the bytes
- *    and mint a short-lived blob URL for the `<video>`, then revoke it. This is the only path that
- *    still base64s, and it's off the interactive hot path.
+ *    and mint a short-lived blob URL for the `<video>`, then revoke it.
  */
 internal class BrowserVideoDecoder : VideoDecoder {
 
@@ -97,7 +97,7 @@ private class VideoUrlHandle private constructor(val url: String, private val ow
         fun resolve(videoPath: String): VideoUrlHandle? {
             if (videoPath.isBlobUrl()) return VideoUrlHandle(videoPath, owned = false)
             val bytes = readOkioBytes(videoPath) ?: return null
-            val url = objectUrlFromBytesJs(Base64.encode(bytes), mimeFromPath(videoPath))
+            val url = bytes.toBlobObjectUrl(mimeFromPath(videoPath))
             return VideoUrlHandle(url, owned = true)
         }
     }
@@ -123,16 +123,6 @@ private fun mimeFromPath(path: String): String =
         "3gp", "3gpp" -> "video/3gpp"
         else -> "video/mp4"
     }
-
-/** atob -> Uint8Array -> Blob -> object URL. Only for the okio fallback (bytes already in wasm). */
-private fun objectUrlFromBytesJs(base64: String, mimeType: String): String = js(
-    """{
-        var bin = atob(base64);
-        var arr = new Uint8Array(bin.length);
-        for (var i = 0; i < bin.length; i++) arr[i] = bin.charCodeAt(i);
-        return URL.createObjectURL(new Blob([arr], { type: mimeType }));
-    }"""
-)
 
 private fun revokeObjectUrlJs(url: String): Unit = js("{ URL.revokeObjectURL(url); }")
 

--- a/homebase-api/src/wasmJsMain/kotlin/id/homebase/api/video/FFmpegBridge.web.kt
+++ b/homebase-api/src/wasmJsMain/kotlin/id/homebase/api/video/FFmpegBridge.web.kt
@@ -1,27 +1,27 @@
-@file:OptIn(kotlin.js.ExperimentalWasmJsInterop::class, kotlin.io.encoding.ExperimentalEncodingApi::class)
+@file:OptIn(kotlin.js.ExperimentalWasmJsInterop::class)
 
 package id.homebase.api.video
 
-import kotlin.io.encoding.Base64
+import id.homebase.api.util.jsUint8ArrayToByteArray
+import id.homebase.api.util.toJsUint8Array
 import kotlin.js.Promise
 import kotlinx.coroutines.await
 
 /* ------------------------------------------------------------------------------------------
  * JS interop with the `globalThis.__odinFfmpeg` bridge defined in webApp's `odin-ffmpeg.js`.
  *
- * ffmpeg.wasm runs in its own web worker, so every call is async (Promise). Byte payloads
- * cross the boundary as Base64 strings — same idiom as WebSqlDriver / ImageUtil.web.kt; it
- * keeps the boundary copy-free of typed-array ownership concerns. (A direct Uint8Array bridge
- * for the two largest crossings is a planned follow-up if large-clip compression is slow.)
+ * ffmpeg.wasm runs in its own web worker, so every call is async (Promise). Byte payloads cross
+ * as `Uint8Array` via the linear-memory bridge in `id.homebase.api.util.WasmByteBridge`; this is
+ * the heaviest crossing in the app because a clip goes in *and* comes back out.
  * ------------------------------------------------------------------------------------------ */
 
 private fun ffIsLoaded(): Boolean = js("globalThis.__odinFfmpeg.isLoaded()")
-private fun ffProbe(b64: String): Promise<JsString> = js("globalThis.__odinFfmpeg.probe(b64)")
+private fun ffProbe(bytes: JsAny): Promise<JsString> = js("globalThis.__odinFfmpeg.probe(bytes)")
 private fun ffProbeFromUrl(url: String): Promise<JsString> = js("globalThis.__odinFfmpeg.probeFromUrl(url)")
-private fun ffWriteFile(path: String, b64: String): Promise<JsAny?> = js("globalThis.__odinFfmpeg.writeFile(path, b64)")
+private fun ffWriteFile(path: String, bytes: JsAny): Promise<JsAny?> = js("globalThis.__odinFfmpeg.writeFile(path, bytes)")
 private fun ffWriteFileFromUrl(path: String, url: String): Promise<JsAny?> = js("globalThis.__odinFfmpeg.writeFileFromUrl(path, url)")
 private fun ffWriteText(path: String, text: String): Promise<JsAny?> = js("globalThis.__odinFfmpeg.writeText(path, text)")
-private fun ffReadFile(path: String): Promise<JsString> = js("globalThis.__odinFfmpeg.readFile(path)")
+private fun ffReadFile(path: String): Promise<JsAny> = js("globalThis.__odinFfmpeg.readFile(path)")
 private fun ffDeleteFile(path: String): Promise<JsAny?> = js("globalThis.__odinFfmpeg.deleteFile(path)")
 private fun ffExec(argsJson: String): Promise<JsString> = js("globalThis.__odinFfmpeg.exec(argsJson)")
 private fun ffSetProgress(cb: (Double) -> Unit): Unit = js("globalThis.__odinFfmpeg.setProgress(cb)")
@@ -53,7 +53,7 @@ internal object FFmpegBridge {
 
     /** mp4box probe; null when the input isn't a parseable mp4/mov. Does not load the core. */
     suspend fun probe(bytes: ByteArray): VideoProbe? {
-        val raw = ffProbe(Base64.encode(bytes)).await<JsString>().toString()
+        val raw = ffProbe(bytes.toJsUint8Array()).await<JsString>().toString()
         if (raw.isBlank()) return null
         val parts = raw.split(";")
         if (parts.size < 5) return null
@@ -67,8 +67,8 @@ internal object FFmpegBridge {
     }
 
     /**
-     * mp4box probe of a (blob:) URL read entirely in JS — the bytes never enter Kotlin and are
-     * never base64'd. The returned [VideoProbe.sizeBytes] is the input size (so the compress
+     * mp4box probe of a (blob:) URL read entirely in JS — the bytes never enter Kotlin at all.
+     * The returned [VideoProbe.sizeBytes] is the input size (so the compress
      * planner needn't read the file). Null when unparseable.
      */
     suspend fun probeFromUrl(url: String): VideoProbe? {
@@ -87,12 +87,12 @@ internal object FFmpegBridge {
     }
 
     suspend fun writeFile(path: String, bytes: ByteArray) {
-        ffWriteFile(path, Base64.encode(bytes)).await<JsAny?>()
+        ffWriteFile(path, bytes.toJsUint8Array()).await<JsAny?>()
     }
 
     /**
-     * Fetch a (blob:) URL's bytes in JS and write them straight into ffmpeg's MEMFS — no Kotlin
-     * read, no base64. Revokes the blob: URL once consumed.
+     * Fetch a (blob:) URL's bytes in JS and write them straight into ffmpeg's MEMFS — the bytes
+     * never enter wasm at all. Revokes the blob: URL once consumed.
      */
     suspend fun writeFileFromUrl(path: String, url: String) {
         ffWriteFileFromUrl(path, url).await<JsAny?>()
@@ -103,7 +103,7 @@ internal object FFmpegBridge {
     }
 
     suspend fun readFile(path: String): ByteArray =
-        Base64.decode(ffReadFile(path).await<JsString>().toString())
+        jsUint8ArrayToByteArray(ffReadFile(path).await<JsAny>())
 
     suspend fun deleteFile(path: String) {
         ffDeleteFile(path).await<JsAny?>()

--- a/homebase-api/src/wasmJsTest/kotlin/id/homebase/api/util/WasmByteBridgeTest.kt
+++ b/homebase-api/src/wasmJsTest/kotlin/id/homebase/api/util/WasmByteBridgeTest.kt
@@ -1,0 +1,41 @@
+@file:OptIn(kotlin.js.ExperimentalWasmJsInterop::class)
+
+package id.homebase.api.util
+
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+
+// Spans several staging windows and ends mid-window, so a wrong offset or a dropped tail shows up.
+private const val MULTI_WINDOW_SIZE = (1 shl 20) * 2 + 12_345
+
+private fun aperiodicBytes(size: Int) = ByteArray(size) { (it xor (it shr 7) xor (it shr 17)).toByte() }
+
+private fun jsBlobSize(blob: JsAny): Int = js("blob.size")
+
+class WasmByteBridgeTest {
+
+    @Test
+    fun roundTripsAcrossStagingWindows() {
+        val bytes = aperiodicBytes(MULTI_WINDOW_SIZE)
+        assertContentEquals(bytes, jsUint8ArrayToByteArray(bytes.toJsUint8Array()))
+    }
+
+    // Uint8Array is unsigned and Kotlin's Byte is signed; 0x80..0xFF is where that goes wrong.
+    @Test
+    fun roundTripsEveryByteValue() {
+        val bytes = ByteArray(256) { (it - 128).toByte() }
+        assertContentEquals(bytes, jsUint8ArrayToByteArray(bytes.toJsUint8Array()))
+    }
+
+    @Test
+    fun roundTripsEmpty() {
+        assertContentEquals(ByteArray(0), jsUint8ArrayToByteArray(ByteArray(0).toJsUint8Array()))
+    }
+
+    @Test
+    fun blobCarriesEveryStagedWindow() {
+        val bytes = aperiodicBytes(MULTI_WINDOW_SIZE)
+        assertEquals(MULTI_WINDOW_SIZE, jsBlobSize(bytes.toJsBlob("application/octet-stream")))
+    }
+}

--- a/homebase-chat/src/wasmJsMain/kotlin/id/homebase/chat/widget/video/HtmlVideoOverlay.web.kt
+++ b/homebase-chat/src/wasmJsMain/kotlin/id/homebase/chat/widget/video/HtmlVideoOverlay.web.kt
@@ -12,9 +12,6 @@ package id.homebase.chat.widget.video
  * `boundsInWindow()` is relative to `#ComposeApp`, so [setVideoOverlayBounds] adds `#ComposeApp`'s
  * viewport offset (the safe-area inset; zero on desktop) to convert to fixed/viewport coordinates.
  * A high z-index keeps it above the canvas; native `controls` give play/seek/volume for free.
- *
- * Byte payloads cross to JS as Base64, the same idiom as FFmpegBridge.web.kt / WebSqlDriver
- * (a direct Uint8Array bridge is a possible follow-up if large-clip playback proves slow).
  */
 
 /**
@@ -113,15 +110,5 @@ internal fun removeVideoOverlay(el: JsAny): Unit = js(
 )
 
 internal fun viewportHeightPx(): Double = js("window.innerHeight")
-
-/** Base64 -> Blob object URL with the given [mimeType] (for the <video> src). */
-internal fun bytesToObjectUrl(base64: String, mimeType: String): String = js(
-    """{
-        var bin = atob(base64);
-        var arr = new Uint8Array(bin.length);
-        for (var i = 0; i < bin.length; i++) arr[i] = bin.charCodeAt(i);
-        return URL.createObjectURL(new Blob([arr], { type: mimeType }));
-    }"""
-)
 
 internal fun revokeObjectUrlJs(url: String): Unit = js("{ URL.revokeObjectURL(url); }")

--- a/homebase-chat/src/wasmJsMain/kotlin/id/homebase/chat/widget/video/LocalVideoPlayerSurface.web.kt
+++ b/homebase-chat/src/wasmJsMain/kotlin/id/homebase/chat/widget/video/LocalVideoPlayerSurface.web.kt
@@ -1,4 +1,4 @@
-@file:OptIn(kotlin.js.ExperimentalWasmJsInterop::class, kotlin.io.encoding.ExperimentalEncodingApi::class)
+@file:OptIn(kotlin.js.ExperimentalWasmJsInterop::class)
 
 package id.homebase.chat.widget.video
 
@@ -18,7 +18,7 @@ import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalDensity
 import id.homebase.api.file.systemFileSystem
 import id.homebase.api.util.isBlobUrl
-import kotlin.io.encoding.Base64
+import id.homebase.api.util.toBlobObjectUrl
 import okio.Path.Companion.toPath
 
 /*
@@ -49,12 +49,12 @@ private class PlayerSrc(val url: String, val createdByUs: Boolean)
 /**
  * Resolve [filePath] to a `<video>`-playable URL. A `blob:` URL (the editor's fast path, minted
  * from the picked File) is used directly and NOT owned — its owner revokes it. An okio path is read
- * and wrapped in a fresh, owned blob URL (the only path that base64s; off the interactive hot path).
+ * and wrapped in a fresh, owned blob URL.
  */
 private fun resolvePlayerSrc(filePath: String): PlayerSrc? {
     if (filePath.isBlobUrl()) return PlayerSrc(filePath, createdByUs = false)
     val bytes = readOkioBytes(filePath) ?: return null
-    return PlayerSrc(bytesToObjectUrl(Base64.encode(bytes), mimeFromPath(filePath)), createdByUs = true)
+    return PlayerSrc(bytes.toBlobObjectUrl(mimeFromPath(filePath)), createdByUs = true)
 }
 
 @Composable

--- a/homebase-chat/src/wasmJsMain/kotlin/id/homebase/chat/widget/video/VideoPlayerSurface.web.kt
+++ b/homebase-chat/src/wasmJsMain/kotlin/id/homebase/chat/widget/video/VideoPlayerSurface.web.kt
@@ -1,4 +1,4 @@
-@file:OptIn(kotlin.js.ExperimentalWasmJsInterop::class, kotlin.io.encoding.ExperimentalEncodingApi::class)
+@file:OptIn(kotlin.js.ExperimentalWasmJsInterop::class)
 
 package id.homebase.chat.widget.video
 
@@ -22,6 +22,7 @@ import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
 import id.homebase.api.client.drives.files.DriveFileProvider
+import id.homebase.api.util.toBlobObjectUrl
 import id.homebase.api.video.VideoContent
 import id.homebase.api.video.VideoPlayerData
 import id.homebase.api.video.resolveVideoContent
@@ -29,7 +30,6 @@ import id.homebase.chat.conversationlist.FullScreenOverlay
 import id.homebase.resources.MR
 import id.homebase.resources.video_error_generic
 import id.homebase.resources.video_web_large_playback_unsupported
-import kotlin.io.encoding.Base64
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.koinInject
 
@@ -96,7 +96,7 @@ actual fun VideoPlayerSurface(
                     data.payload.descriptorContent,
                 ),
                 driveFileProvider,
-                // Web builds a Base64 object URL, so it needs bytes (the wasm FS
+                // Web builds a Blob object URL, so it needs bytes (the wasm FS
                 // is RAM-backed anyway). The render-limit guard bounds it: an
                 // oversized MP4 throws PayloadTooLargeException into the catch
                 // below → unplayable message instead of OOM-ing the tab (#845).
@@ -107,7 +107,7 @@ actual fun VideoPlayerSurface(
                 is VideoContent.Mp4File -> error("Mp4File is the file-backed variant — web passes preferBytes")
                 is VideoContent.Mp4Bytes -> {
                     val mime = content.metadata.mimeType.ifBlank { "video/mp4" }
-                    val url = bytesToObjectUrl(Base64.encode(content.bytes), mime)
+                    val url = content.bytes.toBlobObjectUrl(mime)
                     objectUrl = url
                     val el = createVideoOverlay(muted, controls = true)
                     addVideoOverlayProgressListener(el) { _, _ -> onProgress(1f) }

--- a/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/audio/AudioPlayer.web.kt
+++ b/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/audio/AudioPlayer.web.kt
@@ -1,17 +1,17 @@
-@file:OptIn(kotlin.js.ExperimentalWasmJsInterop::class, kotlin.io.encoding.ExperimentalEncodingApi::class)
+@file:OptIn(kotlin.js.ExperimentalWasmJsInterop::class)
 
 package id.homebase.core.audio
 
 import co.touchlab.kermit.Logger
 import id.homebase.api.file.readWebFileBytes
+import id.homebase.api.util.toBlobObjectUrl
 import id.homebase.core.util.detectContentTypeFromExtensionOrHint
-import kotlin.io.encoding.Base64
 
 /*
  * `filePath` here is a path into the in-memory FakeFileSystem the decrypt-on-demand flow wrote to
  * (MediaDownloadHandler.handleDecryptFile), not a real file the browser can fetch. Read it back,
  * wrap the bytes in a Blob object URL and drive a detached HTMLAudioElement — the same bridge the
- * web video surface uses. Bytes cross to JS as Base64, the idiom used by HtmlVideoOverlay.web.kt.
+ * web video surface uses.
  */
 
 private class WebAudioPlayer : AudioPlayer {
@@ -28,7 +28,7 @@ private class WebAudioPlayer : AudioPlayer {
             return
         }
 
-        val url = audioBytesToObjectUrl(Base64.encode(bytes), audioMimeForPath(filePath))
+        val url = bytes.toBlobObjectUrl(audioMimeForPath(filePath))
         objectUrl = url
 
         val el = createAudioElement(url)
@@ -90,15 +90,6 @@ private fun Double.toWholeSeconds(): Int =
 
 private fun audioMimeForPath(path: String): String =
     detectContentTypeFromExtensionOrHint(path).takeIf { it.startsWith("audio/") } ?: "audio/mp4"
-
-private fun audioBytesToObjectUrl(base64: String, mimeType: String): String = js(
-    """{
-        var bin = atob(base64);
-        var arr = new Uint8Array(bin.length);
-        for (var i = 0; i < bin.length; i++) arr[i] = bin.charCodeAt(i);
-        return URL.createObjectURL(new Blob([arr], { type: mimeType }));
-    }"""
-)
 
 private fun revokeAudioObjectUrl(url: String): Unit = js("{ URL.revokeObjectURL(url); }")
 

--- a/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/clipboard/ClipboardPlatformFileFactory.web.kt
+++ b/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/clipboard/ClipboardPlatformFileFactory.web.kt
@@ -1,10 +1,10 @@
-@file:OptIn(kotlin.js.ExperimentalWasmJsInterop::class, kotlin.io.encoding.ExperimentalEncodingApi::class)
+@file:OptIn(kotlin.js.ExperimentalWasmJsInterop::class)
 
 package id.homebase.core.clipboard
 
 import id.homebase.api.file.readWebFileBytes
+import id.homebase.api.util.toJsBlob
 import io.github.vinceglb.filekit.PlatformFile
-import kotlin.io.encoding.Base64
 import org.w3c.files.File
 
 /**
@@ -23,7 +23,7 @@ actual fun platformFileFromPath(path: String): PlatformFile {
         ?: error("No file at $path on the web filesystem")
     val name = path.substringAfterLast('/')
     val mimeType = mimeTypeForExtension(name.substringAfterLast('.', ""))
-    return PlatformFile(makeJsFile(Base64.encode(bytes), name, mimeType))
+    return PlatformFile(makeJsFile(bytes.toJsBlob(mimeType), name, mimeType))
 }
 
 private fun mimeTypeForExtension(extension: String): String = when (extension.lowercase()) {
@@ -34,16 +34,5 @@ private fun mimeTypeForExtension(extension: String): String = when (extension.lo
     else -> "application/octet-stream"
 }
 
-/**
- * Base64 rather than a typed array over the boundary — the same string-bridge idiom
- * [id.homebase.core.clipboard.readClipboardImage] and the ffmpeg/video bridges use, which keeps
- * the wasm side free of typed-array ownership concerns.
- */
-private fun makeJsFile(base64: String, fileName: String, mimeType: String): File = js(
-    """{
-        var bin = atob(base64);
-        var u8 = new Uint8Array(bin.length);
-        for (var i = 0; i < bin.length; i++) { u8[i] = bin.charCodeAt(i); }
-        return new File([u8], fileName, { type: mimeType });
-    }"""
-)
+private fun makeJsFile(blob: JsAny, fileName: String, mimeType: String): File =
+    js("new File([blob], fileName, { type: mimeType })")

--- a/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/util/FileUtilities.web.kt
+++ b/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/util/FileUtilities.web.kt
@@ -1,12 +1,12 @@
-@file:OptIn(kotlin.js.ExperimentalWasmJsInterop::class, kotlin.io.encoding.ExperimentalEncodingApi::class)
+@file:OptIn(kotlin.js.ExperimentalWasmJsInterop::class)
 
 package id.homebase.core.util
 
 import androidx.compose.runtime.Composable
 import id.homebase.api.file.readWebFileBytes
+import id.homebase.api.util.toBlobObjectUrl
 import kotlinx.browser.window
 import kotlinx.io.files.Path
-import kotlin.io.encoding.Base64
 
 @Composable
 actual fun getUriHandler(): FileSystemHandler {
@@ -32,11 +32,8 @@ actual fun getUriHandler(): FileSystemHandler {
             runCatching {
                 val path = file.toString()
                 val bytes = readWebFileBytes(path) ?: error("No decrypted file at $path")
-                triggerBrowserDownload(
-                    Base64.encode(bytes),
-                    detectContentTypeFromExtensionOrHint(suggestedName),
-                    suggestedName,
-                )
+                val mimeType = detectContentTypeFromExtensionOrHint(suggestedName)
+                triggerBrowserDownload(bytes.toBlobObjectUrl(mimeType), suggestedName)
             }.onSuccess { onSuccess(DOWNLOADS_LOCATION) }.onFailure(onError)
         }
     }
@@ -47,15 +44,10 @@ private const val DOWNLOADS_LOCATION = "Downloads"
 /*
  * The Path is into the in-memory FakeFileSystem the decrypt-on-demand flow wrote to
  * (MediaDownloadHandler), not something the browser can fetch — read the bytes back and hand them
- * to the user as a Blob object URL. Bytes cross to JS as Base64, the idiom used by
- * AudioPlayer.web.kt / HtmlVideoOverlay.web.kt.
+ * to the user as a Blob object URL.
  */
-private fun triggerBrowserDownload(base64: String, mimeType: String, fileName: String): Unit = js(
+private fun triggerBrowserDownload(url: String, fileName: String): Unit = js(
     """{
-        var bin = atob(base64);
-        var arr = new Uint8Array(bin.length);
-        for (var i = 0; i < bin.length; i++) arr[i] = bin.charCodeAt(i);
-        var url = URL.createObjectURL(new Blob([arr], { type: mimeType }));
         var a = document.createElement('a');
         a.href = url;
         a.download = fileName;

--- a/webApp/src/wasmJsMain/resources/odin-ffmpeg.js
+++ b/webApp/src/wasmJsMain/resources/odin-ffmpeg.js
@@ -21,23 +21,6 @@
   var progressCb = null;    // Kotlin (Float)->Unit, set before each exec
   var logLines = [];        // accumulates worker stdout/stderr for version parsing
 
-  function b64ToBytes(b64) {
-    var bin = atob(b64);
-    var len = bin.length;
-    var arr = new Uint8Array(len);
-    for (var i = 0; i < len; i++) arr[i] = bin.charCodeAt(i);
-    return arr;
-  }
-
-  function bytesToB64(u8) {
-    var bin = "";
-    var chunk = 0x8000;
-    for (var i = 0; i < u8.length; i += chunk) {
-      bin += String.fromCharCode.apply(null, u8.subarray(i, Math.min(i + chunk, u8.length)));
-    }
-    return btoa(bin);
-  }
-
   // Same as @ffmpeg/util's toBlobURL: fetch a same-origin asset and re-wrap it as a
   // Blob URL so the worker can import it without cross-origin / module-resolution snags.
   function toBlobURL(url, mimeType) {
@@ -159,8 +142,8 @@
     });
   }
 
-  function probe(b64) {
-    return probeBytes(b64ToBytes(b64), null);
+  function probe(u8) {
+    return probeBytes(u8, null);
   }
 
   // JS-native input read: fetch the (blob:) URL's bytes WITHOUT crossing into Kotlin and
@@ -187,14 +170,14 @@
 
     setProgress: function (cb) { progressCb = cb; },
 
-    writeFile: function (path, b64) {
+    writeFile: function (path, u8) {
       return ensureLoaded().then(function (f) {
-        return f.writeFile(path, b64ToBytes(b64)).then(function () { return true; });
+        return f.writeFile(path, u8).then(function () { return true; });
       });
     },
 
     // JS-native input: fetch the (blob:) URL's bytes and write them straight into ffmpeg's
-    // MEMFS — the original video never enters Kotlin/Wasm memory and is never base64'd.
+    // MEMFS — the original video never enters Kotlin/Wasm memory at all.
     // NOTE: do NOT revoke the blob: URL here — the same URL doubles as the sent message's
     // local-preview source (LocalAttachmentContext.Video.localFilePath); revoking it would
     // break the bubble preview/playback. It's released on logout (store reset) / page reload.
@@ -213,7 +196,7 @@
     },
     readFile: function (path) {
       return ensureLoaded().then(function (f) {
-        return f.readFile(path, "binary").then(function (d) { return bytesToB64(d); });
+        return f.readFile(path, "binary");
       });
     },
     deleteFile: function (path) {


### PR DESCRIPTION
Closes #1387.

## The premise needed correcting first

The issue proposes `new Uint8Array(memory.buffer, ptr, len)` — the Emscripten `HEAPU8.subarray()` idiom. **That does not apply to a `ByteArray` on this target.** Kotlin/Wasm compiles to Wasm GC, not Emscripten linear memory: a `ByteArray` is a GC `(array i8)` living in the GC heap, with no address in `memory.buffer`. JS cannot form a view over one, so true zero-copy is not reachable.

What *is* reachable, verified against this build rather than from memory:

1. **`kotlin.wasm.unsafe` linear memory is real and addressable.** `withScopedMemoryAllocator` hands out a `Pointer` with an `address`, and `storeByte`/`loadByte` are plain wasm `i32.store8`/`i32.load8_s` instructions — no boundary crossing.
2. **The module exports `memory`.** The generated glue ends with:
   ```js
   const exports = wasmInstance.exports
   export const { memory, _start } = exports
   ```
3. **`js()` bodies can reach it.** They are compiled into `chat-kmp-webApp.import-object.mjs`, the same module that declares — with this comment, emitted by the Kotlin compiler itself:
   ```js
   // Placed here to give access to it from externals (js_code)
   let wasmExports;
   ```
4. **Compose Multiplatform already does exactly this.** In the same generated glue:
   ```js
   'org.jetbrains.compose.resources.jsExportInt8ArrayToWasm' : (src, size, dstAddr) => {
       const mem8 = new Int8Array(wasmExports.memory.buffer, dstAddr, size);
       mem8.set(src);
   }
   ```
   So this is the sanctioned first-party mechanism, not a private hack.

## Mechanism chosen: one bulk copy, not zero-copy

Bytes stream through a **fixed 1 MiB staging window** in linear memory. An in-wasm store loop fills the window; one typed-array view hands the whole window to JS. Per direction that is one bulk copy and **one JS call per megabyte instead of one per byte**, with no Base64 string at any point.

Being explicit, since the acceptance criteria said "zero-copy": **this is one bulk copy.** It cannot be zero-copy for the reason above. It still removes the two things that actually hurt — the ~6x Base64 expansion and the synchronous per-byte `charCodeAt` loop on the main thread. For a 100 MB clip: ~100 JS calls instead of ~100 million, and peak memory a small constant over the payload instead of ~600 MB.

The window is **fixed rather than payload-sized on purpose**: wasm linear memory never shrinks, so staging a whole clip would permanently grow the tab's heap by the clip size for the rest of the session.

`kotlinx-browser`'s `ByteArray.toInt8Array()` was evaluated and **rejected** — its source is an element-wise loop (`for (index in indices) result[index] = this[index]`), which costs one wasm→JS interop call per byte and would be *slower* than the Base64 it replaces. No new dependency was added; `kotlinx-browser` is already present transitively via Compose, and the bridge follows house style (file-private `js("…")` functions, no `external`/`@JsFun`).

## Converted vs deliberately left

New shared bridge: `homebase-api/src/wasmJsMain/kotlin/id/homebase/api/util/WasmByteBridge.kt` — `toJsBlob`, `toBlobObjectUrl`, `toJsUint8Array`, `jsUint8ArrayToByteArray`. It lives in `homebase-api` because both `homebase-common` and `homebase-chat` already `api(project(":homebase-api"))`.

**Converted** (acceptance minimum in bold):
- **`HtmlVideoOverlay.web.kt`** — `bytesToObjectUrl` deleted; its three callers (`VideoPlayerSurface`, `LocalVideoPlayerSurface`, and the overlay itself) now use `toBlobObjectUrl`
- **`FFmpegBridge.web.kt`** — the worst case, clip in *and* out: `probe`/`writeFile` now pass a `Uint8Array`, `readFile` returns one. `webApp/.../odin-ffmpeg.js` updated to match; both of its Base64 helpers are gone
- **`FileUtilities.web.kt`** — the download path
- `BrowserVideoDecoder.kt` — the okio fallback object URL
- `AudioPlayer.web.kt`
- `ClipboardPlatformFileFactory.web.kt` — builds the `File` from a Blob

**Deliberately left:**
- `WebSqlDriver` — sql.js has its own contract, and the issue scoped it out
- `ClipboardImageReader.web.kt` / `ClipboardImagePasteEffect.web.kt` and `BrowserVideoDecoder`'s poster/filmstrip JS — these are *inbound* small-JPEG paths where JS does `btoa` on canvas output. Converting them means reshaping `Promise<JsString>` into `Promise<JsAny>`, which is not the mechanical swap the rest of this change is
- Issue items (2) File System Access API and (3) service-worker streaming — deferred by the issue itself

The two now-untrue follow-up comments in `HtmlVideoOverlay.web.kt` and `FFmpegBridge.web.kt` are removed, along with several other comments that asserted the Base64 idiom.

## Verification

| Command | Result |
|---|---|
| `./gradlew :homebase-api:compileKotlinWasmJs :homebase-common:compileKotlinWasmJs :homebase-chat:compileKotlinWasmJs` | BUILD SUCCESSFUL |
| `./gradlew :webApp:compileDevelopmentExecutableKotlinWasmJs` | BUILD SUCCESSFUL (full wasm link) |
| `./gradlew homebase-api:jvmTest homebase-common:jvmTest homebase-chat:jvmTest --rerun-tasks` | BUILD SUCCESSFUL |
| `./gradlew :homebase-api:wasmJsBrowserTest` (full suite, headless Chromium 152) | all suites green |

**Runtime evidence.** `homebase-api/src/wasmJsTest/.../WasmByteBridgeTest.kt` runs in the repo's existing Karma/ChromeHeadless harness and exercises the real linear-memory path: a 2.6 MB round trip spanning several staging windows and ending mid-window, all 256 byte values (the signed-`Byte`/unsigned-`Uint8Array` boundary), the empty array, and Blob assembly across windows. 4 tests, 0 failures.

The test was **mutation-checked** rather than assumed useful: changing `emit(address, offset, length)` to `emit(address, 0, length)` makes `roundTripsAcrossStagingWindows` fail with a real element mismatch, and reverting restores green.

**Honest gap:** the ffmpeg browser tests pass but do *not* validate the ffmpeg conversion at runtime — they early-return green on web because no fixture is wired there (`FfmpegDecoderCommonTest`'s own doc: "iOS / Web (no fixture wired up yet)"), and every case reports `time="0.0"`. That is pre-existing and untouched by this change. The `FFmpegBridge`/`odin-ffmpeg.js` conversion is therefore verified by compile, full wasm link, and inspection of the generated glue, not by a live ffmpeg run. I did not run the dev server to play a clip end-to-end.