### PR TITLE
Blank the composer at send time so a sent message can't come back as a draft (#1492)

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/MessageActionsHandler.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/MessageActionsHandler.kt
@@ -47,6 +47,7 @@ import id.homebase.core.settings.UserPreferences
 import id.homebase.core.share.ShareContentProcessor
 import id.homebase.core.share.hasSendableContent
 import id.homebase.core.share.resolveMessageBody
+import id.homebase.core.util.applyMarkDownContent
 import id.homebase.core.util.contentType
 import id.homebase.core.util.resolveContentType
 import id.homebase.core.util.toMessageMarkdown
@@ -99,6 +100,22 @@ internal fun shouldSendComposerMessage(
 ): Boolean {
     val hasUserInitiatedAttachment = payloadRenderers.any { it !is LinkPreviewRenderer }
     return markdownBody.isNotBlank() || hasUserInitiatedAttachment
+}
+
+/**
+ * Blank the composer BEFORE awaiting [send] — [content] already holds the body — so the
+ * conversation's idle draft debounce can never observe the just-sent text and persist it as a
+ * synced draft while the send is still in flight (#1492). Puts it back if the send throws, unless
+ * the user has meanwhile typed something else, so a failed send still leaves the text to retry.
+ */
+internal suspend fun RichTextState.clearedForSend(content: String, send: suspend () -> Unit) {
+    clear()
+    try {
+        send()
+    } catch (e: Throwable) {
+        if (e !is CancellationException && annotatedString.isBlank()) applyMarkDownContent(content)
+        throw e
+    }
 }
 
 /**
@@ -165,8 +182,6 @@ internal class MessageActionsHandler(
                     payloadRenderers = action.payloadRenderers,
                 )
             }
-            // Input is cleared inside addMessage/replyToMessage after
-            // the send is successfully queued.
         }
     }
 
@@ -229,9 +244,10 @@ internal class MessageActionsHandler(
     }
 
     /**
-     * Blank the composer after a successful send AND clear this conversation's
-     * persisted draft (#1122), so a sent message never leaves a stale synced
-     * draft behind on this or another device.
+     * Clear this conversation's persisted draft (#1122) so a sent message never leaves a stale
+     * synced draft behind on this or another device. The composer itself is already blank on the
+     * text paths — [clearedForSend] blanks it before the send is awaited (#1492) — but the
+     * attachment path still calls this to blank it.
      */
     private fun clearComposerDraft(conversationId: Uuid) {
         messageInputTextState.clear()
@@ -1111,45 +1127,47 @@ internal class MessageActionsHandler(
         payloadRenderers: List<PayloadRenderer> = emptyList(),
     ) {
         scope.launch {
+            val newMessageId = Uuid.random()
             try {
-                val payloadBundle = payloadRenderers.toCombinedPayloadBundle(fileOperationsProvider)
+                messageInputTextState.clearedForSend(content) {
+                    val payloadBundle = payloadRenderers.toCombinedPayloadBundle(fileOperationsProvider)
 
-                val newMessageId = Uuid.random()
-                pendingMessageId = newMessageId
-                registerLocalPreviewContexts(newMessageId, payloadBundle)
-                Logger.d(tag = TAG) { "addMessage: message=$newMessageId conversation=$conversationId" }
+                    pendingMessageId = newMessageId
+                    registerLocalPreviewContexts(newMessageId, payloadBundle)
+                    Logger.d(tag = TAG) { "addMessage: message=$newMessageId conversation=$conversationId" }
 
-                // Arm the own-send follow before the send: this path adds no placeholder,
-                // so the consuming effect waits for this id to land in the list (#995).
-                messagesUiState.update { it.copy(scrollToLatestRequest = newMessageId) }
+                    // Arm the own-send follow before the send: this path adds no placeholder,
+                    // so the consuming effect waits for this id to land in the list (#995).
+                    messagesUiState.update { it.copy(scrollToLatestRequest = newMessageId) }
 
-                // Location is a typed kind (= Event): the coordinate descriptor rides in the header
-                // (appData), the map PNG stays a chat_loc payload. Sending it through the typed path
-                // is what lets a live-share toggle edit the descriptor via updateMessage().
-                val locationPreview =
-                    payloadRenderers.filterIsInstance<LocationPreviewRenderer>().firstOrNull()?.preview
-                if (locationPreview != null && payloadRenderers.size == 1) {
-                    // Carry the user's typed caption in the descriptor (a typed message has no separate
-                    // text body); cap it so the header descriptor stays well under the 7 KB budget.
-                    val caption = content.trim().ifBlank { null }?.truncateToCodePoints(2000)
-                    chatMessageSenderService.sendNewTypedMessage(
-                        messageUniqueId = newMessageId,
-                        conversationId = conversationId,
-                        content = MessageContent.Location(
-                            LocationPreviewPayloadBuilder.descriptorFor(locationPreview).copy(caption = caption)
-                        ),
-                        previousMessageUniqueId = null,
-                        payloadBundle = payloadBundle,
-                    )
-                } else {
-                    chatMessageSenderService.sendNewMessage(
-                        messageUniqueId = newMessageId,
-                        conversationId = conversationId,
-                        messageText = content,
-                        previousMessageUniqueId = null,
-                        payloadBundle = payloadBundle,
-                        dataType = payloadRenderers.toMessageDataType(),
-                    )
+                    // Location is a typed kind (= Event): the coordinate descriptor rides in the header
+                    // (appData), the map PNG stays a chat_loc payload. Sending it through the typed path
+                    // is what lets a live-share toggle edit the descriptor via updateMessage().
+                    val locationPreview =
+                        payloadRenderers.filterIsInstance<LocationPreviewRenderer>().firstOrNull()?.preview
+                    if (locationPreview != null && payloadRenderers.size == 1) {
+                        // Carry the user's typed caption in the descriptor (a typed message has no separate
+                        // text body); cap it so the header descriptor stays well under the 7 KB budget.
+                        val caption = content.trim().ifBlank { null }?.truncateToCodePoints(2000)
+                        chatMessageSenderService.sendNewTypedMessage(
+                            messageUniqueId = newMessageId,
+                            conversationId = conversationId,
+                            content = MessageContent.Location(
+                                LocationPreviewPayloadBuilder.descriptorFor(locationPreview).copy(caption = caption)
+                            ),
+                            previousMessageUniqueId = null,
+                            payloadBundle = payloadBundle,
+                        )
+                    } else {
+                        chatMessageSenderService.sendNewMessage(
+                            messageUniqueId = newMessageId,
+                            conversationId = conversationId,
+                            messageText = content,
+                            previousMessageUniqueId = null,
+                            payloadBundle = payloadBundle,
+                            dataType = payloadRenderers.toMessageDataType(),
+                        )
+                    }
                 }
                 clearComposerDraft(conversationId)
                 jumpToLatestAfterOwnSend(conversationId)
@@ -1206,27 +1224,29 @@ internal class MessageActionsHandler(
         payloadRenderers: List<PayloadRenderer> = emptyList(),
     ) {
         scope.launch {
+            val newMessageId = Uuid.random()
             try {
-                val payloadBundle = payloadRenderers.toCombinedPayloadBundle(fileOperationsProvider)
+                messageInputTextState.clearedForSend(content) {
+                    val payloadBundle = payloadRenderers.toCombinedPayloadBundle(fileOperationsProvider)
 
-                val newMessageId = Uuid.random()
-                pendingMessageId = newMessageId
-                registerLocalPreviewContexts(newMessageId, payloadBundle)
-                Logger.d(tag = TAG) { "replyToMessage: message=$newMessageId conversation=$conversationId replyTo=${replyTo.id}" }
+                    pendingMessageId = newMessageId
+                    registerLocalPreviewContexts(newMessageId, payloadBundle)
+                    Logger.d(tag = TAG) { "replyToMessage: message=$newMessageId conversation=$conversationId replyTo=${replyTo.id}" }
 
-                // Arm the own-send follow before the send: this path adds no placeholder,
-                // so the consuming effect waits for this id to land in the list (#995).
-                messagesUiState.update { it.copy(scrollToLatestRequest = newMessageId) }
+                    // Arm the own-send follow before the send: this path adds no placeholder,
+                    // so the consuming effect waits for this id to land in the list (#995).
+                    messagesUiState.update { it.copy(scrollToLatestRequest = newMessageId) }
 
-                chatMessageSenderService.replyToMessage(
-                    messageUniqueId = newMessageId,
-                    conversationId = conversationId,
-                    replyTo = replyTo.toReplyPreview(),
-                    messageText = content,
-                    previousMessageUniqueId = null,
-                    payloadBundle = payloadBundle,
-                    dataType = payloadRenderers.toMessageDataType(),
-                )
+                    chatMessageSenderService.replyToMessage(
+                        messageUniqueId = newMessageId,
+                        conversationId = conversationId,
+                        replyTo = replyTo.toReplyPreview(),
+                        messageText = content,
+                        previousMessageUniqueId = null,
+                        payloadBundle = payloadBundle,
+                        dataType = payloadRenderers.toMessageDataType(),
+                    )
+                }
                 clearComposerDraft(conversationId)
                 messagesUiState.update { it.copy(replyToMessage = null) }
                 jumpToLatestAfterOwnSend(conversationId)

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationService.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationService.kt
@@ -2601,19 +2601,21 @@ class ConversationService(
      * so it is offline-safe. Also seeds the dedup guard so restoring this draft
      * into the composer can't immediately echo back out to the outbox. #1122.
      */
-    suspend fun readDraft(conversationId: Uuid): String? {
+    suspend fun readDraft(conversationId: Uuid): String? = draftMutex.withLock {
+        readPersistedDraft(conversationId).also { lastPersistedDraft = conversationId to it }
+    }
+
+    private suspend fun readPersistedDraft(conversationId: Uuid): String? {
         val identityId = credentialsManager.getActiveCredentials()?.getIdentityId() ?: return null
         val file = dbm.driveMainIndex.selectHomebaseFileByUnique(identityId, chatDrive, conversationId)
             ?: return null
-        val draft = file.fileMetadata.localAppData?.content?.let {
+        return file.fileMetadata.localAppData?.content?.let {
             try {
                 OdinSystemSerializer.deserialize<ConversationLocalAppDataJson>(it).draft
             } catch (_: Throwable) {
                 null
             }
         }
-        draftMutex.withLock { lastPersistedDraft = conversationId to draft }
-        return draft
     }
 
     /**
@@ -2630,14 +2632,14 @@ class ConversationService(
      * the very next attempt (the leaving-the-thread save) a silent no-op and
      * losing the draft.
      */
-    suspend fun updateLocalDraft(conversationId: Uuid, draft: String?) {
+    suspend fun updateLocalDraft(conversationId: Uuid, draft: String?): Unit = draftMutex.withLock {
         val capped = draft?.truncateToCodePoints(draftMaxCodepoints)?.ifBlank { null }
-        if (draftMutex.withLock { lastPersistedDraft } == (conversationId to capped)) return
+        if (lastPersistedDraft == (conversationId to capped)) return@withLock
         val request = optimisticWriter
             .stampConversationDraft(chatDrive, conversationId, capped, UnixTimeUtc())
-            ?: return
+            ?: return@withLock
         outboxSync.tryEnqueue(request)
-        draftMutex.withLock { lastPersistedDraft = conversationId to capped }
+        lastPersistedDraft = conversationId to capped
     }
 
     /**
@@ -2649,12 +2651,17 @@ class ConversationService(
      * Nothing stored means nothing to clear — and that's the common case, since
      * composing straight through and sending never trips the idle debounce. Without
      * this check every send would bill a stamp + outbox push to erase a draft that
-     * was never written. The guard is accurate by send time: [readDraft] seeds it
-     * (null included) when the conversation is opened.
+     * was never written.
+     *
+     * That "nothing stored" decision reads the PERSISTED draft, not the in-memory
+     * dedup guard: the guard misses anything written outside this device's
+     * composer (a peer draft the sync merged in) and, before the whole body took
+     * [draftMutex], could still read "cleared" while a flush was mid-write — both
+     * of which skipped the clear and left the sent text behind as a draft (#1492).
      */
-    suspend fun clearLocalDraft(conversationId: Uuid) {
-        if (draftMutex.withLock { lastPersistedDraft } == (conversationId to null)) return
-        draftMutex.withLock { lastPersistedDraft = conversationId to null }
+    suspend fun clearLocalDraft(conversationId: Uuid): Unit = draftMutex.withLock {
+        lastPersistedDraft = conversationId to null
+        if (readPersistedDraft(conversationId) == null) return@withLock
         optimisticWriter.stampConversationDraft(chatDrive, conversationId, null, UnixTimeUtc())
             ?.let { outboxSync.tryEnqueue(it) }
     }

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/conversationlist/ComposerClearedForSendTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/conversationlist/ComposerClearedForSendTest.kt
@@ -1,0 +1,82 @@
+package id.homebase.chat.conversationlist
+
+import com.mohamedrejeb.richeditor.model.RichTextState
+import id.homebase.core.util.toMessageMarkdown
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.test.runTest
+
+/**
+ * Pins the send-time composer contract behind #1492: the composer must be blank for the WHOLE
+ * duration of the send, not just after it returns. A send that outlives the conversation's
+ * `DRAFT_IDLE_MS` idle debounce otherwise lets the debounce read the still-populated composer and
+ * persist the just-sent text as a synced draft, which then restores on re-entry.
+ */
+class ComposerClearedForSendTest {
+
+    private val body = "the long message that came back as a draft"
+
+    @Test
+    fun composerIsBlankForTheWholeSend() = runTest {
+        val composer = RichTextState()
+        composer.setMarkdown(body)
+
+        val sendStarted = CompletableDeferred<Unit>()
+        val releaseSend = CompletableDeferred<Unit>()
+        val send = async {
+            composer.clearedForSend(body) {
+                sendStarted.complete(Unit)
+                releaseSend.await()
+            }
+        }
+
+        sendStarted.await()
+        assertEquals("", composer.toMessageMarkdown(), "composer still held the sent text mid-send")
+
+        releaseSend.complete(Unit)
+        send.await()
+        assertEquals("", composer.toMessageMarkdown())
+    }
+
+    @Test
+    fun aFailedSendPutsTheTextBack() = runTest {
+        val composer = RichTextState()
+        composer.setMarkdown(body)
+
+        val failed = async {
+            runCatching {
+                composer.clearedForSend(body) { error("upload blew up") }
+            }
+        }.await()
+
+        assertEquals(true, failed.isFailure)
+        assertEquals(body, composer.toMessageMarkdown())
+    }
+
+    @Test
+    fun aFailedSendDoesNotClobberWhatTheUserTypedMeanwhile() = runTest {
+        val composer = RichTextState()
+        composer.setMarkdown(body)
+
+        val sendStarted = CompletableDeferred<Unit>()
+        val releaseSend = CompletableDeferred<Unit>()
+        val send = async {
+            runCatching {
+                composer.clearedForSend(body) {
+                    sendStarted.complete(Unit)
+                    releaseSend.await()
+                    error("upload blew up")
+                }
+            }
+        }
+
+        sendStarted.await()
+        composer.setMarkdown("something else entirely")
+        releaseSend.complete(Unit)
+        send.await()
+
+        assertEquals("something else entirely", composer.toMessageMarkdown())
+    }
+}

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/ConversationServiceDraftGuardTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/ConversationServiceDraftGuardTest.kt
@@ -1,7 +1,9 @@
 package id.homebase.chat.services.convo
 
+import id.homebase.api.common.time.UnixTimeUtc
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -75,6 +77,49 @@ class ConversationServiceDraftGuardTest {
                     fixture.getConversationFile(convoId)!!.fileMetadata.updated,
                     "conv file untouched",
                 )
+            }
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    /**
+     * The send-time clear used to skip the write whenever its in-memory guard read
+     * "cleared" — but the guard only tracks what THIS composer wrote. A draft can be
+     * persisted behind its back: a peer device's draft merged in by the drive sync, or
+     * this device's own idle flush still inside its read-modify-write when the send
+     * finishes. Both left the stale draft in `localAppData`, to be restored into the
+     * composer on the next entry — the sent-message-reappears bug. #1492.
+     */
+    @Test
+    fun theSendClearsADraftTheGuardNeverSaw() = runBlocking {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+        try {
+            ConversationServiceTestFixture().use { fixture ->
+                val service = fixture.build(scope = scope)
+                val convoId = fixture.seedOneOnOne(other = "alice.test")
+
+                // Opening the conversation seeds the guard with "no draft stored".
+                assertEquals(null, service.readDraft(convoId))
+
+                // Persist a draft WITHOUT going through updateLocalDraft, so the guard
+                // still reads "cleared". Not via readDraft — that would reseed the guard
+                // and hide the very thing under test.
+                fixture.optimisticWriter.stampConversationDraft(
+                    fixture.chatDriveId,
+                    convoId,
+                    "the long message I just sent",
+                    UnixTimeUtc(),
+                )
+                assertTrue(
+                    fixture.getConversationFile(convoId)!!.fileMetadata.localAppData?.content
+                        ?.contains("the long message I just sent") == true,
+                    "seed failed: no draft was persisted",
+                )
+
+                service.clearLocalDraft(convoId)
+
+                assertEquals(null, service.readDraft(convoId), "the send left a stale draft behind")
             }
         } finally {
             scope.cancel()


### PR DESCRIPTION
Closes #1492.

A sent message's text could come back in the composer as a draft. Verified the issue's analysis against current `main` before building; the results are below.

## Which claimed mechanisms are real

**CONFIRMED — the composer is blanked only after the send returns.** `addMessage` / `replyToMessage` awaited `chatMessageSenderService.sendNewMessage(...)` and only then called `clearComposerDraft`. Anything that reads the composer during that window sees the sent text. Two readers do:
- the idle debounce (`ConversationListViewModel.kt:748-751`, `DRAFT_IDLE_MS = 2_000`) — fires 2 s after the last keystroke, i.e. during any send slower than 2 s;
- the leave-the-thread flush (`:728`, `previous?.let { flushDraft(it) }`) — this one is not even a race: navigating back while a slow send is in flight *deterministically* persists the sent text as that conversation's draft.

**CONFIRMED — `clearLocalDraft`'s early-return can skip the clear entirely.** The guard is an in-memory cache of what *this device's composer* last wrote. It reads "cleared" in two situations where the persisted draft is not empty:
- the racing flush is inside `stampConversationDraft` (a DB read-modify-write) and has not advanced the guard yet — `updateLocalDraft` deliberately advances it only after the write lands, so the window is the whole write;
- a peer device's draft arrived through drive sync — that writes the local index without ever touching the guard. This one is not a race at all; it is reproducible every time, and it is what the new `theSendClearsADraftTheGuardNeverSaw` test pins.

**CONFIRMED — the clear runs from a detached `scope.launch`.** Nothing sequenced it against an in-flight flush.

**CONFIRMED, but only for the server copy — last-write-wins / arrival order.** Locally this is deterministic and was never the problem: `stampConversationDraft` is a read-modify-write through `withDraftLww`, which drops a strictly-older stamp and accepts equal-or-newer, so a clear stamped after the flush always wins on disk. The server copy is different: each stamp enqueues an independent outbox row carrying the whole serialized `localAppData`, and the outbox drains `ORDER BY priority ASC, nextRunTime ASC` — a retried/backed-off flush row can therefore land *after* the clear row and leave the stale draft on the server. Not fixed directly; the fix removes the competing flush instead, so there is no second row to reorder.

**PARTIALLY REFUTED — "restore-on-enter re-runs on every emission of `ActiveConversation.conversation`".** Literally true, but `ActiveConversation.conversation` is a `MutableStateFlow` (`homebase-common/.../navigation/ActiveConversation.kt`), which conflates equal values — it only emits when the active conversation actually changes. So the restore is a normal restore-on-(re-)entry, not a spurious re-restore of the current thread. The stale draft becomes visible when the user leaves and comes back (or on the next launch), not while sitting in the thread.

## What changed

**1. `MessageActionsHandler.kt` — blank the composer before awaiting the send.** New `internal suspend fun RichTextState.clearedForSend(content, send)` (top-level, next to the existing `shouldSendComposerMessage`), used by `addMessage` and `replyToMessage`. It clears, runs the send, and on a throw puts `content` back — but only if the composer is still blank, so it can't clobber text the user typed during a slow send, and never restores on `CancellationException`. The existing catch/`ShowErrorMessage` behaviour is unchanged: a failed send still surfaces the error *and* still leaves the text in the composer to retry, exactly as before.

`addMessageWithFiles` (the attachment path) already blanked the composer before its upload — untouched.

**2. `ConversationService.kt` — make the send-time clear correct.** `clearLocalDraft`'s "nothing stored, nothing to clear" shortcut now consults the **persisted** draft (`readPersistedDraft`, the non-locking body extracted out of `readDraft`) instead of the in-memory guard, and `readDraft` / `updateLocalDraft` / `clearLocalDraft` now hold `draftMutex` across their whole body rather than only around the guard read. That both fixes the guard-disagrees-with-disk case and orders the clear after any in-flight flush. The cheap-send optimisation is preserved — the common "composed straight through, no draft ever written" send still does one indexed local read and no outbox push (the pre-existing `clearingADraftThatWasNeverWrittenCostsNothing` test still passes unmodified).

## What I deliberately did NOT change

- **The issue's suggestion (2), "suppress draft flushes while a send is in flight".** With the composer blanked at send time a mid-send flush writes an empty body, so there is nothing to suppress — and suppressing would be actively wrong: typing message 2 while message 1 is still uploading is a genuine draft that should be persisted.
- **The issue's suggestion (4), explicitly cancelling the pending debounce.** `debounce` restarts its timer on every upstream emission, and the send-time blank *is* an emission, so the armed flush of the typed text is discarded for free. Adding a cancellation handle would be machinery for something the operator already does.
- **`DRAFT_IDLE_MS`, the restore-on-enter path, `withDraftLww`, and the `updateLocalDraft` guard semantics** — all still as #1122 left them.
- **No `delay()`, no retry, no symptom patch.**

Edit mode is untouched: `flushDraft` still early-returns on `isEditingMessageId != null`, and `handleEditMessage` / `handleEditMessageSave` / `handleCancelEditMessage` are unmodified. #1122's abandoned-draft persist-and-restore path is unmodified and still covered by `aWriteThatDidNotLandDoesNotPoisonTheDedupGuard`.

## Tests

`homebase-chat/src/jvmTest/.../conversationlist/ComposerClearedForSendTest.kt` (new) — drives `clearedForSend` with a controllable suspension point (`CompletableDeferred`) and asserts the composer is blank **while the send is still in flight**, plus the two failure-path guarantees.

`homebase-chat/src/jvmTest/.../convo/ConversationServiceDraftGuardTest.kt` — new `theSendClearsADraftTheGuardNeverSaw`, against the real in-memory-SQLite fixture: open the conversation (guard seeded "no draft"), persist a draft *without* going through `updateLocalDraft`, then `clearLocalDraft` and assert nothing is left.

### Mutation check (each mutation applied alone, then reverted)

| Mutation | Result |
|---|---|
| `clearedForSend` clears **after** `send()` instead of before | `ComposerClearedForSendTest > composerIsBlankForTheWholeSend FAILED` |
| drop the failure restore from `clearedForSend` | `ComposerClearedForSendTest > aFailedSendPutsTheTextBack FAILED` |
| restore `clearLocalDraft`'s `lastPersistedDraft` early-return | `ConversationServiceDraftGuardTest > theSendClearsADraftTheGuardNeverSaw FAILED` |

All three pass again with the mutation reverted.

## Verification

```
$ ./gradlew homebase-chat:jvmTest homebase-auth:jvmTest homebase-common:jvmTest homebase-api:jvmTest --rerun-tasks
BUILD SUCCESSFUL in 6m 5s
76 actionable tasks: 76 executed

homebase-chat:   1347 tests, 0 failures, 6 skipped (184 classes)
homebase-auth:     31 tests, 0 failures, 0 skipped (3 classes)
homebase-common:  598 tests, 0 failures, 0 skipped (79 classes)
homebase-api:    1250 tests, 0 failures, 0 skipped (141 classes)
TOTAL:           3226 tests, 0 failures, 6 skipped
```

```
$ ./gradlew :homebase-chat:compileKotlinJvm :homebase-chat:compileAndroidMain \
            :homebase-chat:compileKotlinWasmJs :homebase-chat:compileKotlinIosSimulatorArm64
BUILD SUCCESSFUL in 3s
116 actionable tasks: 7 executed, 109 up-to-date
```

`homebase-chat` is the only module touched.

## Not verified

The acceptance criterion "no stale draft in `localAppData` after a send — verified on a second device" was **not** exercised on real hardware: I have no second logged-in identity here, so the cross-device leg is covered only by the local-index assertions above plus the unchanged `ConversationDraftLwwTest`. The server-side outbox reordering noted in the LWW paragraph is reasoned from `Outbox.sq`'s `ORDER BY`, not observed. Neither the iOS repro nor the slow-network send was reproduced end-to-end on a device.
