### PR TITLE
Leave a breadcrumb for a stall the process never lives to report (#1491)

### DIFF
--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/diagnostics/MainThreadWatchdog.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/diagnostics/MainThreadWatchdog.kt
@@ -43,6 +43,9 @@ import kotlin.time.TimeSource
  * Both detectors report through one shared, throttled [StallReporter], so the same incident
  * can't produce two log lines.
  *
+ * Both also share one remaining blind spot: they report only once the stall *ends*, so a process
+ * killed while stalled writes nothing. [ProcessHeartbeat] closes that from the next launch.
+ *
  * Platform notes (see `captureMainThreadStackTrace` actuals):
  *  - Android: stack comes from the main `Looper` thread, ~1s before the OS ANR cutoff.
  *  - Desktop (JVM): stack comes from the AWT event-dispatch thread (Compose's Main dispatcher).
@@ -56,7 +59,9 @@ class MainThreadWatchdog(
     throttleMs: Long = 30_000,
     private val mainDispatcher: CoroutineDispatcher = Dispatchers.Main,
     private val workDispatcher: CoroutineDispatcher = Dispatchers.Default,
-    log: (String) -> Unit = { Logger.w(tag = TAG) { it } },
+    private val log: (String) -> Unit = { Logger.w(tag = TAG) { it } },
+    private val heartbeat: ProcessHeartbeat? = null,
+    private val heartbeatIntervalMs: Long = 5_000,
 ) {
     private val scope = CoroutineScope(SupervisorJob() + workDispatcher)
     private val timeOrigin = TimeSource.Monotonic.markNow()
@@ -66,6 +71,10 @@ class MainThreadWatchdog(
     private var livenessHandle: MainThreadLivenessProbe.Handle? = null
 
     fun start() {
+        heartbeat?.let { hb ->
+            hb.postMortem()?.let(log)
+            hb.beat()
+        }
         installMainThreadLivenessProbe()
         installMemoryDiagnostics()
         livenessHandle = MainThreadLivenessProbe.startIfAvailable(
@@ -87,6 +96,7 @@ class MainThreadWatchdog(
         }
 
         scope.launch {
+            var lastBeatMs = nowMs()
             while (isActive) {
                 val pong = CompletableDeferred<Unit>()
                 val postedAt = nowMs()
@@ -136,6 +146,11 @@ class MainThreadWatchdog(
                             stack = stack,
                         )
                     }
+                }
+
+                if (heartbeat != null && nowMs() - lastBeatMs >= heartbeatIntervalMs) {
+                    lastBeatMs = nowMs()
+                    heartbeat.beat()
                 }
             }
         }

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/diagnostics/ProcessHeartbeat.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/diagnostics/ProcessHeartbeat.kt
@@ -1,0 +1,88 @@
+package id.homebase.core.diagnostics
+
+import kotlinx.io.buffered
+import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
+import kotlinx.io.readString
+import kotlinx.io.writeString
+import kotlin.concurrent.Volatile
+import kotlin.time.Clock
+
+/** The last thing a process managed to record about itself before it stopped ticking. */
+internal data class Heartbeat(val epochMs: Long, val foreground: Boolean)
+
+internal fun encodeHeartbeat(beat: Heartbeat): String =
+    "${beat.epochMs} ${if (beat.foreground) FOREGROUND_MARK else BACKGROUND_MARK}"
+
+internal fun decodeHeartbeat(line: String?): Heartbeat? {
+    val parts = line?.trim()?.split(' ') ?: return null
+    if (parts.size != 2) return null
+    val epochMs = parts[0].toLongOrNull() ?: return null
+    val foreground = when (parts[1]) {
+        FOREGROUND_MARK -> true
+        BACKGROUND_MARK -> false
+        else -> return null
+    }
+    return Heartbeat(epochMs, foreground)
+}
+
+/**
+ * The breadcrumb the *next* process writes about the one that died, or `null` when the previous
+ * exit is unremarkable.
+ *
+ * A background beat is never reported: iOS suspends a process only after backgrounding it, and
+ * backgrounding posts `UIApplicationDidEnterBackground`, which writes `foreground=false`. Every
+ * ordinary end-of-life — user leaves the app, OS suspends it, jetsam collects it later — passes
+ * through that transition, so gating on the flag is what keeps this out of the routine-launch
+ * noise the way `stalled ~986967ms` was not.
+ */
+internal fun renderProcessDeathMessage(previous: Heartbeat?, launchEpochMs: Long): String? {
+    if (previous == null || !previous.foreground) return null
+    return "Previous process ended on screen without ever recording a background transition — " +
+        "its last heartbeat was ${launchEpochMs - previous.epochMs}ms before this launch. An OS " +
+        "suspension always backgrounds first, so that process was killed or died while it was " +
+        "still foreground: read the tail of its session above for how far it got."
+}
+
+/**
+ * Cross-process half of [MainThreadWatchdog], for the stall a process never lives to report.
+ *
+ * Both in-process detectors report after the fact and both need `workDispatcher` to resume
+ * them — the main-thread sentinel to time out, the wall-clock-gap check to read its gap once
+ * `delay()` returns. A process killed *during* the stall (force-quit, jetsam) therefore writes
+ * nothing at all, which is exactly what #1491's 47s iOS freeze produced: silence, then a fresh
+ * `APP STARTUP`. The record has to outlive the process, so it goes to disk.
+ *
+ * Beats are written from the watchdog's own loop, so a wedged dispatcher stops them by
+ * construction, and from the foreground observer, so a wedged main thread does too.
+ */
+class ProcessHeartbeat(
+    private val file: Path,
+    private val nowEpochMs: () -> Long = { Clock.System.now().toEpochMilliseconds() },
+) {
+    @Volatile
+    private var foreground = false
+
+    private val previous: Heartbeat? = decodeHeartbeat(read())
+
+    /** The line to log about the previous process, or `null` if it ended cleanly. */
+    fun postMortem(): String? = renderProcessDeathMessage(previous, nowEpochMs())
+
+    fun setForeground(value: Boolean) {
+        foreground = value
+        beat()
+    }
+
+    fun beat() {
+        val line = encodeHeartbeat(Heartbeat(nowEpochMs(), foreground))
+        runCatching { SystemFileSystem.sink(file).buffered().use { it.writeString(line) } }
+    }
+
+    private fun read(): String? = runCatching {
+        if (SystemFileSystem.metadataOrNull(file) == null) null
+        else SystemFileSystem.source(file).buffered().use { it.readString() }
+    }.getOrNull()
+}
+
+private const val FOREGROUND_MARK = "F"
+private const val BACKGROUND_MARK = "B"

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/session/IdentitySession.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/session/IdentitySession.kt
@@ -62,6 +62,8 @@ class IdentitySessionScope(private val koin: Koin) {
     @Volatile
     private var currentIdentity: String? = null
 
+    private var scopeSeq = 0L
+
     /** The open scope, or null while logged out. */
     val scopeOrNull: Scope? get() = current?.takeIf { !it.closed }
 
@@ -77,25 +79,40 @@ class IdentitySessionScope(private val koin: Koin) {
      * authenticated transition can run more than once per session (headless bootstrap
      * followed by [foreground promotion][id.homebase.core.auth.AuthConnectionCoordinator.promoteToForeground]),
      * and tearing down live services on the second pass would be a regression, not a reset.
+     *
+     * [lock] guards only the two state transitions. Building the scope and destroying the
+     * previous one happen outside it, because dropping a Koin scope's instances fires every
+     * `onClose` in it — arbitrary app teardown that must never run while a process-wide lock
+     * is held. The cost is that a racing caller can publish between the two critical sections;
+     * the second one reconciles, so at most one scope stays live and the loser is destroyed.
      */
-    fun open(identity: String): Scope = synchronized(lock) {
-        val live = current?.takeIf { !it.closed }
-        if (live != null && currentIdentity == identity) return@synchronized live
-
-        if (live != null) {
-            Logger.i(tag = TAG) { "identity changed ($currentIdentity -> $identity) — closing previous session scope" }
-            closeLocked()
+    fun open(identity: String): Scope {
+        // Scope ids are unique per open, never reused, so a racing pair cannot collide on
+        // Koin's non-atomic contains-then-put and there is no orphan left to delete first.
+        val scopeId = synchronized(lock) {
+            val live = current?.takeIf { !it.closed }
+            if (live != null && currentIdentity == identity) return live
+            "$SCOPE_ID_PREFIX$identity#${++scopeSeq}"
         }
 
-        Logger.i(tag = TAG) { "opening session scope for $identity" }
-        // Defensive: createScope throws ScopeAlreadyCreatedException on a duplicate id. That
-        // needs an earlier open() to have half-failed, leaving a scope in the registry we no
-        // longer hold — rare, but the consequence would be an unrecoverable login.
-        koin.deleteScope(scopeId(identity))
-        return@synchronized koin.createScope(scopeId(identity), IdentitySessionQualifier).also {
-            current = it
-            currentIdentity = identity
+        Logger.i(tag = TAG) { "opening session scope for $identity ($scopeId)" }
+        val candidate = koin.createScope(scopeId, IdentitySessionQualifier)
+
+        var discarded: Scope? = null
+        val opened = synchronized(lock) {
+            val live = current?.takeIf { !it.closed }
+            if (live != null && currentIdentity == identity) {
+                discarded = candidate
+                live
+            } else {
+                discarded = current
+                current = candidate
+                currentIdentity = identity
+                candidate
+            }
         }
+        destroy(discarded)
+        return opened
     }
 
     /**
@@ -103,15 +120,20 @@ class IdentitySessionScope(private val koin: Koin) {
      * one path (explicit sign-out, token expiry, an identity switch) and must not throw on
      * the second.
      */
-    fun close() = synchronized(lock) { closeLocked() }
+    fun close() {
+        val doomed = synchronized(lock) {
+            val live = current
+            current = null
+            currentIdentity = null
+            live
+        }
+        destroy(doomed)
+    }
 
-    private fun closeLocked() {
-        val live = current
-        current = null
-        currentIdentity = null
-        if (live == null || live.closed) return
-        Logger.i(tag = TAG) { "closing session scope ${live.id}" }
-        live.close()
+    private fun destroy(scope: Scope?) {
+        if (scope == null || scope.closed) return
+        Logger.i(tag = TAG) { "closing session scope ${scope.id}" }
+        scope.close()
     }
 
     /**
@@ -121,8 +143,6 @@ class IdentitySessionScope(private val koin: Koin) {
      */
     fun requireScope(): Scope = scopeOrNull
         ?: error("No identity session is open — cannot resolve identity-scoped dependencies while logged out")
-
-    private fun scopeId(identity: String) = "$SCOPE_ID_PREFIX$identity"
 
     private companion object {
         const val TAG = "IdentitySession"

--- a/homebase-common/src/commonTest/kotlin/id/homebase/core/diagnostics/MainThreadWatchdogTest.kt
+++ b/homebase-common/src/commonTest/kotlin/id/homebase/core/diagnostics/MainThreadWatchdogTest.kt
@@ -184,4 +184,49 @@ class MainThreadWatchdogTest {
 
         assertEquals(listOf("a", "c"), logged)
     }
+
+    // --- ProcessHeartbeat (#1491) ------------------------------------------------------------
+
+    @Test
+    fun heartbeat_roundTripsThroughItsEncoding() {
+        listOf(
+            Heartbeat(epochMs = 1_757_277_526_838, foreground = true),
+            Heartbeat(epochMs = 0, foreground = false),
+        ).forEach { assertEquals(it, decodeHeartbeat(encodeHeartbeat(it))) }
+    }
+
+    @Test
+    fun heartbeat_decodesNothingFromAMissingOrCorruptRecord() {
+        // A first-ever launch, a truncated write, a file from an older format: all "no previous
+        // process", never a bogus breadcrumb.
+        listOf(null, "", "   ", "1757277526838", "1757277526838 F B", "abc F", "1757277526838 X")
+            .forEach { assertNull(decodeHeartbeat(it), "should not decode: $it") }
+    }
+
+    @Test
+    fun processDeath_isReportedWhenThePreviousProcessDiedOnScreen() {
+        val message = renderProcessDeathMessage(
+            previous = Heartbeat(epochMs = 1_000_000, foreground = true),
+            launchEpochMs = 1_095_000,
+        )
+        assertTrue(message!!.startsWith("Previous process ended on screen"), message)
+        assertTrue(message.contains("95000ms before this launch"), message)
+    }
+
+    @Test
+    fun processDeath_isSilentForABackgroundedProcess() {
+        // The routine end of every session — and the shape of the benign `stalled ~986967ms`
+        // suspension already in the field logs. Reporting it would drown the real thing.
+        assertNull(
+            renderProcessDeathMessage(
+                previous = Heartbeat(epochMs = 1_000_000, foreground = false),
+                launchEpochMs = 9_999_000,
+            )
+        )
+    }
+
+    @Test
+    fun processDeath_isSilentOnAFirstLaunch() {
+        assertNull(renderProcessDeathMessage(previous = null, launchEpochMs = 1_000))
+    }
 }

--- a/homebase-common/src/jvmTest/kotlin/id/homebase/core/diagnostics/ProcessHeartbeatJvmTest.kt
+++ b/homebase-common/src/jvmTest/kotlin/id/homebase/core/diagnostics/ProcessHeartbeatJvmTest.kt
@@ -1,0 +1,63 @@
+package id.homebase.core.diagnostics
+
+import kotlinx.io.files.Path
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * The part of #1491's breadcrumb that only exists on disk: whether one [ProcessHeartbeat] can
+ * actually read back what a *previous* one wrote. JVM-only because it needs a real temp directory;
+ * the decision logic itself is covered platform-free in [MainThreadWatchdogTest].
+ *
+ * Each `ProcessHeartbeat` here stands in for one app process — the whole point is that the record
+ * outlives the process that wrote it.
+ */
+class ProcessHeartbeatJvmTest {
+
+    private val dir = Path(Files.createTempDirectory("heartbeat").toString())
+    private val file = Path(dir, "heartbeat")
+
+    private fun processStartingAt(nowEpochMs: Long) = ProcessHeartbeat(file) { nowEpochMs }
+
+    @Test
+    fun aForegroundProcessThatNeverBackgroundsIsReportedByTheNextLaunch() {
+        val frozen = processStartingAt(1_000_000)
+        frozen.setForeground(true)
+        // …and then it is gone: force-quit mid-freeze, so it never writes anything again.
+
+        val relaunch = processStartingAt(1_095_000)
+
+        val message = assertNotNull(relaunch.postMortem(), "expected a post-mortem breadcrumb")
+        assertTrue(message.contains("95000ms before this launch"), message)
+    }
+
+    @Test
+    fun aProcessThatBackgroundedFirstIsNotReported() {
+        val backgrounded = processStartingAt(1_000_000)
+        backgrounded.setForeground(true)
+        backgrounded.setForeground(false)
+
+        assertNull(processStartingAt(99_000_000).postMortem())
+    }
+
+    @Test
+    fun theFirstLaunchOnAFreshInstallHasNothingToReport() {
+        assertNull(processStartingAt(1_000).postMortem())
+    }
+
+    @Test
+    fun eachProcessReadsTheRecordOnceAndThenOwnsIt() {
+        processStartingAt(1_000_000).setForeground(true)
+
+        // The relaunch snapshots the previous record at construction, so its own beats can't
+        // turn into a post-mortem about itself on the next tick.
+        val relaunch = processStartingAt(1_050_000)
+        relaunch.setForeground(true)
+        relaunch.beat()
+
+        assertTrue(relaunch.postMortem()!!.contains("50000ms before this launch"))
+    }
+}

--- a/homebase-common/src/jvmTest/kotlin/id/homebase/core/session/IdentitySessionConcurrencyTest.kt
+++ b/homebase-common/src/jvmTest/kotlin/id/homebase/core/session/IdentitySessionConcurrencyTest.kt
@@ -1,0 +1,190 @@
+package id.homebase.core.session
+
+import org.koin.core.Koin
+import org.koin.core.scope.Scope
+import org.koin.dsl.koinApplication
+import org.koin.dsl.module
+import org.koin.dsl.onClose
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.CyclicBarrier
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.concurrent.thread
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+/**
+ * The orderings #1491 froze on, made deterministic.
+ *
+ * The failing iOS launch resolved auth and opened the Koin identity scope *before* the ComposeView
+ * existed, so first composition navigated straight to the main screen and resolved its whole
+ * battery of identity-scoped ViewModels in one cold burst while the session was still settling.
+ * These tests reproduce that shape — a transition in flight against a burst of resolution — and
+ * pin the two invariants that shape depends on: identity teardown never runs under the session
+ * lock, and a racing re-open never swaps the scope out from under the resolvers.
+ *
+ * JVM-only: it needs real threads and latches. Note this does NOT reproduce the production freeze,
+ * whose cause is still unconfirmed — it guards the hardening, not a diagnosis.
+ */
+class IdentitySessionConcurrencyTest {
+
+    private class Service : IdentityScoped {
+        val closed = AtomicBoolean(false)
+        /** Lets a test hold teardown open and observe what the rest of the app can still do. */
+        @Volatile var onCloseHook: (() -> Unit)? = null
+    }
+
+    private lateinit var koin: Koin
+    private lateinit var session: IdentitySessionScope
+
+    @BeforeTest
+    fun setUp() {
+        koin = koinApplication(createEagerInstances = false) {
+            modules(
+                module {
+                    scope(IdentitySessionQualifier) {
+                        scoped { Service() } onClose { service ->
+                            service?.closed?.set(true)
+                            service?.onCloseHook?.invoke()
+                        }
+                    }
+                },
+            )
+        }.koin
+        session = IdentitySessionScope(koin)
+    }
+
+    @AfterTest
+    fun tearDown() = koin.close()
+
+    @Test
+    fun `identity teardown runs without holding the session lock`() {
+        // Closing a Koin scope drops every instance in it and fires each onClose — arbitrary app
+        // teardown (coroutine scopes cancelled, collectors torn down, ViewModels cleared). While
+        // that ran under the session lock, any concurrent open()/close() queued behind whatever
+        // the slowest onClose decided to do.
+        session.open(FRODO)
+        val service = session.get<Service>()
+
+        val teardownStarted = CountDownLatch(1)
+        val releaseTeardown = CountDownLatch(1)
+        service.onCloseHook = {
+            teardownStarted.countDown()
+            releaseTeardown.await(TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        }
+
+        val closer = thread { session.close() }
+        assertTrue(teardownStarted.await(TIMEOUT_SECONDS, TimeUnit.SECONDS), "teardown never ran")
+
+        val opener = thread { session.open(SAM) }
+        opener.join(2_000)
+        val blocked = opener.isAlive
+
+        releaseTeardown.countDown()
+        closer.join()
+        opener.join()
+
+        assertFalse(blocked, "open() blocked behind identity teardown — the lock is held across scope.close()")
+    }
+
+    @Test
+    fun `a re-open racing a first-composition burst never swaps the live scope`() {
+        // The failing ordering: the scope is already open when composition starts, and the
+        // authenticated transition runs a second time (headless bootstrap -> promoteToForeground)
+        // while the screen resolves out of it. The re-open must stay a no-op even when it races.
+        session.open(FRODO)
+        val service = session.get<Service>()
+
+        val start = CyclicBarrier(REOPENERS + RESOLVERS)
+        val failure = AtomicReference<Throwable?>(null)
+
+        val reopeners = List(REOPENERS) {
+            thread {
+                runCatching { start.await(); repeat(BURST) { session.open(FRODO) } }
+                    .onFailure(failure::set)
+            }
+        }
+        val resolvers = List(RESOLVERS) {
+            thread {
+                runCatching {
+                    start.await()
+                    repeat(BURST) { assertSame(service, session.get<Service>()) }
+                }.onFailure(failure::set)
+            }
+        }
+
+        (reopeners + resolvers).forEach { it.join(TIMEOUT_SECONDS * 1_000) }
+        (reopeners + resolvers).forEach { assertFalse(it.isAlive, "a thread deadlocked") }
+        failure.get()?.let { throw it }
+
+        assertFalse(service.closed.get(), "the live identity's state was torn down by a re-open")
+        assertSame(service, session.get<Service>())
+        assertEquals(FRODO, session.identity)
+    }
+
+    @Test
+    fun `opens racing from cold agree on one scope and leave no other behind`() {
+        // Every racer passes the fast path (nothing is open yet) and builds its own candidate,
+        // because scope ids are now unique per open — that is what stops a racing pair colliding
+        // on Koin's contains-then-put. Exactly one candidate may survive: the rest have to be
+        // handed back as the winner's scope AND destroyed, or the registry grows a dead scope
+        // per login.
+        val returned = ConcurrentLinkedQueue<Scope>()
+        val start = CyclicBarrier(REOPENERS)
+        val threads = List(REOPENERS) {
+            thread { start.await(); returned += session.open(FRODO) }
+        }
+        threads.forEach { it.join(TIMEOUT_SECONDS * 1_000) }
+        threads.forEach { assertFalse(it.isAlive, "a thread deadlocked") }
+
+        val live = session.requireScope()
+        assertEquals(REOPENERS, returned.size)
+        assertEquals(setOf(live), returned.toSet(), "racing opens handed out more than one scope")
+        assertFalse(live.closed)
+
+        val prefix = live.id.substringBeforeLast('#')
+        val stillRegistered = (1..REOPENERS * 2).count { koin.getScopeOrNull("$prefix#$it") != null }
+        assertEquals(1, stillRegistered, "a discarded scope was left in Koin's registry")
+    }
+
+    @Test
+    fun `a close racing an open leaves no half-open session`() {
+        // Which of the two wins is decided by the order their state transitions take the lock —
+        // the same rule as before. What must hold either way: the scope Koin still knows about is
+        // the one the session points at, and nothing is left created-but-unreachable.
+        repeat(30) {
+            session.open(FRODO)
+            val start = CyclicBarrier(2)
+            val opener = thread { start.await(); session.open(SAM) }
+            val closer = thread { start.await(); session.close() }
+            opener.join(TIMEOUT_SECONDS * 1_000)
+            closer.join(TIMEOUT_SECONDS * 1_000)
+            assertFalse(opener.isAlive || closer.isAlive, "a thread deadlocked")
+
+            val live = session.scopeOrNull
+            if (live == null) {
+                assertEquals(null, session.identity)
+            } else {
+                assertFalse(live.closed)
+                assertSame(live, koin.getScopeOrNull(live.id))
+            }
+            session.close()
+        }
+    }
+
+    private companion object {
+        const val FRODO = "frodo.dotyou.cloud"
+        const val SAM = "sam.dotyou.cloud"
+        const val REOPENERS = 4
+        const val RESOLVERS = 4
+        const val BURST = 200
+        const val TIMEOUT_SECONDS = 10L
+    }
+}

--- a/homebase-core/src/nativeMain/kotlin/id/homebase/core/MainViewController.kt
+++ b/homebase-core/src/nativeMain/kotlin/id/homebase/core/MainViewController.kt
@@ -23,6 +23,7 @@ import id.homebase.api.sync.database.DatabaseDriverFactory
 import id.homebase.api.sync.database.DatabaseManager
 import id.homebase.core.di.allModules
 import id.homebase.core.diagnostics.MainThreadWatchdog
+import id.homebase.core.diagnostics.ProcessHeartbeat
 import id.homebase.core.diagnostics.installGpuTextDiagnostics
 import id.homebase.core.diagnostics.installIosMemoryDiagnostics
 import id.homebase.core.crash.CrashMetadata
@@ -31,6 +32,7 @@ import id.homebase.core.logging.LoggerConfig
 import id.homebase.core.logging.StartupLogger
 import id.homebase.core.logging.setErrorCollectionEnabled
 import id.homebase.core.logging.setupIOSCrashHandler
+import id.homebase.core.location.tracking.observeAppForeground
 import id.homebase.core.settings.UserPreferencesHelper
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.coroutines.runBlocking
@@ -134,7 +136,12 @@ fun initializeApp() {
 
     // Detect main-thread stalls and log them to homebase.log. On iOS the stack itself can't be
     // captured from a background thread, but the "stalled for Nms" breadcrumb is still recorded.
-    MainThreadWatchdog().start()
+    // The heartbeat is the cross-process half: a freeze the user force-quits out of can only be
+    // reported by the NEXT launch, and the foreground flag is what keeps a routine OS suspension
+    // from looking like one (#1491).
+    val heartbeat = ProcessHeartbeat(Path(getLogDirectory(), "heartbeat"))
+    observeAppForeground { heartbeat.setForeground(it) }
+    MainThreadWatchdog(heartbeat = heartbeat).start()
 
     // Memory context attached to a MainThreadWatchdog stall breadcrumb (see MemoryDiagnostics).
     installIosMemoryDiagnostics()


### PR DESCRIPTION
Refs #1491. **Does not close it** — the root cause is still unconfirmed. The acceptance box "Root cause confirmed from a paused/spindump main-thread stack during a live freeze" stays unchecked, because that artifact does not exist yet and nothing here can substitute for it. What this PR does is make the *next* occurrence diagnosable from `homebase.log` alone, and remove a genuine landmine that the issue correctly identified regardless of cause.

## First: the issue's premise about the #1444 instrumentation is stale

The issue says the #1444 instrumentation "is no longer on main" and "should be re-landed". That was true when it was written and is not true now:

```
$ git log --oneline origin/main --grep=1444
b241fcca5 Instrument the iOS headless-launch black screen (#1444) (#1463) (#1469)   <- re-landed
76643be15 Revert the #1444 instrumentation and the #1465 REST 401 reporting (#1466)
9bdbf08b3 Instrument the iOS headless-launch black screen (#1444) (#1463)
```

Read back from the source on this branch, **all of the following already exist on main** and need no work:

| Instrumentation | Where |
|---|---|
| `scenePhase` transition trace | `iosApp/iosApp/ContentView.swift:74-75` -> `IosGpuTextDiagnosticsKt.logLaunchTrace` |
| deferred-ComposeView `prevention:` marker | `IosGpuTextDiagnostics.kt:104` (`logPrevention`) |
| background/foreground observers + `GpuTextDiag` snapshots | `IosGpuTextDiagnostics.kt:67-95` |
| `StartupLogger` checkpoints | `StartupLogger.kt:22`, called at `App()` first composition / Koin injections done |
| `IdentitySession` scope open/close logging | `IdentitySession.kt` (from `c3951bbf9`) |
| Wall-clock gap detector (`WatchdogStarved`) | `MainThreadWatchdog.kt:116-139` |
| OS-suspension vs self-stall split (CPU vs wall) | `StallEvent.kt:41` `classifyStallCause`, `MainThreadWatchdog.apple.kt:33` `captureProcessTimes` |

Notably the wall-clock gap detector the issue asks for **is already implemented**, and so is the suspension/deadlock discriminator for the live case — the field log's `stalled ~986967ms` line predates it; on current main that same suspension would read `OS-SUSPENDED: cpu +Xms over Yms wall`.

Also, per the issue's own instruction, I re-verified the refuted lock cycle in the current source rather than taking it on trust: `scopeOrNull` is `current?.takeIf { !it.closed }` over a plain `MutableStateFlow` read (`IdentitySession.kt:66`), and `requireScope()`/`get()` go through it. Resolving identity-scoped dependencies takes no `IdentitySession` lock. The cycle cannot exist. Not chased.

## So what was actually missing

Not a gap detector — a gap detector that **survives the process**.

Both existing detectors report *after* the stall ends, and both need `workDispatcher` (`Dispatchers.Default`) to resume the coroutine:

* `MainThreadBlock`: `withTimeoutOrNull(thresholdMs) { pong.await() }` — the timeout itself has to be scheduled on `Dispatchers.Default`.
* `WatchdogStarved`: reads `actualGapMs` only once `delay(tickIntervalMs)` **returns**.

In this incident the process never returned. The log's next line is a fresh `APP STARTUP` — the user force-quit it at ~47s. A recovery-time breadcrumb can by construction never be written by a process that is killed while stalled. On top of that, `MainThreadLivenessProbe` — the one dispatcher-independent detector — is a **no-op on iOS** (`MainThreadLivenessProbe.apple.kt:7`), so on the platform where this happens there was nothing else running either.

That is why there was zero output. It is not a missing check; it is that every existing check lives inside the process that died.

### The fix: `ProcessHeartbeat`

`homebase-common/.../diagnostics/ProcessHeartbeat.kt` writes one short line (`<epochMs> F|B`) to `logs/heartbeat`, and the **next** launch reads it back before overwriting it. Beats come from the watchdog's own loop (every 5s, so a wedged dispatcher stops them by construction) and from the foreground observer (so a wedged main thread does too). ~40 bytes, 12 writes/minute.

**Distinguishing suspension from deadlock — the noise question.** The CPU-vs-wall discriminator that `classifyStallCause` uses is unavailable post-mortem: those counters die with the process. The discriminator that *is* available is the foreground flag, and it is clean for the reason the issue cares about:

> iOS suspends a process only after backgrounding it, and backgrounding posts `UIApplicationDidEnterBackground`, which writes a `foreground=false` beat.

So every ordinary end-of-life — user leaves the app, OS suspends it, jetsam collects it hours later, user swipes it out of the app switcher (which backgrounds it first), device locks — passes through a background transition and is **never reported**. The benign `stalled ~986967ms` shape produces nothing. A record still saying `F` means the process died on screen without ever getting to run that callback. Two residual caveats I am not engineering around and would rather state: a **crash** while foreground also leaves an `F` record (it will sit next to its own crash report and stack, so it corroborates rather than misleads), and a hard power-loss does too.

Wired on **iOS only**. Deliberate: Desktop's `observeAppForeground` is a constant `true`, so the discriminator does not exist there and every normal quit would produce a line — exactly the noise this is trying to avoid. Android has a real observer and could adopt it in two lines at its `MainThreadWatchdog()` call site, but Android already has the dedicated-thread liveness probe plus native ANR traces and logcat; iOS has none of that.

No Swift changes, so nothing here needs an Xcode build (I cannot build the Xcode project from this worktree anyway).

## Hardening: `IdentitySession.lock` is no longer held across Koin work

I checked what Koin 4.2.1 actually does under that lock rather than assuming, by disassembling `koin-core-jvm-4.2.1.jar`:

* `ScopeRegistry.createScope` — registry bookkeeping, `Scope.linkTo`, map put. **No app code**, no eager instances.
* `deleteScope` / `Scope.close()` -> `InstanceRegistry.dropScopeInstances` -> `ScopedInstanceFactory.drop`, which **invokes each definition's `onClose`**. That is arbitrary app teardown — coroutine scopes cancelled, collectors torn down, ViewModels cleared — and it was running while a process-wide lock was held.

`close()` now detaches under the lock and destroys outside it. `open()` splits into two critical sections with `koin.createScope` in between.

### Why the split is still correct

Scope ids become unique per open (`identity:<domain>#<n>`, counter bumped under the lock). Two consequences: racing opens can no longer collide on Koin's non-atomic contains-then-put, and the defensive `koin.deleteScope(...)` guarding against a half-failed earlier open is **deleted** — an id is never reused, so `ScopeAlreadyCreatedException` is unreachable.

* **Two concurrent `open("A")` from cold.** Both pass the fast path, both build a candidate with distinct ids. The first to reach the publish section sets `current`. The second sees a live scope for the same identity, returns *that one*, and destroys its own candidate outside the lock. One live scope, nothing left in Koin's registry. Test: `opens racing from cold agree on one scope and leave no other behind`.
* **`open("A")` racing `open("B")`.** Whichever publishes second wins and destroys the other's scope. Same outcome as the old single-lock version, where whichever acquired the lock second also won.
* **`close()` racing `open()`.** The winner is decided by which *state transition* takes the lock last, which is the same rule as before (previously: which whole method took it first). Either ordering leaves a consistent state: either `current == candidate` with the old scope destroyed, or `current == null` with the candidate destroyed. **No scope is ever left created-but-unreachable in Koin's registry** — that is the invariant, and it is the one asserted. Test: `a close racing an open leaves no half-open session` (30 rounds).
* **Re-entrancy.** Teardown now runs with no lock held and with `current` already updated, so an `onClose` that calls back into `open()`/`close()` sees consistent state instead of the previous unbounded-hold hazard.

Reader paths are untouched: `scopeOrNull` / `isOpen` / `identity` / `requireScope` were already lock-free StateFlow reads and still are.

**Not touched:** `AppNavHost`'s ViewModel resolution — that is #1373's scope.

## Mutation check

Each fix was broken and the tests re-run; every one failed, then was restored.

| Mutation | Result |
|---|---|
| `close()` destroys the scope **inside** `synchronized(lock)` | `IdentitySessionConcurrencyTest > identity teardown runs without holding the session lock FAILED` |
| `open()` publish section always publishes its own candidate (drop the reconciliation) | `IdentitySessionConcurrencyTest > opens racing from cold agree on one scope and leave no other behind FAILED` |
| `open()` skips `destroy(discarded)` | `IdentitySessionScopeTest > switching identity destroys the previous identity's state FAILED` |
| `renderProcessDeathMessage` drops the `!previous.foreground` gate | `MainThreadWatchdogTest > processDeath_isSilentForABackgroundedProcess FAILED` and `ProcessHeartbeatJvmTest > aProcessThatBackgroundedFirstIsNotReported FAILED` |

## Verification

```
$ ./gradlew homebase-chat:jvmTest homebase-auth:jvmTest homebase-common:jvmTest homebase-api:jvmTest --rerun-tasks
BUILD SUCCESSFUL in 5m 54s
76 actionable tasks: 76 executed
```

Per-module counts read out of `build/test-results/jvmTest/TEST-*.xml`:

```
homebase-common: 611 tests, 0 failures, 0 errors, 0 skipped
homebase-chat:  1343 tests, 0 failures, 0 errors, 6 skipped
homebase-auth:    31 tests, 0 failures, 0 errors, 0 skipped
homebase-api:   1250 tests, 0 failures, 0 errors, 0 skipped
```

New tests (all in that run):

```
IdentitySessionConcurrencyTest  tests="4" skipped="0" failures="0" errors="0"
  identity teardown runs without holding the session lock
  a re-open racing a first-composition burst never swaps the live scope
  opens racing from cold agree on one scope and leave no other behind
  a close racing an open leaves no half-open session
ProcessHeartbeatJvmTest         tests="4" skipped="0" failures="0" errors="0"
MainThreadWatchdogTest          tests="19" (was 14; +5 for the heartbeat logic)
```

Per-target compile checks for both modules I touched:

```
$ ./gradlew :homebase-common:compileKotlinJvm :homebase-common:compileAndroidMain \
            :homebase-common:compileKotlinWasmJs :homebase-common:compileKotlinIosSimulatorArm64 \
            :homebase-core:compileKotlinJvm :homebase-core:compileAndroidMain \
            :homebase-core:compileKotlinWasmJs :homebase-core:compileKotlinIosSimulatorArm64
BUILD SUCCESSFUL in 8m 47s

$ ./gradlew :androidApp:compileDebugKotlin :desktopApp:compileKotlinJvm
BUILD SUCCESSFUL in 1m 20s
```

iOS target compiled (macOS host), which matters since the change is iOS-facing.

## Diffstat

```
 .../core/diagnostics/MainThreadWatchdog.kt         |  17 +-
 .../homebase/core/diagnostics/ProcessHeartbeat.kt  |  88 ++++++++++
 .../id/homebase/core/session/IdentitySession.kt    |  72 +++++---
 .../core/diagnostics/MainThreadWatchdogTest.kt     |  45 +++++
 .../core/diagnostics/ProcessHeartbeatJvmTest.kt    |  63 +++++++
 .../core/session/IdentitySessionConcurrencyTest.kt | 190 +++++++++++++++++++++
 .../kotlin/id/homebase/core/MainViewController.kt  |   9 +-
 7 files changed, 456 insertions(+), 28 deletions(-)
```

## Acceptance criteria

- [ ] **Root cause confirmed from a paused/spindump main-thread stack** — still required, still the only thing that settles it. Everything else is inference.
- [x] Navigating to the main screen immediately after auth resolves (scope open before first composition) cannot deadlock — covered by `IdentitySessionConcurrencyTest`, under the caveat that it guards the hardening, not a diagnosis.
- [x] `IdentitySession`'s lock is never held across `koin.createScope` / `deleteScope` / `scope.close()`.
- [x] A whole-process stall leaves a breadcrumb — from the next launch, which is the only place it can come from when the process is killed mid-stall.
- [x] A repeatable test covers the failing ordering.
- [ ] The app never reaches a state where all dispatchers are silent with no breadcrumb — the breadcrumb now exists, but this cannot be ticked until a field log shows it firing.
