### PR TITLE
Support dragging files onto the chat on web

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/FileDropTarget.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/FileDropTarget.kt
@@ -66,13 +66,24 @@ sealed interface FileDropPreview {
     data object Rejected : FileDropPreview
 }
 
-// Desktop only; every other target has no external file-drag source and returns Modifier unchanged.
+// Desktop and web; Android and iOS have no external file-drag source and return Modifier unchanged.
 @Composable
 expect fun Modifier.fileDropTarget(
     enabled: Boolean,
     onDragPreviewChanged: (FileDropPreview?) -> Unit,
     onFilesDropped: (List<PlatformFile>) -> Unit,
 ): Modifier
+
+internal data class DropItem(val kind: String, val mimeType: String, val isDirectory: Boolean)
+
+internal fun dropPreviewOf(items: List<DropItem>): FileDropPreview {
+    val attachable = items.filter { it.kind == "file" && !it.isDirectory }
+    if (attachable.isEmpty()) return FileDropPreview.Rejected
+    return FileDropPreview.Attachable(
+        total = attachable.size,
+        images = attachable.count { it.mimeType.startsWith("image/") },
+    )
+}
 
 @Composable
 fun FileDropOverlay(preview: FileDropPreview?, modifier: Modifier = Modifier) {

--- a/homebase-chat/src/commonTest/kotlin/id/homebase/chat/widget/DropPreviewTest.kt
+++ b/homebase-chat/src/commonTest/kotlin/id/homebase/chat/widget/DropPreviewTest.kt
@@ -1,0 +1,60 @@
+package id.homebase.chat.widget
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+private fun file(mimeType: String) = DropItem("file", mimeType, isDirectory = false)
+
+private fun folder() = DropItem("file", "", isDirectory = true)
+
+private fun text() = DropItem("string", "text/plain", isDirectory = false)
+
+class DropPreviewTest {
+
+    @Test
+    fun allImagesReportsEveryItemAsAnImage() {
+        assertEquals(
+            FileDropPreview.Attachable(total = 3, images = 3),
+            dropPreviewOf(listOf(file("image/png"), file("image/jpeg"), file("image/webp"))),
+        )
+    }
+
+    @Test
+    fun mixedCountsOnlyTheImages() {
+        assertEquals(
+            FileDropPreview.Attachable(total = 3, images = 1),
+            dropPreviewOf(listOf(file("image/png"), file("application/pdf"), file("text/plain"))),
+        )
+    }
+
+    @Test
+    fun noItemsIsRejected() {
+        assertEquals(FileDropPreview.Rejected, dropPreviewOf(emptyList()))
+    }
+
+    @Test
+    fun draggedTextIsRejected() {
+        assertEquals(FileDropPreview.Rejected, dropPreviewOf(listOf(text())))
+    }
+
+    @Test
+    fun foldersAreRejected() {
+        assertEquals(FileDropPreview.Rejected, dropPreviewOf(listOf(folder(), folder())))
+    }
+
+    @Test
+    fun aFolderDoesNotCountTowardsTheFilesBesideIt() {
+        assertEquals(
+            FileDropPreview.Attachable(total = 1, images = 0),
+            dropPreviewOf(listOf(folder(), file("application/zip"), text())),
+        )
+    }
+
+    @Test
+    fun anUntypedFileStillCounts() {
+        assertEquals(
+            FileDropPreview.Attachable(total = 1, images = 0),
+            dropPreviewOf(listOf(file(""))),
+        )
+    }
+}

--- a/homebase-chat/src/wasmJsMain/kotlin/id/homebase/chat/widget/FileDropTarget.web.kt
+++ b/homebase-chat/src/wasmJsMain/kotlin/id/homebase/chat/widget/FileDropTarget.web.kt
@@ -1,12 +1,154 @@
+@file:OptIn(kotlin.js.ExperimentalWasmJsInterop::class)
+
 package id.homebase.chat.widget
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.layout.boundsInWindow
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalDensity
 import io.github.vinceglb.filekit.PlatformFile
+import kotlinx.browser.window
+import org.w3c.dom.DataTransferItem
+import org.w3c.dom.DragEvent
+import org.w3c.dom.get
+import org.w3c.dom.events.Event
+import org.w3c.dom.events.EventListener as EventListenerInterface
 
+/**
+ * Compose's own `Modifier.dragAndDropTarget` cannot carry this on wasmJs: measured against CMP
+ * 1.10.3, an external file drag reaches `shouldStartDragAndDrop` and `onStarted` with the DOM
+ * `DataTransfer` attached, but `onEntered`/`onMoved` arrive with a null one and `onDrop` is never
+ * dispatched at all — so neither the hover preview nor the payload is reachable through it.
+ */
 @Composable
 actual fun Modifier.fileDropTarget(
     enabled: Boolean,
     onDragPreviewChanged: (FileDropPreview?) -> Unit,
     onFilesDropped: (List<PlatformFile>) -> Unit,
-): Modifier = this
+): Modifier {
+    val previewChanged = rememberUpdatedState(onDragPreviewChanged)
+    val filesDropped = rememberUpdatedState(onFilesDropped)
+    val density = LocalDensity.current.density
+    val bounds = remember { DropBounds() }
+
+    DisposableEffect(enabled, density) {
+        if (!enabled) return@DisposableEffect onDispose { }
+        var depth = 0
+        var showing = false
+
+        fun clear() {
+            depth = 0
+            if (showing) {
+                showing = false
+                previewChanged.value(null)
+            }
+        }
+
+        // Without preventDefault on both dragenter and dragover the browser never fires drop and
+        // navigates to the file instead.
+        val entered = EventListener {
+            it.preventDefault()
+            depth++
+        }
+        val moved = EventListener { event ->
+            event.preventDefault()
+            val over = bounds.covers(event.scenePosition(density))
+            if (over && !showing) {
+                // Anything without a file item — a dragged text selection, a link — is not ours.
+                val items = event.items().map { it.describe() }
+                if (items.any { it.kind == "file" }) {
+                    showing = true
+                    previewChanged.value(dropPreviewOf(items))
+                }
+            } else if (!over && showing) {
+                showing = false
+                previewChanged.value(null)
+            }
+        }
+        // dragenter for the element being entered fires before dragleave for the one being left,
+        // so only a zero depth means the drag really left the page.
+        val left = EventListener {
+            depth--
+            if (depth <= 0) clear()
+        }
+        val dropped = EventListener { event ->
+            event.preventDefault()
+            // Only take a drop we actually offered to accept, so a dragged selection landing on
+            // the chat doesn't report an empty attachment.
+            val accept = showing && bounds.covers(event.scenePosition(density))
+            clear()
+            if (accept) {
+                filesDropped.value(
+                    event.items()
+                        .filter { it.kind == "file" && !isDirectoryEntry(it) }
+                        .mapNotNull { it.getAsFile() }
+                        .map { PlatformFile(it) },
+                )
+            }
+        }
+        val ended = EventListener { clear() }
+
+        window.addEventListener("dragenter", entered)
+        window.addEventListener("dragover", moved)
+        window.addEventListener("dragleave", left)
+        window.addEventListener("drop", dropped)
+        window.addEventListener("dragend", ended)
+        onDispose {
+            window.removeEventListener("dragenter", entered)
+            window.removeEventListener("dragover", moved)
+            window.removeEventListener("dragleave", left)
+            window.removeEventListener("drop", dropped)
+            window.removeEventListener("dragend", ended)
+        }
+    }
+
+    return this.onGloballyPositioned { bounds.rect = it.boundsInWindow() }
+}
+
+// A plain holder, not a MutableState: the layout write has to be visible to a DOM callback
+// immediately, and a snapshot write is only published when the next Compose frame commits — which
+// on an idle web scene can be after the drag has already started.
+private class DropBounds {
+    var rect = Rect.Zero
+
+    // An unmeasured rect accepts anywhere: the web scene defers layout until a frame is driven,
+    // and on a freshly loaded page the drag itself drives the first one, so the opening dragover
+    // would otherwise be swallowed.
+    fun covers(point: Offset) = rect.isEmpty || rect.contains(point)
+}
+
+// offsetX/offsetY are CSS pixels against the canvas the event landed on, the same origin
+// boundsInWindow reports against once scaled by the scene density.
+private fun Event.scenePosition(density: Float): Offset {
+    val event = this as DragEvent
+    return Offset(event.offsetX.toFloat() * density, event.offsetY.toFloat() * density)
+}
+
+private fun Event.items(): List<DataTransferItem> {
+    val list = (this as DragEvent).dataTransfer?.items ?: return emptyList()
+    return (0 until list.length).mapNotNull { list[it] }
+}
+
+private fun DataTransferItem.describe() =
+    DropItem(kind = kind, mimeType = type, isDirectory = isDirectoryEntry(this))
+
+// A dragged directory is a "file" item with an empty type; only the entry tells them apart, and
+// browsers withhold it until the drop.
+@Suppress("UNUSED_PARAMETER")
+private fun isDirectoryEntry(item: DataTransferItem): Boolean = js(
+    """{
+        var entry = item.webkitGetAsEntry ? item.webkitGetAsEntry() : null;
+        return !!(entry && entry.isDirectory);
+    }"""
+)
+
+// EventListener is a bare interface on wasm, so the lambda needs a JS wrapper.
+@Suppress("UNUSED_PARAMETER")
+private fun EventListener(handler: (Event) -> Unit): EventListenerInterface =
+    js("(event) => { handler(event) }")


### PR DESCRIPTION
Web was the only browser-capable target still stubbed out to `Modifier` unchanged, while the whole
drop UI — `FileDropPreview`, `FileDropOverlay`, its strings and plurals, and the wiring into
`ConversationContent`'s `Scaffold` — already lived in `commonMain` and shipped on Desktop. This
fills in the wasmJs actual, so dragging files onto the chat in a browser shows the same overlay and
attaches the same files.

## Which path, and why

I first tried mirroring the JVM actual with Compose's own `Modifier.dragAndDropTarget`, because CMP
1.10.3 *does* ship a `WebDragAndDropManager` that registers `dragstart`/`dragenter`/`dragover`/`drop`
on the Compose canvas and explicitly routes external drags into the target pipeline. That much is
real. But instrumenting a live build showed the target callbacks are only half-fed:

| callback | fires? | `transferData` |
|---|---|---|
| `shouldStartDragAndDrop` | yes (dragenter) | present, 3 items, correct kinds/MIME |
| `onStarted` | yes (dragenter) | present, 3 items |
| `onEntered` | yes (from the dragover pass) | **null**, 0 items |
| `onMoved` | yes | **null**, 0 items |
| `onDrop` | **never** | — |
| `onEnded` | **never** | — |

The cause is visible in CMP's source: the `dragover` handler builds `DragAndDropEvent(offset, null)`,
so everything downstream of it is blind, and the drop never reaches the target at all. Neither the
hover preview nor the payload is obtainable that way, so the actual is built on document-level DOM
listeners instead. Compose's `dragAndDropTarget` is not used.

## Browser quirks handled

- **`DataTransfer.files` is empty during dragenter/dragover by spec.** The hover preview is built
  from `dataTransfer.items`, where `kind` and `type` are readable pre-drop. Measured: hovering three
  images reports 3 items with `image/png`/`image/jpeg` and `files.length == 0`; at drop, `files.length == 3`.
- **`preventDefault` on both `dragenter` and `dragover`**, without which the browser never fires
  `drop` and navigates to the file.
- **Folders.** A dragged directory is a `kind == "file"` item with an empty `type`; only
  `webkitGetAsEntry()?.isDirectory` tells them apart. Measured in Chromium 152: that entry is
  withheld until the drop, so a folder cannot be identified while hovering. Consequence: a folder
  counts toward the hover total, and is filtered out at drop. Dropping a folder alongside two files
  attaches exactly the two files; dropping only a folder yields an empty list, which the existing
  call site already turns into the "folders can't be sent" snackbar. The `Rejected` card is
  therefore not reachable on web today — it stays correct in the classifier for browsers that expose
  the entry earlier.
- **`dragleave` flicker.** `dragenter` for the next element fires before `dragleave` for the previous
  one, so a depth counter clears only at zero.
- **Leaving the window.** Verified with a real browser-generated `dragleave` (a `dragOver` past the
  viewport edge): the overlay clears rather than being stranded.
- **Scoping and coordinates.** The composable's rect comes from `onGloballyPositioned`/`boundsInWindow`,
  and the pointer from the DOM event's `offsetX`/`offsetY` (CSS px against the canvas) scaled by the
  scene density — the same conversion CMP does internally.
- **The rect is a plain holder, not a `MutableState`.** A snapshot write is only published when the
  next Compose frame commits, and the web scene defers layout until a frame is driven — measured:
  even six seconds after load, the first `dragover` still read `Rect.Zero`. An unmeasured rect
  therefore accepts anywhere rather than swallowing the opening event.
- **Non-file drags are ignored.** A dragged text selection shows no overlay and delivers no drop, so
  it can't trip the empty-attachment snackbar.

## Tests

The DOM plumbing isn't unit-testable; the classification is. `dropPreviewOf(List<DropItem>)` in
`commonMain` is a pure function from item descriptors to a `FileDropPreview`, covered by
`DropPreviewTest` (all-images, mixed, zero items, a dragged text selection, folders, a folder mixed
in with files, an untyped file). It runs on JVM CI inside `homebase-chat:jvmTest`.

Mutation check: dropping the `!it.isDirectory` filter and replacing
`count { it.mimeType.startsWith("image/") }` with `attachable.size` failed 4 of the 7 cases
(`mixedCountsOnlyTheImages`, `anUntypedFileStillCounts`, `aFolderDoesNotCountTowardsTheFilesBesideIt`,
`foldersAreRejected`). Restored, all 7 pass.

## Verified in a real browser

Driven through the Chrome DevTools Protocol against Chromium 152, using `Input.dispatchDragEvent`
with real absolute file paths — the browser materialises genuine `File` objects, so `DataTransfer`
protected mode, MIME sniffing and `webkitGetAsEntry` all behave as they do for an OS drag.

| drag | overlay | drop |
|---|---|---|
| 3 images | image icon, "Drop to attach / 3 images" (screenshotted) | `alpha.png, beta.png, gamma.jpg` |
| png + txt + folder | file icon, "Drop to attach / 3 files" (screenshotted) | `alpha.png, notes.txt` — folder filtered |
| folder only | "1 file" | empty list → existing snackbar path |
| image, dragged back out of the viewport | appears, then clears | — |
| text selection | none | none |

Scope of that check, stated plainly: the drag ran against a **temporary standalone Compose page**
that mounted `Modifier.fileDropTarget` + `FileDropOverlay` directly, not the logged-in chat screen —
reaching a real conversation needs a Homebase identity session. The harness was reverted and is not
part of this diff. The `ConversationContent` wiring it feeds is pre-existing `commonMain` code shared
with Desktop and was not modified. I did not perform a physical mouse drag from Finder, and I did not
see the "folders can't be sent" card on screen — it is unreachable in Chromium for the reason above.

Also compiled clean: `:homebase-chat:compileKotlinWasmJs`, `:compileKotlinJvm`, `:compileAndroidMain`,
`:compileKotlinIosSimulatorArm64` (the `expect` declaration's comment changed, so the other actuals
were rebuilt), `:webApp:compileDevelopmentExecutableKotlinWasmJs`, and
`homebase-chat:jvmTest homebase-common:jvmTest homebase-api:jvmTest --rerun-tasks`.
