### PR TITLE
Fix chat media auto-save: exact-match chat_web and gate on message dataType (#1496)

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMediaAutoSaveRules.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMediaAutoSaveRules.kt
@@ -11,6 +11,7 @@ const val HLS_PLAYLIST_CONTENT_TYPE = "application/vnd.apple.mpegurl"
  */
 fun shouldAutoSave(
     payload: PayloadDescriptor,
+    messageDataType: Int?,
     isIncoming: Boolean,
     isSoftDeleted: Boolean,
     autoSaveEnabled: Boolean,
@@ -26,6 +27,10 @@ fun shouldAutoSave(
     // Only what arrived after the switch was flipped: the recent-message window the sync lane
     // rescans still holds older media the user never asked to have copied into their album.
     if (messageTimestampMs < enabledSinceMs) return false
+    // Only plain messages carry user attachments. An Event cover photo (210) and a shared
+    // contact's photo (215) are keyed `chat_web0` too, so the payload key alone cannot tell
+    // them from a first attachment.
+    if ((messageDataType ?: 0) != 0) return false
     if (isNonMediaPayloadKey(payload.key)) return false
 
     val contentType = payload.contentType ?: return false
@@ -47,12 +52,14 @@ fun shouldAutoSave(
 
 /**
  * Payload keys that carry app plumbing rather than a photo the user would want in their album:
- * the message body overflow and event cover photos (`chat_web` keys), link and location previews
- * (both of which carry an image content type), and the two descriptor slots.
+ * the message body overflow (`dflt_key`), link and location previews (both of which carry an
+ * image content type), and the two descriptor slots. Matched exactly, as every other chat media
+ * filter does — user attachments are keyed `chat_web<index>`, and a prefix match on `chat_web`
+ * would swallow all of them.
  */
 private fun isNonMediaPayloadKey(key: String): Boolean =
     key == ChatProtocol.DefaultPayloadKey ||
         key == ChatProtocol.PAYLOAD_KEY_LINKS ||
         key == ChatProtocol.PAYLOAD_KEY_LOCATION ||
-        key.startsWith(ChatProtocol.PAYLOAD_KEY_MESSAGE_WEB) ||
+        key == ChatProtocol.PAYLOAD_KEY_MESSAGE_WEB ||
         key.startsWith(ChatProtocol.DEFAULT_PAYLOAD_DESCRIPTOR_KEY)

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMediaAutoSaveService.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/ChatMediaAutoSaveService.kt
@@ -115,6 +115,7 @@ class ChatMediaAutoSaveService(
                         dbm.autoSavedMedia.isSaved(file.fileId.toString(), payload.key)
                     val save = shouldAutoSave(
                         payload = payload,
+                        messageDataType = file.fileMetadata.appData.dataType,
                         isIncoming = isIncoming,
                         isSoftDeleted = file.isSoftDeleted(),
                         autoSaveEnabled = enabled,

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMediaAutoSaveRulesTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/ChatMediaAutoSaveRulesTest.kt
@@ -7,10 +7,13 @@ import kotlin.test.assertTrue
 
 class ChatMediaAutoSaveRulesTest {
 
-    private val photo = PayloadDescriptor(key = "chat_img0", contentType = "image/jpeg")
+    // Every user attachment is keyed chat_web<index> — the keys the send path actually emits,
+    // so a green suite means the feature works.
+    private val photo = PayloadDescriptor(key = "chat_web0", contentType = "image/jpeg")
 
     private fun decide(
         payload: PayloadDescriptor = photo,
+        messageDataType: Int? = 0,
         isIncoming: Boolean = true,
         isSoftDeleted: Boolean = false,
         autoSaveEnabled: Boolean = true,
@@ -21,6 +24,7 @@ class ChatMediaAutoSaveRulesTest {
         enabledSinceMs: Long = 1_000L,
     ) = shouldAutoSave(
         payload = payload,
+        messageDataType = messageDataType,
         isIncoming = isIncoming,
         isSoftDeleted = isSoftDeleted,
         autoSaveEnabled = autoSaveEnabled,
@@ -36,22 +40,42 @@ class ChatMediaAutoSaveRulesTest {
 
     @Test
     fun incomingVideoIsSaved() =
-        assertTrue(decide(payload = PayloadDescriptor(key = "chat_vid0", contentType = "video/mp4")))
+        assertTrue(decide(payload = PayloadDescriptor(key = "chat_web0", contentType = "video/mp4")))
+
+    @Test
+    fun secondAttachmentIsSaved() =
+        assertTrue(decide(payload = PayloadDescriptor(key = "chat_web3", contentType = "image/jpeg")))
+
+    @Test
+    fun aMessageWithNoDataTypeIsPlainAndIsSaved() = assertTrue(decide(messageDataType = null))
 
     @Test
     fun settingOffSavesNothing() = assertFalse(decide(autoSaveEnabled = false))
 
     @Test
     fun nonMediaContentTypeIsSkipped() =
-        assertFalse(decide(payload = PayloadDescriptor(key = "chat_doc0", contentType = "application/pdf")))
+        assertFalse(decide(payload = PayloadDescriptor(key = "chat_web0", contentType = "application/pdf")))
 
     @Test
     fun missingContentTypeIsSkipped() =
-        assertFalse(decide(payload = PayloadDescriptor(key = "chat_img0", contentType = null)))
+        assertFalse(decide(payload = PayloadDescriptor(key = "chat_web0", contentType = null)))
 
     @Test
-    fun messageBodyOverflowIsSkipped() =
-        assertFalse(decide(payload = PayloadDescriptor(key = "chat_web0", contentType = "image/jpeg")))
+    fun bareMessageWebKeyIsSkipped() =
+        assertFalse(decide(payload = PayloadDescriptor(key = "chat_web", contentType = "image/jpeg")))
+
+    @Test
+    fun eventCoverPhotoIsSkipped() = assertFalse(
+        decide(messageDataType = ChatProtocol.ChatEventMessageDataType)
+    )
+
+    @Test
+    fun contactCardPhotoIsSkipped() = assertFalse(
+        decide(messageDataType = ChatProtocol.ChatContactCardMessageDataType)
+    )
+
+    @Test
+    fun anUnrecognisedTypedKindIsSkipped() = assertFalse(decide(messageDataType = 9_999))
 
     @Test
     fun linkPreviewIsSkipped() =
@@ -73,7 +97,7 @@ class ChatMediaAutoSaveRulesTest {
     fun stickerIsSkipped() = assertFalse(
         decide(
             payload = PayloadDescriptor(
-                key = "chat_img0",
+                key = "chat_web0",
                 contentType = "image/png",
                 descriptorContent = """{"isSticker":true}""",
             )
@@ -91,14 +115,14 @@ class ChatMediaAutoSaveRulesTest {
 
     @Test
     fun hlsPlaylistIsSkipped() = assertFalse(
-        decide(payload = PayloadDescriptor(key = "chat_vid0", contentType = HLS_PLAYLIST_CONTENT_TYPE))
+        decide(payload = PayloadDescriptor(key = "chat_web0", contentType = HLS_PLAYLIST_CONTENT_TYPE))
     )
 
     @Test
     fun segmentedVideoIsSkipped() = assertFalse(
         decide(
             payload = PayloadDescriptor(
-                key = "chat_vid0",
+                key = "chat_web0",
                 contentType = "video/mp4",
                 descriptorContent = """{"mimeType":"video/mp4","isSegmented":true}""",
             )


### PR DESCRIPTION
Closes #1496.

> Branched from `feat-1154-media-settings`, but #1482 squash-merged into `main` (`bf5cc32d9`) before
> this PR was opened and its branch was deleted, so the single fix commit is rebased onto `main` and
> this targets `main`. The three touched files were byte-identical between `main` and the pre-fix
> base, and the rebase changed none of them.

Auto-save of incoming chat media was a complete no-op. `shouldAutoSave` excluded
`key.startsWith(ChatProtocol.PAYLOAD_KEY_MESSAGE_WEB)`, and `PAYLOAD_KEY_MESSAGE_WEB` is
`"chat_web"` — the prefix of the key **every** user attachment uses. Nothing was ever eligible.

## What I confirmed from the issue

- `MessageActionsHandler.kt:777`, `:886`, `:1037` all build `"${ChatProtocol.PAYLOAD_KEY_MESSAGE_WEB}$index"` → `chat_web0`, `chat_web1`, … Confirmed.
- `ChatProtocol.kt:156` — `PAYLOAD_KEY_MESSAGE_WEB = "chat_web"`. Confirmed.
- `MessageBubble.kt:533-538` and `MediaDownloadHandler.kt:118-123` filter with `.contains(it.key)` against the bare constant — an **exact** match. The rest of the codebase treats `chat_web<N>` as genuine user media; only the auto-save rule used a prefix match. Confirmed.
- `EventComposerSheet.kt:299` sets `payloadKey = PAYLOAD_KEY_MESSAGE_WEB + "0"` — an event cover photo really is `chat_web0`, indistinguishable from a first attachment by key. Confirmed.
- `ChatMediaAutoSaveRulesTest.kt:54` asserted the bug was correct behaviour. Confirmed and corrected.

## What I found different

**1. A second cover-photo case the issue didn't name: shared contact cards.**
`ShareContactPickerViewModel.kt:168` also uses `PAYLOAD_KEY_MESSAGE_WEB + "0"` for the shared
contact's profile photo, and `ContactCardPhoto.kt:15` says so outright: *"Shares the Event cover's
key because every generic media surface already filters `chat_web*`."* A fix that only excluded
Event (210) would have started writing strangers' profile pictures into the camera roll.

**2. The long-message body overflow does NOT use a bare `"chat_web"` key — it uses `dflt_key`.**
`ChatMessageSenderService.kt:1024` writes the overflow as
`PayloadFile(key = ChatProtocol.DefaultPayloadKey, …)`, and `EditCoalesce.kt:19` calls it
"the text-overflow payload (`ChatProtocol.DefaultPayloadKey`)". No production code anywhere emits a
bare `"chat_web"`. So the overflow was already excluded by the existing exact `== DefaultPayloadKey`
check, and the old KDoc claiming the overflow rides on a `chat_web` key was simply wrong — corrected
in this PR. The bare-key exclusion is kept anyway (as an exact match, matching the two sibling
filters) in case an older client ever put one on the wire; `bareMessageWebKeyIsSkipped` pins it.

**3. The positive tests were testing keys that don't exist.**
`incomingPhotoIsSaved` used `chat_img0` and `incomingVideoIsSaved` used `chat_vid0` — keys the send
path never emits. That is *why* all 20 tests passed against a dead feature. Every test now uses the
real `chat_web<N>` keys, so a green suite means the rule actually admits real media.

## The discriminator: message `dataType`, allow-list on 0

The payload key cannot separate the three cases — a first attachment, an Event cover, and a
ContactCard photo are all literally `chat_web0`. The message kind can:

| kind | dataType | carries `chat_web*`? |
|---|---|---|
| plain text/media | 0 (or null) | yes — real attachments |
| status | 202 | no |
| Event | 210 | yes — cover photo |
| Location | 211 | no (`chat_loc`) |
| DiceRoll / Groodle / Poll | 212 / 213 / 214 | no |
| ContactCard | 215 | yes — contact photo |

`shouldAutoSave` now takes `messageDataType: Int?` and returns false for anything non-zero;
`ChatMediaAutoSaveService` passes `file.fileMetadata.appData.dataType`.

**Allow-list rather than a deny-list of `{210, 215}`**, for the same number of lines: it is the
existing meaning of `dataType` (`MessageContentParser`: "0 = plain text/media"), and any future typed
kind that decides to hang a cover photo off `chat_web0` is excluded by default rather than silently
leaking into the camera roll until someone remembers to update this list. Null is treated as 0, which
is what every other consumer does (`ChatMessageSenderService.kt:749`, `:811`, `:856`).

I checked the one place a media message could plausibly pick up a non-zero dataType —
`MessageActionsHandler.kt:1151`/`:1228` pass `payloadRenderers.toMessageDataType()` — and it cannot
produce a false negative: `PayloadRenderer` has exactly two subtypes (`LinkPreviewRenderer`,
`LocationPreviewRenderer`) whose payloads are `chat_links` / `chat_loc`
(`PayloadRendererBundle.kt:33-36`), and those are the renderer-only send paths. The attachment paths
(`addMessageWithFiles`, `ShareReceiverActivity`) never pass a dataType at all — `grep -n dataType`
on both returns nothing for the attachment sites.

## Exclusions verified as still holding

Each has a test, all green: `dflt_key` body overflow, bare `chat_web`, `chat_links` link previews,
`chat_loc` location previews, `pld_desc*` descriptor slots, stickers (`isSticker`), own outgoing
messages, soft-deleted messages, already-saved payloads, HLS playlists, segmented video, the metered
guard both ways, and the enabled-since backfill floor — plus the two new cover-photo exclusions and
an unrecognised typed kind.

## Mutation check

Both new guards were broken independently and the right tests failed.

**Mutation 1 — restore `key.startsWith(PAYLOAD_KEY_MESSAGE_WEB)`** (i.e. put the bug back):

```
ChatMediaAutoSaveRulesTest[jvm] > secondAttachmentIsSaved[jvm] FAILED
ChatMediaAutoSaveRulesTest[jvm] > incomingVideoIsSaved[jvm] FAILED
ChatMediaAutoSaveRulesTest[jvm] > mediaAtTheMomentOfEnablingIsSaved[jvm] FAILED
ChatMediaAutoSaveRulesTest[jvm] > aMessageWithNoDataTypeIsPlainAndIsSaved[jvm] FAILED
ChatMediaAutoSaveRulesTest[jvm] > incomingPhotoIsSaved[jvm] FAILED
ChatMediaAutoSaveRulesTest[jvm] > meteredNetworkIsSavedOnceTheWifiGuardIsOff[jvm] FAILED
25 tests completed, 6 failed
```

(Under the old `chat_img0` test keys this mutation failed **zero** tests — that is the regression gap
this PR closes.)

**Mutation 2 — delete the `if ((messageDataType ?: 0) != 0) return false` guard:**

```
ChatMediaAutoSaveRulesTest[jvm] > anUnrecognisedTypedKindIsSkipped[jvm] FAILED
ChatMediaAutoSaveRulesTest[jvm] > eventCoverPhotoIsSkipped[jvm] FAILED
ChatMediaAutoSaveRulesTest[jvm] > contactCardPhotoIsSkipped[jvm] FAILED
25 tests completed, 3 failed
```

Both mutations reverted; the tree below is the restored state.

## Verification

Re-run after the rebase onto `main`.

`./gradlew homebase-chat:jvmTest homebase-common:jvmTest homebase-core:jvmTest homebase-api:jvmTest --rerun-tasks` → `BUILD SUCCESSFUL in 4m 11s`

```
homebase-chat:   tests=1386 failures=0 errors=0 skipped=6
homebase-common: tests=613  failures=0 errors=0 skipped=0
homebase-core:   tests=673  failures=0 errors=0 skipped=2
homebase-api:    tests=1250 failures=0 errors=0 skipped=0
```

3922 tests, 0 failures. `ChatMediaAutoSaveRulesTest` is 25 tests (was 20).

`./gradlew :homebase-chat:compileKotlinJvm :homebase-chat:compileAndroidMain :homebase-chat:compileKotlinWasmJs :homebase-chat:compileKotlinIosSimulatorArm64` → `BUILD SUCCESSFUL in 2m 8s` (all four targets).

## Still open — NOT verified

End-to-end device verification has **not** been done. This PR is unit-verified only; the rule is now
correct against the keys production emits, but nothing has been observed writing to a real camera
roll. Still required from #1496's acceptance criteria:

- [ ] An incoming chat photo from a real second identity is written to the album.
- [ ] An incoming chat video (non-segmented) is written.
- [ ] An incoming Event cover photo is **not** written.
- [ ] An incoming shared-contact-card photo is **not** written (the case this PR adds).
- [ ] Dedupe: reacting to an already-saved photo does not re-save it (`BatchReceived` re-fires on reactions).
- [ ] The enabled-since backfill guard — #1496 notes the earlier "pass" was a false pass, since nothing was eligible to save. It has still never actually been exercised.

Diffstat: 3 files, +44 −12. No changes to AlbumSaver, NetworkMonitor, the AutoSavedMedia dedupe, or the settings screen.
