### PR TITLE
Make the developer Test notification button work on web

### DIFF
--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/notifications/WebPush.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/notifications/WebPush.kt
@@ -33,6 +33,32 @@ interface WebPushBridge {
 
     /** Delivers the raw notification JSON a service-worker click posted back to the page. */
     fun onNotificationClick(handler: (String) -> Unit)
+
+    /**
+     * Developer menu only — a server push is displayed by `sw.js` and never reaches Kotlin.
+     * Returns null when the browser accepted it, else a code for [describeWebNotificationFailure].
+     */
+    suspend fun showLocalNotification(title: String, body: String): String?
+}
+
+/**
+ * Turns a [WebPushBridge.showLocalNotification] failure into a message that says which of
+ * "notifications can't display here" and "delivery is broken" the developer is looking at.
+ */
+fun describeWebNotificationFailure(code: String): String = when (code) {
+    "NotAllowedError" ->
+        "Notifications are blocked for this site — re-allow them in the browser's site settings"
+    "PermissionNotGranted" ->
+        "Notification permission not granted yet — enable notifications in Settings first"
+    "NeedsInstall" ->
+        "iOS Safari shows notifications only once the app is added to the Home Screen"
+    "Unsupported" ->
+        "This browser can't show notifications (needs HTTPS plus service worker support)"
+    "NoServiceWorker" ->
+        "No service worker registered — sw.js failed to load"
+    "TimeoutError" ->
+        "The browser never answered the showNotification call"
+    else -> "The browser refused to show the notification: $code"
 }
 
 expect fun webPushBridge(): WebPushBridge?

--- a/homebase-common/src/jvmTest/kotlin/id/homebase/core/notifications/WebNotificationFailureTest.kt
+++ b/homebase-common/src/jvmTest/kotlin/id/homebase/core/notifications/WebNotificationFailureTest.kt
@@ -1,0 +1,31 @@
+package id.homebase.core.notifications
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * The developer test button exists to tell "notifications can't display here" apart from
+ * "display works, delivery is broken", so every failure has to read as its own thing and an
+ * unrecognised DOMException.name must not be swallowed into a generic message.
+ */
+class WebNotificationFailureTest {
+
+    @Test
+    fun `each known failure gets its own message`() {
+        val codes = listOf(
+            "NotAllowedError",
+            "PermissionNotGranted",
+            "NeedsInstall",
+            "Unsupported",
+            "NoServiceWorker",
+            "TimeoutError",
+        )
+        assertEquals(codes.size, codes.map { describeWebNotificationFailure(it) }.toSet().size)
+    }
+
+    @Test
+    fun `an unrecognised DOMException name survives into the message`() {
+        assertTrue(describeWebNotificationFailure("TypeError").contains("TypeError"))
+    }
+}

--- a/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/notifications/WebPush.web.kt
+++ b/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/notifications/WebPush.web.kt
@@ -30,6 +30,9 @@ private fun pushUnsubscribe(): Promise<JsAny?> = js("globalThis.__odinPush.unsub
 
 private fun pushOnClick(cb: (String) -> Unit): Unit = js("globalThis.__odinPush.onClick(cb)")
 
+private fun pushShowLocalNotification(title: String, body: String): Promise<JsString> =
+    js("globalThis.__odinPush.showLocalNotification(title, body)")
+
 private fun hasPushBridge(): Boolean = js("typeof globalThis.__odinPush !== 'undefined'")
 
 actual fun webPushBridge(): WebPushBridge? = if (hasPushBridge()) BrowserPushBridge else null
@@ -56,6 +59,11 @@ private object BrowserPushBridge : WebPushBridge {
 
     override fun onNotificationClick(handler: (String) -> Unit) {
         pushOnClick(handler)
+    }
+
+    override suspend fun showLocalNotification(title: String, body: String): String? {
+        val raw = pushShowLocalNotification(title, body).await<JsString>().toString()
+        return if (raw == "ok") null else raw.split(";", limit = 2).getOrNull(1) ?: "Error"
     }
 }
 

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/devmenu/DeveloperMenuViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/devmenu/DeveloperMenuViewModel.kt
@@ -21,9 +21,12 @@ import id.homebase.api.youauth.YouAuthFlowManager
 import id.homebase.core.config.locationLabeledDrive
 import id.homebase.core.notifications.RichNotificationData
 import id.homebase.core.notifications.RichNotificationDisplayer
+import id.homebase.core.notifications.describeWebNotificationFailure
+import id.homebase.core.notifications.webPushBridge
 import id.homebase.core.ui.screens.location.model.LOCATION_POINTS_PAYLOAD_KEY
 import id.homebase.core.ui.screens.location.model.LOCATION_TRACK_FILE_TYPE
 import id.homebase.core.ui.screens.location.model.LocationTrackCodec
+import id.homebase.core.util.isWeb
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -117,7 +120,28 @@ class DeveloperMenuViewModel(
             silent = false,
         )
 
-        RichNotificationDisplayer().show(richData)
+        if (!isWeb()) {
+            RichNotificationDisplayer().show(richData)
+            return
+        }
+
+        // Web is the one target where the displayer is a deliberate no-op (sw.js owns every push),
+        // so the button routes to the same registration sw.js displays through and reports why not.
+        val bridge = webPushBridge()
+        if (bridge == null) {
+            sendEvent(DeveloperMenuUiEvent.Error("Push bridge missing — odin-push.js did not load"))
+            return
+        }
+        viewModelScope.launch {
+            val failure = bridge.showLocalNotification(richData.title, richData.body)
+            sendEvent(
+                if (failure == null) {
+                    DeveloperMenuUiEvent.Success("Notification handed to the browser")
+                } else {
+                    DeveloperMenuUiEvent.Error(describeWebNotificationFailure(failure))
+                }
+            )
+        }
     }
 
     /**

--- a/webApp/src/wasmJsMain/resources/odin-push.js
+++ b/webApp/src/wasmJsMain/resources/odin-push.js
@@ -16,6 +16,14 @@
   var registrationPromise = null;
   var clickHandler = null;
 
+  // capability() values that cannot show anything, as the code the Kotlin side maps to a message.
+  var NOT_GRANTED_CODE = {
+    denied: 'NotAllowedError',
+    'default': 'PermissionNotGranted',
+    'needs-install': 'NeedsInstall',
+    unsupported: 'Unsupported',
+  };
+
   function isIosLike() {
     var ua = navigator.userAgent || '';
     return /iPad|iPhone|iPod/.test(ua) ||
@@ -156,6 +164,23 @@
           return sub ? sub.unsubscribe() : null;
         });
       }).catch(function () { return null; });
+    },
+
+    // Developer menu only — never on the push path, which sw.js displays. showNotification() on
+    // the registration rather than `new Notification(...)`: the constructor is unsupported on
+    // Android Chrome and deprecated wherever a worker is registered.
+    showLocalNotification: function (title, body) {
+      var cap = capability();
+      if (cap !== 'granted') return Promise.resolve('err;' + (NOT_GRANTED_CODE[cap] || 'Unsupported'));
+      return withTimeout(registration().then(function (reg) {
+        if (!reg) return 'err;NoServiceWorker';
+        return reg.showNotification(title, {
+          body: body,
+          icon: new URL('icon-192.png', document.baseURI).href,
+          tag: 'odin-dev-test',
+          renotify: true,
+        }).then(function () { return 'ok'; });
+      }).catch(fail));
     },
 
     onClick: function (handler) {


### PR DESCRIPTION
Stacked on #1489 (`feat-1359-web-push`) — the `__odinPush` bridge this extends lives there.

## What the button does now

`Developer menu → Test notification` was a silent no-op on wasmJs: `RichNotificationDisplayer.web.kt` is an empty `show()`, so pressing the button did nothing and said nothing.

`DeveloperMenuViewModel.testRichNotification()` now branches on `isWeb()`. Off web it calls `RichNotificationDisplayer().show(richData)` exactly as before. On web it calls a new `WebPushBridge.showLocalNotification(title, body)`, which reaches `ServiceWorkerRegistration.showNotification()` through the existing `globalThis.__odinPush` bridge — the same registration `sw.js` displays pushes through, and deliberately not the bare `new Notification(...)` constructor, which is unsupported on Android Chrome and deprecated wherever a worker is registered.

The `RichNotificationData` fields that map: `title` → notification title, `body` → `options.body`. Plus `icon: icon-192.png` (resolved against `document.baseURI`, so the `-PpublicPath=/apps/chat-wasm/` mount keeps working) and a fixed `tag` with `renotify: true`, so repeated presses replace rather than stack. Nothing else in `RichNotificationData` has a browser equivalent, and no new fields were invented.

## Why the live push path is provably unaffected

- **`sw.js` is not touched** — no change to its `push` or `notificationclick` handler. `git diff` for this PR lists four files plus one new test; `sw.js` is not among them.
- **`RichNotificationDisplayer.web.kt` is not touched.** It stays an empty `show()` and its rationale stays true: `userVisibleOnly: true` obliges the worker to display a notification for every push, and no push path reaches Kotlin on web.
- **The other three `RichNotificationDisplayer` actuals are not touched** (android / jvm / native).
- **No second display path for a push.** `showLocalNotification` is reachable from exactly one call site — `DeveloperMenuViewModel.testRichNotification()`. It is not wired into `WebPushService`, `NotificationService`, `NotificationClickRouter`, or anything the `push` event runs. A server push cannot enter it, so it cannot double-display.
- The bridge additions are purely additive: one new key on the `__odinPush` object, one new file-private `js("…")` in `WebPush.web.kt`, one new interface method. No existing JS function or Kotlin override was edited. The `WebPushBridge` interface has exactly one implementation (`BrowserPushBridge`); the three non-web `webPushBridge()` actuals still `return null`, so Android/iOS/Desktop see no behaviour change at all.
- `PermissionsManager.web.kt` is untouched (that's #1498).

## Failure modes and the exact message the developer sees

Silence was the one unacceptable outcome, so every path ends in a snackbar. Following the `odin-push.js` house rule, the JS side **resolves** rather than rejects — awaiting a rejected JS promise on kotlinx-coroutines 1.10.2 collapses the `DOMException.name` into a generic `IllegalStateException`, and the name is the whole diagnostic.

| Condition | Code across the bridge | Snackbar |
|---|---|---|
| Notification shown | `ok` | `Notification handed to the browser` (Success) |
| `Notification.permission === "denied"` | `NotAllowedError` | `Notifications are blocked for this site — re-allow them in the browser's site settings` |
| Permission still `default` | `PermissionNotGranted` | `Notification permission not granted yet — enable notifications in Settings first` |
| iOS Safari tab, not Home-Screen installed | `NeedsInstall` | `iOS Safari shows notifications only once the app is added to the Home Screen` |
| No SW / PushManager / secure context | `Unsupported` | `This browser can't show notifications (needs HTTPS plus service worker support)` |
| `sw.js` failed to register | `NoServiceWorker` | `No service worker registered — sw.js failed to load` |
| Bridge never resolved (30s) | `TimeoutError` | `The browser never answered the showNotification call` |
| `showNotification()` threw anything else | the raw `DOMException.name` | `The browser refused to show the notification: <name>` |
| `odin-push.js` did not load at all | — (`webPushBridge()` is null on web) | `Push bridge missing — odin-push.js did not load` |

The unknown-name row is the point: an unrecognised `DOMException.name` is passed through verbatim rather than swallowed into a generic message.

This is what makes the Brave case readable. Brave ships *"Use Google services for push messaging"* off by default, so `pushManager.subscribe()` rejects with `AbortError` while local display works fine. With this button, a visible test notification plus a failing subscribe says "display is fine, delivery is broken"; a failing test notification says the display side is the problem. Nothing here detects or special-cases Brave.

## Test

`WebNotificationFailureTest` (homebase-common jvmTest, 2 cases) covers the one pure decision added, `describeWebNotificationFailure`: that every known code gets a distinct message, and that an unrecognised `DOMException.name` survives into the message. Both were mutation-checked — collapsing `NoServiceWorker` onto the `Unsupported` message failed the first test only, and dropping `$code` from the fallback failed the second test only; the original was restored and both pass.

The DOM call itself has no unit-testable seam and none was invented for it.

## Verification — all run, output seen

- `./gradlew homebase-common:jvmTest homebase-core:jvmTest --rerun-tasks` — **BUILD SUCCESSFUL**. homebase-common 619 tests, homebase-core 675 tests, 0 failures / 0 errors. Includes the Konsist `ArchitectureTest`.
- `./gradlew :homebase-common:compileKotlinWasmJs :homebase-common:compileKotlinJvm :homebase-common:compileAndroidMain :homebase-common:compileKotlinIosSimulatorArm64` — **BUILD SUCCESSFUL** (all four targets, since `RichNotificationDisplayer` and `webPushBridge` are expect/actual).
- `./gradlew :webApp:compileDevelopmentExecutableKotlinWasmJs` — **BUILD SUCCESSFUL**.

## NOT verified in a live browser

**This was compiled, not run.** No dev server was started (one was already running on port 8080 from another worktree) and no browser session was opened. I did not see a notification appear, in Brave or anywhere else. Specifically untested: that `showNotification()` actually renders a visible notification; that the icon resolves; that the `tag`/`renotify` replace behaviour works; and that any of the failure snackbars render with the expected text. The JS is exercised by no automated test.
