### PR TITLE
Record a per-type web permission decision instead of a blanket true (#1498)

### DIFF
--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/permissions/WebPermissionPolicy.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/permissions/WebPermissionPolicy.kt
@@ -1,0 +1,27 @@
+package id.homebase.core.permissions
+
+/**
+ * The browser has no OS permission model to consult, so each [PermissionType] needs a chosen
+ * answer. Kept in commonMain only so it is unit-testable on the JVM — the wasmJs
+ * `createPermissionsManager` is its only caller.
+ */
+internal fun webPermissionGranted(
+    permission: PermissionType,
+    notificationGranted: Boolean,
+): Boolean = when (permission) {
+    PermissionType.NOTIFICATION -> notificationGranted
+
+    // A file picker carries its own grant, so a gate here would only block a path that works.
+    PermissionType.GALLERY, PermissionType.GALLERY_LIMITED -> true
+
+    // No browser recorder in this build, so "granted" opens a recording UI that can only fail.
+    PermissionType.RECORD_AUDIO -> false
+
+    // Never asked of the browser: camera capture, geolocation and step counting are unimplemented
+    // on web and already report their own unavailable state, so a gate would add a second one.
+    PermissionType.CAMERA,
+    PermissionType.LOCATION,
+    PermissionType.LOCATION_ALWAYS,
+    PermissionType.ACTIVITY,
+        -> true
+}

--- a/homebase-common/src/jvmTest/kotlin/id/homebase/core/permissions/WebPermissionPolicyTest.kt
+++ b/homebase-common/src/jvmTest/kotlin/id/homebase/core/permissions/WebPermissionPolicyTest.kt
@@ -1,0 +1,36 @@
+package id.homebase.core.permissions
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class WebPermissionPolicyTest {
+
+    @Test
+    fun `notification follows the push bridge`() {
+        assertTrue(webPermissionGranted(PermissionType.NOTIFICATION, notificationGranted = true))
+        assertFalse(webPermissionGranted(PermissionType.NOTIFICATION, notificationGranted = false))
+    }
+
+    @Test
+    fun `record audio is denied because web has no recorder`() {
+        assertFalse(webPermissionGranted(PermissionType.RECORD_AUDIO, notificationGranted = true))
+        assertFalse(webPermissionGranted(PermissionType.RECORD_AUDIO, notificationGranted = false))
+    }
+
+    @Test
+    fun `every other type stays granted regardless of the push bridge`() {
+        val granted = listOf(
+            PermissionType.GALLERY,
+            PermissionType.GALLERY_LIMITED,
+            PermissionType.CAMERA,
+            PermissionType.LOCATION,
+            PermissionType.LOCATION_ALWAYS,
+            PermissionType.ACTIVITY,
+        )
+        granted.forEach { type ->
+            assertTrue(webPermissionGranted(type, notificationGranted = false), "$type")
+            assertTrue(webPermissionGranted(type, notificationGranted = true), "$type")
+        }
+    }
+}

--- a/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/permissions/PermissionsManager.web.kt
+++ b/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/permissions/PermissionsManager.web.kt
@@ -34,14 +34,10 @@ actual fun createPermissionsManager(
             }
 
             override suspend fun isPermissionGranted(permission: PermissionType): Boolean =
-                if (permission == PermissionType.NOTIFICATION) {
-                    bridge?.capability() == WebPushCapability.GRANTED
-                } else {
-                    // Camera / gallery / microphone reach the browser through file pickers and
-                    // getUserMedia, which prompt on their own; the blanket true keeps their
-                    // permission gates out of the way rather than claiming an answer we don't have.
-                    true
-                }
+                webPermissionGranted(
+                    permission,
+                    notificationGranted = bridge?.capability() == WebPushCapability.GRANTED,
+                )
 
             override fun launchSettings() {}
         }


### PR DESCRIPTION
Closes #1498.

## The decision, per type

The issue asked for a decision recorded per permission type rather than a blind fix. Here it is. `#1489` already made `NOTIFICATION` honest; this replaces the blanket `true` for the rest with a table that states the reason for each.

| Type | Web answer | Why |
|---|---|---|
| `NOTIFICATION` | real state | Unchanged from #1489 — the push bridge reports `Notification.permission`. |
| `GALLERY`, `GALLERY_LIMITED` | `true` | The path is `<input type="file">`, which carries its own grant. A gate would block a path that works. Also unreachable on web: `AttachmentOptions.kt:128` wraps the whole gallery strip in `if (isMobile())`, and `ConversationContent.kt:1787` gates the call site too. |
| `RECORD_AUDIO` | **`false`** (changed) | The only type where the claim is both reachable and harmful. See below. |
| `CAMERA` | `true` | No composable reads it anywhere — `CAMERA` is handled only inside the Android/iOS actuals. `rememberCameraManager(...).launch()` is `// No-op on web` (`CameraUtil.web.kt:9-11`). |
| `LOCATION`, `LOCATION_ALWAYS` | `true` | The browser is never asked. `createOneShotLocationProvider()` returns `GpsFixResult.Unavailable` and `createLocationTracker()` reports `isAvailable = false` on web, and the location UI already keys its state off `trackingAvailable`, not off this. |
| `ACTIVITY` | `true` | `DeviceSensors.web.kt` returns null steps and null battery. Nothing to gate. |

## The premise in the issue turned out to be wrong, in a useful way

The issue anticipated the risk as "a sticky per-origin browser denial surfacing as a generic failure" — a `getUserMedia()` `NotAllowedError` with nowhere to land.

**`getUserMedia` is never called anywhere in this repo.** Neither is `navigator.geolocation`. Nor `MediaRecorder`, outside `AndroidAudioRecorder`. So on web there is no browser permission for mic, camera or location to grant or deny in the first place, and no `NotAllowedError` can arise. That makes two acceptance criteria vacuous as written:

- *"No screen claims a capability is granted when the browser has denied it"* — no screen renders a granted/enabled affordance for gallery, mic or camera at all. A `true` only removes a rationale prompt. The one "Granted" row that does exist (`LocationContent.kt:239-243`) sits behind `trackingAvailable`, which is `false` on web.
- *"A denied microphone/camera produces an explanation naming site settings"* — unreachable; nothing asks the browser for either.

It also means `navigator.permissions.query()` was **not** added. It would be a gate for a code path that does not exist. If a browser recorder is ever wired up, that is when it earns its place.

## What was actually broken

`RECORD_AUDIO`. The mic button in `MessageInputBar.kt` has no platform gate (`showRecordingButton = !editExistingMode && !showSendButton`, `:614-617`, rendered at `:930`). On web the blanket `true` therefore let a 300 ms press-and-hold pass the check at `MessageInputBar.kt:678`, set `isRecordingActive = true`, and render the full recording overlay — pulsing red mic, ticking MM:SS timer, "Slide to cancel" (`:1115-1175`).

Underneath: `WebAudioRecorder.startRecording()` is an empty body (`WebPlatformStubs.kt:44`) and `newRecordingFile()` is `error("Audio recording is not supported on web")` (`AudioRecordingFiles.web.kt:9-10`). So `handleStartRecording` throws, is caught at `AttachmentHandler.kt:693`, and the user gets `chat_error_start_recording` with the raw exception string interpolated into it — while a convincing recording UI keeps ticking.

No broken attachment is ever sent (`recordingData` stays null, so `handleStopRecording`'s `recordingData?.let` is skipped), but the capability claim is real and it is exactly the "generic failure" shape the issue is about — just with a different cause than expected.

Reporting `false` stops the gesture at the permission check. No overlay, no raw exception.

## Needs your eye before merge

The mic button still renders on web; it is now inert rather than misleading. Hiding it outright is the better end state, but that is a composer layout change in `homebase-chat` that I could not see running, so it is deliberately not in this PR.

Acceptance criterion 4 asks for `GalleryPermissionState` / `RecordAudioPermissionState` behaviour on web to be checked against a live identity before any gate change. **`RECORD_AUDIO` is a gate change**, so please confirm on web that press-and-hold on the mic now does nothing instead of opening the recording overlay. `GALLERY` is untouched.

## Follow-up worth its own issue

`isLocationPermissionGranted()` is a separate `expect fun` and its web actual is a hardcoded `true` (`LocationPermissionCheck.web.kt:5`). It feeds `LiveShareReadiness` (`AppModule.kt:346-352`), whose stated job is to guarantee "a share would capture and relay GPS rather than silently send nothing". On web it lets a live location share start over `UnavailableOneShotLocationProvider`. Out of scope here — different file, and the fix changes screens that need the same live check.

## Verification

- `homebase-common:jvmTest` — full suite green, including the Konsist `ArchitectureTest`.
- `:homebase-common:compileKotlinWasmJs`, `:compileAndroidMain`, `:compileKotlinIosSimulatorArm64` — all green.
- New `WebPermissionPolicyTest` is mutation-verified twice: flipping `RECORD_AUDIO` back to `true` fails with `AssertionError: Expected value to be false.` at `WebPermissionPolicyTest.kt:17`; hardcoding `NOTIFICATION -> true` fails at `:12`, which guards #1489's behaviour from being flattened by this table.
- `wasmJsBrowserTest` deliberately not used — it is known to exit 0 with a failing test.

Android, iOS and Desktop are untouched: the only non-test caller of `webPermissionGranted` is the wasmJs actual, and `PermissionsManager.jvm/android/native` are not modified.
