### PR TITLE
Give the chat media viewer the whole window (#1503)

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListScreen.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListScreen.kt
@@ -1,5 +1,11 @@
 package id.homebase.chat.conversationlist
 
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.SharedTransitionLayout
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
@@ -41,6 +47,7 @@ import androidx.compose.material3.adaptive.layout.rememberPaneExpansionState
 import androidx.compose.material3.adaptive.navigation.BackNavigationBehavior
 import androidx.compose.material3.adaptive.navigation.rememberListDetailPaneScaffoldNavigator
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
@@ -71,11 +78,13 @@ import com.mohamedrejeb.richeditor.model.RichTextState
 import id.homebase.chat.archivedconversations.ArchivedConversationsUiState
 import id.homebase.chat.archivedconversations.ArchivedConversationsViewModel
 import id.homebase.chat.contactcard.ContactCardDescriptor
+import id.homebase.chat.widget.ChatMediaViewer
 import id.homebase.chat.widget.ConversationListPane
 import id.homebase.chat.widget.ConversationMessagesPane
 import id.homebase.chat.widget.EmptyDetailPane
 import id.homebase.chat.widget.ExtendPermissionDialog
 import id.homebase.chat.widget.StickerCreatorSheet
+import id.homebase.core.HomebaseConstants
 import id.homebase.core.connections.ConnectRequestAction
 import id.homebase.core.connections.ConnectRequestBottomSheet
 import id.homebase.core.connections.ConnectRequestViewModel
@@ -179,6 +188,7 @@ fun ConversationListScreen(
     onNavigateToCropper: (requestId: Uuid) -> Unit = {},
     onNavigateToDrawer: (requestId: Uuid) -> Unit = {},
     onDetailPaneVisibilityChanged: (Boolean) -> Unit = {},
+    onMediaViewerVisibilityChanged: (Boolean) -> Unit = {},
     onSaveContactCard: (ContactCardDescriptor) -> Unit = {},
 ) {
     val conversationsUiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -539,7 +549,8 @@ fun ConversationListScreen(
             messagesSearchTextState = viewModel.messagesSearchTextState,
             onUiAction = viewModel::onAction,
             onNavigateToSettingsScreen = onNavigateToSettingsScreen,
-            onDetailPaneVisibilityChanged = onDetailPaneVisibilityChanged
+            onDetailPaneVisibilityChanged = onDetailPaneVisibilityChanged,
+            onMediaViewerVisibilityChanged = onMediaViewerVisibilityChanged,
         )
 
         conversationsUiState.inFlightOperationLabel?.let { label ->
@@ -757,6 +768,7 @@ fun ConversationListUi(
      *  caller that doesn't drive events still compiles. */
     onNavigateToSettingsScreen: () -> Unit,
     onDetailPaneVisibilityChanged: (Boolean) -> Unit = {},
+    onMediaViewerVisibilityChanged: (Boolean) -> Unit = {},
 ) {
     val windowAdaptiveInfo = currentWindowAdaptiveInfo()
     val defaultDirective = calculatePaneScaffoldDirective(windowAdaptiveInfo)
@@ -876,6 +888,14 @@ fun ConversationListUi(
     // Notify parent about detail pane visibility in compact view
     LaunchedEffect(showingOnlyDetail) { onDetailPaneVisibilityChanged(showingOnlyDetail) }
 
+    val hoistedMediaViewer = messagesUiState.hoistedMediaViewer(isExpanded)
+    // The rail lives above this screen, so the viewer can only own the window if the rail is told
+    // to stand down — same contract the feed and the Vault gallery already use.
+    LaunchedEffect(hoistedMediaViewer != null) {
+        onMediaViewerVisibilityChanged(hoistedMediaViewer != null)
+    }
+    DisposableEffect(Unit) { onDispose { onMediaViewerVisibilityChanged(false) } }
+
     // Installs the coupled cleanup + swap effects that drive notification-tap navigation.
     // See NotificationNavigationEffects.kt for why the two effects must be coordinated.
     NotificationNavigationEffects(
@@ -896,124 +916,162 @@ fun ConversationListUi(
     }
 
     Scaffold(snackbarHost = { SnackbarHost(snackbarHostState) }) {
-        ListDetailPaneScaffold(
-            modifier = Modifier.fillMaxSize().onGloballyPositioned {
-                scaffoldLeft = it.positionInRoot().x
-                scaffoldWidth = it.size.width.toFloat()
-            }.onPreviewKeyEvent { keyEvent ->
-                if (isDesktopOrWeb() &&
-                    keyEvent.type == KeyEventType.KeyDown &&
-                    keyEvent.key == Key.F &&
-                    (keyEvent.isCtrlPressed || keyEvent.isMetaPressed)
-                ) {
-                    // The field is absent in the archived and icon-only list modes.
-                    runCatching { conversationSearchFocusRequester.requestFocus() }
-                    true
-                } else {
-                    false
-                }
-            },
-            directive = scaffoldNavigator.scaffoldDirective,
-            scaffoldState = scaffoldNavigator.scaffoldState,
-            listPane = {
-                AnimatedPane(modifier = Modifier) {
-                    ConversationListPane(
-                        uiState = uiState,
-                        selectedConversationId = scaffoldNavigator.currentDestination?.contentKey,
-                        searchTextState = conversationSearchTextFieldState,
-                        searchFocusRequester = conversationSearchFocusRequester,
-                        archivedUiState = archivedConversationsUiState,
-                        listPaneVisible = !isListPaneHidden,
-                        onProfileClick = onNavigateToSettingsScreen,
-                        onUiAction = onUiAction,
-                        onConversationSelected = {
-                            Logger.i(tag = "ConversationListUi") { "Navigating to detail for $it" }
-                            scope.launch {
-                                scaffoldNavigator.navigateTo(
-                                    ListDetailPaneScaffoldRole.Detail,
-                                    it
-                                )
-                            }
-                        }
-                    )
-                }
-            },
-            detailPane = {
-                AnimatedPane {
-                    val contentKey = scaffoldNavigator.currentDestination?.contentKey
-                    val conversation =
-                        uiState.activeConversations.find { it.conversation.id == contentKey }
-                    LaunchedEffect(contentKey, conversation != null) {
-                        Logger.i(tag = "ConversationListUi") {
-                            "detailPane render: contentKey=$contentKey, conversationFound=${conversation != null}, activeConversationsSize=${uiState.activeConversations.size}"
-                        }
-                    }
-                    if (conversation != null) {
-                        key(conversation.conversation.id) {
-                            ConversationMessagesPane(
-                                conversation = conversation,
-                                uiState = messagesUiState,
-                                textFieldState = messageInputTextFieldState,
-                                searchTextState = messagesSearchTextState,
-                                showBackButton = scaffoldNavigator.scaffoldValue[ListDetailPaneScaffoldRole.List] == PaneAdaptedValue.Hidden,
-                                onBackClick = {
-                                    onUiAction(ConversationListUiAction.ClearSelection)
-                                    scope.launch {
-                                        scaffoldNavigator.navigateBack(
-                                            backNavigationBehavior
-                                        )
-                                    }
-                                },
-                                onUiAction = onUiAction,
-                            )
-                        }
+        Box(modifier = Modifier.fillMaxSize()) {
+            ListDetailPaneScaffold(
+                modifier = Modifier.fillMaxSize().onGloballyPositioned {
+                    scaffoldLeft = it.positionInRoot().x
+                    scaffoldWidth = it.size.width.toFloat()
+                }.onPreviewKeyEvent { keyEvent ->
+                    if (isDesktopOrWeb() &&
+                        keyEvent.type == KeyEventType.KeyDown &&
+                        keyEvent.key == Key.F &&
+                        (keyEvent.isCtrlPressed || keyEvent.isMetaPressed)
+                    ) {
+                        // The field is absent in the archived and icon-only list modes.
+                        runCatching { conversationSearchFocusRequester.requestFocus() }
+                        true
                     } else {
-                        EmptyDetailPane(
-                            title = stringResource(
-                                MR.string.chat_select_a_conversation
-                            ), subtitle = stringResource(
-                                MR.string.chat_select_a_conversation_hint
-                            )
-                        )
-                    }
-                }
-            },
-            paneExpansionState = rememberPaneExpansionState(
-                keyProvider = scaffoldNavigator.scaffoldValue,
-                anchors = paneAnchors,
-                consumeDragDelta = { delta ->
-                    if (scaffoldWidth <= 0f) delta else {
-                        val offset = splitterCenter - scaffoldLeft
-                        (offset + delta).coerceIn(
-                            scaffoldWidth * LIST_PANE_MIN_PERCENT / 100f,
-                            scaffoldWidth * LIST_PANE_MAX_PERCENT / 100f,
-                        ) - offset
+                        false
                     }
                 },
-            ),
-            // M3's VerticalDragHandle animates itself off the hover interaction, which on Skiko
-            // never goes quiet: it pinned the desktop render loop at ~164 fps and ~15% GPU while
-            // idle. This handle is an invisible hit strip over the hairline ConversationListPane
-            // already draws, with nothing to animate.
-            paneExpansionDragHandle = if (!isDesktopOrWeb()) null else {
-                { state ->
-                    Box(
-                        Modifier
-                            .fillMaxHeight()
-                            .width(SPLITTER_HIT_WIDTH)
-                            .onGloballyPositioned {
-                                splitterCenter = it.positionInRoot().x + it.size.width / 2f
+                directive = scaffoldNavigator.scaffoldDirective,
+                scaffoldState = scaffoldNavigator.scaffoldState,
+                listPane = {
+                    AnimatedPane(modifier = Modifier) {
+                        ConversationListPane(
+                            uiState = uiState,
+                            selectedConversationId = scaffoldNavigator.currentDestination?.contentKey,
+                            searchTextState = conversationSearchTextFieldState,
+                            searchFocusRequester = conversationSearchFocusRequester,
+                            archivedUiState = archivedConversationsUiState,
+                            listPaneVisible = !isListPaneHidden,
+                            onProfileClick = onNavigateToSettingsScreen,
+                            onUiAction = onUiAction,
+                            onConversationSelected = {
+                                Logger.i(tag = "ConversationListUi") { "Navigating to detail for $it" }
+                                scope.launch {
+                                    scaffoldNavigator.navigateTo(
+                                        ListDetailPaneScaffoldRole.Detail,
+                                        it
+                                    )
+                                }
                             }
-                            .horizontalResizeCursor()
-                            .paneExpansionDraggable(
-                                state = state,
-                                minTouchTargetSize = SPLITTER_HIT_WIDTH,
-                                interactionSource = splitterInteractionSource,
+                        )
+                    }
+                },
+                detailPane = {
+                    AnimatedPane {
+                        val contentKey = scaffoldNavigator.currentDestination?.contentKey
+                        val conversation =
+                            uiState.activeConversations.find { it.conversation.id == contentKey }
+                        LaunchedEffect(contentKey, conversation != null) {
+                            Logger.i(tag = "ConversationListUi") {
+                                "detailPane render: contentKey=$contentKey, conversationFound=${conversation != null}, activeConversationsSize=${uiState.activeConversations.size}"
+                            }
+                        }
+                        if (conversation != null) {
+                            key(conversation.conversation.id) {
+                                ConversationMessagesPane(
+                                    conversation = conversation,
+                                    uiState = messagesUiState,
+                                    textFieldState = messageInputTextFieldState,
+                                    searchTextState = messagesSearchTextState,
+                                    showBackButton = scaffoldNavigator.scaffoldValue[ListDetailPaneScaffoldRole.List] == PaneAdaptedValue.Hidden,
+                                    onBackClick = {
+                                        onUiAction(ConversationListUiAction.ClearSelection)
+                                        scope.launch {
+                                            scaffoldNavigator.navigateBack(
+                                                backNavigationBehavior
+                                            )
+                                        }
+                                    },
+                                    onUiAction = onUiAction,
+                                    hoistMediaViewer = isExpanded,
+                                )
+                            }
+                        } else {
+                            EmptyDetailPane(
+                                title = stringResource(
+                                    MR.string.chat_select_a_conversation
+                                ), subtitle = stringResource(
+                                    MR.string.chat_select_a_conversation_hint
+                                )
                             )
-                    )
+                        }
+                    }
+                },
+                paneExpansionState = rememberPaneExpansionState(
+                    keyProvider = scaffoldNavigator.scaffoldValue,
+                    anchors = paneAnchors,
+                    consumeDragDelta = { delta ->
+                        if (scaffoldWidth <= 0f) delta else {
+                            val offset = splitterCenter - scaffoldLeft
+                            (offset + delta).coerceIn(
+                                scaffoldWidth * LIST_PANE_MIN_PERCENT / 100f,
+                                scaffoldWidth * LIST_PANE_MAX_PERCENT / 100f,
+                            ) - offset
+                        }
+                    },
+                ),
+                // M3's VerticalDragHandle animates itself off the hover interaction, which on Skiko
+                // never goes quiet: it pinned the desktop render loop at ~164 fps and ~15% GPU while
+                // idle. This handle is an invisible hit strip over the hairline ConversationListPane
+                // already draws, with nothing to animate.
+                paneExpansionDragHandle = if (!isDesktopOrWeb()) null else {
+                    { state ->
+                        Box(
+                            Modifier
+                                .fillMaxHeight()
+                                .width(SPLITTER_HIT_WIDTH)
+                                .onGloballyPositioned {
+                                    splitterCenter = it.positionInRoot().x + it.size.width / 2f
+                                }
+                                .horizontalResizeCursor()
+                                .paneExpansionDraggable(
+                                    state = state,
+                                    minTouchTargetSize = SPLITTER_HIT_WIDTH,
+                                    interactionSource = splitterInteractionSource,
+                                )
+                        )
+                    }
+                },
+                )
+
+            // Inside the Scaffold, so snackbars still draw above it. The bubble that opened it
+            // belongs to the pane's SharedTransitionLayout, out of reach of this one, so what is
+            // left here is a crossfade run in step with the pane's.
+            if (isExpanded) {
+                SharedTransitionLayout(modifier = Modifier.fillMaxSize()) {
+                    AnimatedContent(
+                        targetState = hoistedMediaViewer,
+                        modifier = Modifier.fillMaxSize(),
+                        contentKey = { overlay ->
+                            when (overlay) {
+                                null -> "none"
+                                is FullScreenOverlay.ViewMessageData -> "view"
+                                is FullScreenOverlay.VideoPlayerData -> "videoPlayer"
+                                is FullScreenOverlay.PdfViewerData -> "pdf"
+                            }
+                        },
+                        transitionSpec = {
+                            val duration =
+                                HomebaseConstants.Animation.CHAT_IMAGE_FULL_SCREEN_TRANSITION_DURATION
+                            fadeIn(tween(duration)) togetherWith fadeOut(tween(duration))
+                        },
+                    ) { overlay ->
+                        if (overlay != null) {
+                            ChatMediaViewer(
+                                data = overlay,
+                                uiState = messagesUiState,
+                                onUiAction = onUiAction,
+                                sharedTransitionScope = this@SharedTransitionLayout,
+                                animatedVisibilityScope = this@AnimatedContent,
+                            )
+                        }
+                    }
                 }
-            },
-            )
+            }
+        }
     }
 }
 

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiState.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiState.kt
@@ -387,6 +387,16 @@ sealed interface FullScreenOverlay {
 internal fun MessageListUiState.closeMediaViewer(): MessageListUiState =
     if (fullScreenOverlay is FullScreenOverlay.MediaViewer) copy(fullScreenOverlay = null) else this
 
+/**
+ * A viewer rendered inside the messages pane only covers that pane, so on a two-pane layout it
+ * has to be lifted above the scaffold to own the window. On a single-pane layout the pane already
+ * is the window, and staying there keeps the thumbnail→fullscreen shared-element transition.
+ */
+internal fun MessageListUiState.hoistedMediaViewer(
+    isExpandedLayout: Boolean,
+): FullScreenOverlay.MediaViewer? =
+    if (isExpandedLayout) fullScreenOverlay as? FullScreenOverlay.MediaViewer else null
+
 sealed class AttachmentPendingFile(val attachmentId: Uuid) {
     /**
      * @param metadata EXIF / image-file metadata, populated asynchronously after

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiState.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListUiState.kt
@@ -317,6 +317,9 @@ sealed class RecipientModel(val name: String) {
 @Immutable
 sealed interface FullScreenOverlay {
 
+    /** Read-only views of a message that already exists in the conversation. */
+    sealed interface MediaViewer : FullScreenOverlay
+
     data class ViewMessageData(
         val messageId: Uuid,
         val title: String,
@@ -332,7 +335,7 @@ sealed interface FullScreenOverlay {
         /** Set with [globalTransitId] to read the payloads over peer; both null for local media. */
         val remoteOdinId: OdinId? = null,
         val globalTransitId: Uuid? = null,
-    ) : FullScreenOverlay
+    ) : FullScreenOverlay.MediaViewer
 
     data class AttachmentData(
         val selected: Uuid,
@@ -364,7 +367,7 @@ sealed interface FullScreenOverlay {
         /** Set together for a followed identity's post; playback then reads the author's drive by gtid. */
         val remoteOdinId: OdinId? = null,
         val globalTransitId: Uuid? = null,
-    ) : FullScreenOverlay
+    ) : FullScreenOverlay.MediaViewer
 
     @Immutable
     data class PdfViewerData(
@@ -373,8 +376,16 @@ sealed interface FullScreenOverlay {
         val payloadKey: String,
         val title: String,
         val userDate: Instant,
-    ) : FullScreenOverlay
+    ) : FullScreenOverlay.MediaViewer
 }
+
+/**
+ * Leaving a conversation drops only the read-only viewers: [FullScreenOverlay.AttachmentData]
+ * is the composer editor, whose picked files and crop/draw/trim edits exist nowhere else and
+ * would be destroyed with no way to get them back.
+ */
+internal fun MessageListUiState.closeMediaViewer(): MessageListUiState =
+    if (fullScreenOverlay is FullScreenOverlay.MediaViewer) copy(fullScreenOverlay = null) else this
 
 sealed class AttachmentPendingFile(val attachmentId: Uuid) {
     /**

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListViewModel.kt
@@ -1284,7 +1284,7 @@ class ConversationListViewModel(
                 _uiState.value.selectedConversationId?.let { frozenUnreadBoundary.remove(it) }
                 _uiState.update { it.copy(selectedConversationId = null) }
                 _messagesUiState.update {
-                    it.copy(
+                    it.closeMediaViewer().copy(
                         messages = persistentListOf(),
                         isLoadingMessages = false,
                         pinnedMessages = persistentListOf(),
@@ -1840,15 +1840,16 @@ class ConversationListViewModel(
         // the Pane's remember only re-evaluates ONCE, with the resolved scroll.
         // The brief blank-screen window is the same one uncached switches
         // already have (a few ms of groupBy + clustering on Dispatchers.Default).
-        _messagesUiState.update {
-            it.copy(
+        _messagesUiState.update { state ->
+            val base = if (isNewSelection) state.closeMediaViewer() else state
+            base.copy(
                 scrollPosition = null,
                 isLoadingMessages = true,
                 replyToMessage = null,
                 // Drop the previous conversation's pinned bar on a real switch so it
                 // doesn't flash stale pins before the new conversation's collector emits.
-                pinnedMessages = if (isNewSelection) persistentListOf() else it.pinnedMessages,
-                currentPinIndex = if (isNewSelection) 0 else it.currentPinIndex,
+                pinnedMessages = if (isNewSelection) persistentListOf() else base.pinnedMessages,
+                currentPinIndex = if (isNewSelection) 0 else base.currentPinIndex,
                 awaitingJumpMessageId = null,
             )
         }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ChatMediaViewer.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ChatMediaViewer.kt
@@ -1,0 +1,67 @@
+package id.homebase.chat.widget
+
+import androidx.compose.animation.AnimatedVisibilityScope
+import androidx.compose.animation.SharedTransitionScope
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.runtime.Composable
+import id.homebase.chat.conversationlist.ConversationListUiAction
+import id.homebase.chat.conversationlist.ConversationListUiAction.CloseFullScreenOverlay
+import id.homebase.chat.conversationlist.ConversationListUiAction.DeleteMessage
+import id.homebase.chat.conversationlist.ConversationListUiAction.DownloadMedia
+import id.homebase.chat.conversationlist.ConversationListUiAction.DownloadVideoMedia
+import id.homebase.chat.conversationlist.ConversationListUiAction.ShareMedia
+import id.homebase.chat.conversationlist.DecryptedFileKey
+import id.homebase.chat.conversationlist.FullScreenOverlay
+import id.homebase.chat.conversationlist.MessageListUiState
+
+/**
+ * Rendered either inside the messages pane (single-pane, where the shared-element scopes come
+ * from the pane's own AnimatedContent) or lifted above the list/detail scaffold (two-pane, where
+ * there is no bubble to pair with and the scopes only drive a fade).
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun ChatMediaViewer(
+    data: FullScreenOverlay.MediaViewer,
+    uiState: MessageListUiState,
+    onUiAction: (ConversationListUiAction) -> Unit,
+    sharedTransitionScope: SharedTransitionScope,
+    animatedVisibilityScope: AnimatedVisibilityScope,
+) {
+    when (data) {
+        is FullScreenOverlay.ViewMessageData -> FullScreenMediaViewer(
+            data = data,
+            isDownloading = "${data.messageId}_${data.selectedPayloadKey}" in uiState.downloadingFiles,
+            onShare = { id, key -> onUiAction(ShareMedia(id, key)) },
+            onSave = { message, key -> onUiAction(DownloadMedia(message, key)) },
+            onSaveSticker = { message, key ->
+                onUiAction(ConversationListUiAction.SaveStickerFromMessage(message, key))
+            },
+            onDelete = { onUiAction(DeleteMessage(it)) },
+            onDismiss = { onUiAction(CloseFullScreenOverlay) },
+            animatedVisibilityScope = animatedVisibilityScope,
+            sharedTransitionScope = sharedTransitionScope,
+        )
+
+        is FullScreenOverlay.VideoPlayerData -> FullScreenVideoPlayer(
+            data = data,
+            isDownloading = "${data.fileId}_${data.payloadKey}" in uiState.downloadingFiles,
+            onDismiss = { onUiAction(CloseFullScreenOverlay) },
+            onSave = {
+                onUiAction(
+                    DownloadVideoMedia(data.fileId, data.payloadKey, data.keyHeader, data.payload)
+                )
+            },
+            uploadStatus = data.uploadMessageId?.let { uiState.uploadProgress[it] },
+        )
+
+        is FullScreenOverlay.PdfViewerData -> ChatPdfViewer(
+            title = data.title,
+            userDate = data.userDate,
+            filePath = uiState.decryptedFiles[DecryptedFileKey(data.fileId, data.payloadKey)],
+            isDownloading = "${data.messageId}_${data.payloadKey}" in uiState.downloadingFiles,
+            onDownload = { onUiAction(DownloadMedia(data.messageId, data.payloadKey)) },
+            onDismiss = { onUiAction(CloseFullScreenOverlay) },
+        )
+    }
+}

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationMessagesPane.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationMessagesPane.kt
@@ -9,6 +9,7 @@ import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
@@ -39,15 +40,10 @@ import co.touchlab.kermit.Logger
 import com.mohamedrejeb.richeditor.model.RichTextState
 import id.homebase.chat.conversationlist.ConversationListUiAction
 import id.homebase.chat.conversationlist.ConversationListUiAction.CloseFullScreenOverlay
-import id.homebase.chat.conversationlist.ConversationListUiAction.DeleteMessage
-import id.homebase.chat.conversationlist.ConversationListUiAction.DownloadMedia
-import id.homebase.chat.conversationlist.ConversationListUiAction.DownloadVideoMedia
 import id.homebase.chat.conversationlist.ConversationListUiAction.SaveFile
 import id.homebase.chat.conversationlist.ConversationListUiAction.SaveScrollPosition
 import id.homebase.chat.conversationlist.ConversationListUiAction.SendFile
-import id.homebase.chat.conversationlist.ConversationListUiAction.ShareMedia
 import id.homebase.chat.conversationlist.ConversationListUiAction.UnAttachFile
-import id.homebase.chat.conversationlist.DecryptedFileKey
 import id.homebase.chat.conversationlist.FullScreenOverlay
 import id.homebase.chat.conversationlist.MessageListContentModel
 import id.homebase.chat.conversationlist.MessageListUiState
@@ -81,6 +77,9 @@ fun ConversationMessagesPane(
     showBackButton: Boolean,
     onBackClick: () -> Unit,
     onUiAction: (ConversationListUiAction) -> Unit,
+    /** Two-pane layouts draw the read-only viewers above the scaffold instead; the pane still
+     *  drops [ConversationContent] so the composer cannot hold focus behind one. */
+    hoistMediaViewer: Boolean = false,
 ) {
     var currentGalleryPage by remember { mutableStateOf(0) }
 
@@ -320,47 +319,18 @@ fun ConversationMessagesPane(
                 )
             } else {
                 when (data) {
-                    is FullScreenOverlay.ViewMessageData -> {
-                        FullScreenMediaViewer(
-                            data = data,
-                            isDownloading = "${data.messageId}_${data.selectedPayloadKey}" in uiState.downloadingFiles,
-                            onShare = { id, key -> onUiAction(ShareMedia(id, key)) },
-                            onSave = { message, key ->
-                                onUiAction(DownloadMedia(message, key))
-                            },
-                            onSaveSticker = { message, key ->
-                                onUiAction(
-                                    ConversationListUiAction.SaveStickerFromMessage(message, key)
-                                )
-                            },
-                            onDelete = { onUiAction(DeleteMessage(it)) },
-                            onDismiss = { onUiAction(CloseFullScreenOverlay) },
-                            animatedVisibilityScope = this@AnimatedContent,
-                            sharedTransitionScope = this@SharedTransitionLayout,
-                        )
-                    }
-
-                    is FullScreenOverlay.VideoPlayerData -> {
-                        FullScreenVideoPlayer(
-                            data = data,
-                            isDownloading = "${data.fileId}_${data.payloadKey}" in uiState.downloadingFiles,
-                            onDismiss = { onUiAction(CloseFullScreenOverlay) },
-                            onSave = { onUiAction(DownloadVideoMedia(data.fileId, data.payloadKey, data.keyHeader, data.payload)) },
-                            uploadStatus = data.uploadMessageId?.let { uiState.uploadProgress[it] },
-                        )
-                    }
-
-                    is FullScreenOverlay.PdfViewerData -> {
-                        ChatPdfViewer(
-                            title = data.title,
-                            userDate = data.userDate,
-                            filePath = uiState.decryptedFiles[
-                                DecryptedFileKey(data.fileId, data.payloadKey)
-                            ],
-                            isDownloading = "${data.messageId}_${data.payloadKey}" in uiState.downloadingFiles,
-                            onDownload = { onUiAction(DownloadMedia(data.messageId, data.payloadKey)) },
-                            onDismiss = { onUiAction(CloseFullScreenOverlay) },
-                        )
+                    is FullScreenOverlay.MediaViewer -> {
+                        if (hoistMediaViewer) {
+                            Spacer(modifier = Modifier.fillMaxSize())
+                        } else {
+                            ChatMediaViewer(
+                                data = data,
+                                uiState = uiState,
+                                onUiAction = onUiAction,
+                                animatedVisibilityScope = this@AnimatedContent,
+                                sharedTransitionScope = this@SharedTransitionLayout,
+                            )
+                        }
                     }
 
                     is FullScreenOverlay.AttachmentData -> {

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/conversationlist/CloseMediaViewerTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/conversationlist/CloseMediaViewerTest.kt
@@ -1,0 +1,79 @@
+package id.homebase.chat.conversationlist
+
+import id.homebase.api.client.KeyHeader
+import id.homebase.api.client.drives.files.PayloadDescriptor
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+import kotlin.time.Instant
+import kotlin.uuid.Uuid
+
+class CloseMediaViewerTest {
+
+    private fun imageViewer() = FullScreenOverlay.ViewMessageData(
+        messageId = Uuid.random(),
+        title = "Alice",
+        userDate = Instant.fromEpochMilliseconds(0),
+        content = "",
+        fileId = Uuid.random(),
+        driveId = Uuid.random(),
+        payloads = emptyList(),
+        keyHeader = KeyHeader.empty(),
+        selectedPayloadKey = "chat_web0",
+    )
+
+    private fun videoPlayer() = FullScreenOverlay.VideoPlayerData(
+        fileId = Uuid.random(),
+        driveId = Uuid.random(),
+        payloadKey = "chat_web0",
+        keyHeader = KeyHeader.empty(),
+        payload = PayloadDescriptor(key = "chat_web0", contentType = "video/mp4"),
+    )
+
+    private fun pdfViewer() = FullScreenOverlay.PdfViewerData(
+        messageId = Uuid.random(),
+        fileId = Uuid.random(),
+        payloadKey = "chat_web0",
+        title = "spec.pdf",
+        userDate = Instant.fromEpochMilliseconds(0),
+    )
+
+    private fun attachmentEditor() = FullScreenOverlay.AttachmentData(
+        selected = Uuid.random(),
+        conversationTitle = "Alice",
+        conversationId = Uuid.random(),
+        attachments = emptyList(),
+    )
+
+    @Test
+    fun `image viewer is dropped`() {
+        val state = MessageListUiState(fullScreenOverlay = imageViewer())
+        assertNull(state.closeMediaViewer().fullScreenOverlay)
+    }
+
+    @Test
+    fun `video player is dropped`() {
+        val state = MessageListUiState(fullScreenOverlay = videoPlayer())
+        assertNull(state.closeMediaViewer().fullScreenOverlay)
+    }
+
+    @Test
+    fun `pdf viewer is dropped`() {
+        val state = MessageListUiState(fullScreenOverlay = pdfViewer())
+        assertNull(state.closeMediaViewer().fullScreenOverlay)
+    }
+
+    @Test
+    fun `composer attachment editor is kept`() {
+        val editor = attachmentEditor()
+        val state = MessageListUiState(fullScreenOverlay = editor)
+        assertEquals(editor, state.closeMediaViewer().fullScreenOverlay)
+    }
+
+    @Test
+    fun `state is untouched when nothing is open`() {
+        val state = MessageListUiState()
+        assertSame(state, state.closeMediaViewer())
+    }
+}

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/conversationlist/HoistedMediaViewerLayerTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/conversationlist/HoistedMediaViewerLayerTest.kt
@@ -1,0 +1,78 @@
+package id.homebase.chat.conversationlist
+
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsFocused
+import androidx.compose.ui.test.getUnclippedBoundsInRoot
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.runDesktopComposeUiTest
+import androidx.compose.ui.unit.dp
+import com.mohamedrejeb.richeditor.model.RichTextState
+import id.homebase.chat.archivedconversations.ArchivedConversationsUiState
+import id.homebase.core.ui.theme.HomebaseTheme
+import kotlin.test.Test
+import kotlin.test.assertTrue
+import kotlin.time.Instant
+import kotlin.uuid.Uuid
+
+/**
+ * Two-pane layouts lift the read-only media viewers out of the detail pane so they own the whole
+ * window. Rendered on the JVM host renderer at a width that resolves to the expanded layout.
+ */
+@OptIn(ExperimentalTestApi::class)
+class HoistedMediaViewerLayerTest {
+
+    @Composable
+    private fun Subject(messages: MessageListUiState) {
+        HomebaseTheme {
+            ConversationListUi(
+                snackbarHostState = SnackbarHostState(),
+                uiState = ConversationListUiState(),
+                messagesUiState = messages,
+                archivedConversationsUiState = ArchivedConversationsUiState(),
+                conversationSearchTextFieldState = TextFieldState(),
+                messagesSearchTextState = TextFieldState(),
+                messageInputTextFieldState = RichTextState(),
+                onUiAction = {},
+                onNavigateToSettingsScreen = {},
+            )
+        }
+    }
+
+    @Test
+    fun `viewer chrome is drawn over the list pane`() =
+        runDesktopComposeUiTest(width = 1400, height = 900) {
+            val title = "quarterly-report.pdf"
+            setContent {
+                Subject(
+                    MessageListUiState(
+                        fullScreenOverlay = FullScreenOverlay.PdfViewerData(
+                            messageId = Uuid.random(),
+                            fileId = Uuid.random(),
+                            payloadKey = "chat_web0",
+                            title = title,
+                            userDate = Instant.fromEpochMilliseconds(1_700_000_000_000),
+                        )
+                    )
+                )
+            }
+            waitForIdle()
+            // The list pane is 360.dp wide, so anything the detail pane draws starts to the right
+            // of it — a title this far left can only come from a viewer above the whole scaffold.
+            val left = onNodeWithText(title).getUnclippedBoundsInRoot().left
+            assertTrue(left < 300.dp, "viewer title at $left is still inside the detail pane")
+        }
+
+    @Test
+    fun `closed viewer layer does not swallow input`() =
+        runDesktopComposeUiTest(width = 1400, height = 900) {
+            setContent { Subject(MessageListUiState()) }
+            waitForIdle()
+            onNodeWithText("Search").performClick()
+            waitForIdle()
+            onNodeWithText("Search").assertIsFocused()
+        }
+}

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/conversationlist/HoistedMediaViewerTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/conversationlist/HoistedMediaViewerTest.kt
@@ -1,0 +1,54 @@
+package id.homebase.chat.conversationlist
+
+import id.homebase.api.client.KeyHeader
+import kotlin.test.Test
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+import kotlin.time.Instant
+import kotlin.uuid.Uuid
+
+class HoistedMediaViewerTest {
+
+    private fun imageViewer() = FullScreenOverlay.ViewMessageData(
+        messageId = Uuid.random(),
+        title = "Alice",
+        userDate = Instant.fromEpochMilliseconds(0),
+        content = "",
+        fileId = Uuid.random(),
+        driveId = Uuid.random(),
+        payloads = emptyList(),
+        keyHeader = KeyHeader.empty(),
+        selectedPayloadKey = "chat_web0",
+    )
+
+    private fun attachmentEditor() = FullScreenOverlay.AttachmentData(
+        selected = Uuid.random(),
+        conversationTitle = "Alice",
+        conversationId = Uuid.random(),
+        attachments = emptyList(),
+    )
+
+    @Test
+    fun `two-pane layout hoists the viewer out of the pane`() {
+        val viewer = imageViewer()
+        val state = MessageListUiState(fullScreenOverlay = viewer)
+        assertSame(viewer, state.hoistedMediaViewer(isExpandedLayout = true))
+    }
+
+    @Test
+    fun `single-pane layout keeps the viewer in the pane`() {
+        val state = MessageListUiState(fullScreenOverlay = imageViewer())
+        assertNull(state.hoistedMediaViewer(isExpandedLayout = false))
+    }
+
+    @Test
+    fun `composer attachment editor is never hoisted`() {
+        val state = MessageListUiState(fullScreenOverlay = attachmentEditor())
+        assertNull(state.hoistedMediaViewer(isExpandedLayout = true))
+    }
+
+    @Test
+    fun `nothing to hoist when no overlay is open`() {
+        assertNull(MessageListUiState().hoistedMediaViewer(isExpandedLayout = true))
+    }
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
@@ -389,6 +389,10 @@ fun AppNavHost(
     // renders *under* this Scaffold's bottom bar unless the screen reports it up.
     var isFeedMediaOpen by remember { mutableStateOf(false) }
 
+    // Same contract for the chat's two-pane media viewer, which additionally has to displace the
+    // navigation rail to own the whole window.
+    var isChatMediaOpen by remember { mutableStateOf(false) }
+
     // Check if current destination is a top-level route. Uses the static route-type
     // check (not topLevelRoutes) so the bottom nav still shows on the Vault screen even
     // when the user has hidden the Vault icon from the nav bar.
@@ -413,7 +417,7 @@ fun AppNavHost(
     val isVaultEditorOpen = vaultUiState.pendingEditor != null
     val showBottomNavigationBar =
         isOnTopLevelScreen && !showNavigationRail && !isVaultGalleryOpen && !isVaultEditorOpen &&
-                !isFeedMediaOpen
+                !isFeedMediaOpen && !isChatMediaOpen
 
     // Get the lifecycle owner of the current composable
     val lifecycleOwner = LocalLifecycleOwner.current
@@ -785,7 +789,8 @@ fun AppNavHost(
                 .padding(paddingValues)
         ) {
             Row(modifier = Modifier.fillMaxSize()) {
-                val railVisible = showNavigationRail && isAuthenticated && isOnTopLevelScreen
+                val railVisible =
+                    showNavigationRail && isAuthenticated && isOnTopLevelScreen && !isChatMediaOpen
                 if (railVisible) {
                     NavigationRail(
                         modifier = Modifier.width(NavigationRailWidth),
@@ -1313,6 +1318,10 @@ fun AppNavHost(
                                         // THIS IS USED, THE WARNING IS WRONG, IT'S A KNOWN ISSUE
                                         @Suppress("AssignedValueIsNeverRead")
                                         showingOnlyDetailPane = it
+                                    },
+                                    onMediaViewerVisibilityChanged = {
+                                        @Suppress("AssignedValueIsNeverRead")
+                                        isChatMediaOpen = it
                                     },
                                     onSaveContactCard = { pendingContactCard = it },
                                 )


### PR DESCRIPTION
Fixes #1503.

## What changed

The media viewer now owns the whole window on Desktop and tablet, and it is
dismissed when you leave the conversation it belongs to.

**Full-window viewer.** `FullScreenMediaViewer` / `FullScreenVideoPlayer` /
`ChatPdfViewer` rendered inside `ConversationMessagesPane`'s `AnimatedContent`,
which sits in the scaffold's *detail slot* — so on a two-pane layout the image
covered the detail pane and nothing else: conversation list beside it,
navigation rail beside that. They are now drawn over the whole
`ListDetailPaneScaffold` (still inside the `Scaffold`, so snackbars keep drawing
above them), and `ConversationListUi` reports "media open" up to `AppNavHost`,
which stands the rail down — the mechanism the feed (`isFeedMediaOpen`) and the
Vault gallery (`isVaultGalleryOpen`) already use.

**Dismiss on conversation change.** `fullScreenOverlay` is a field on the single
`MessageListUiState` the ViewModel shares across conversations, and nothing on
the selection path cleared it, so an image opened in A stayed painted over B.
Cleared at the two seams that own selection — `loadMessagesForConversation`'s
`isNewSelection` block and `ClearSelection` (which the delete/leave path already
dispatches) — rather than at the ~30 `fullScreenOverlay = …` call sites.

## The design, and what it costs

Only the **two-pane** layout hoists (`isExpandedLayout()`, the existing 840dp
gate). A single-pane layout's pane already *is* the window, so it keeps rendering
the viewer in place — including the thumbnail→fullscreen shared-element
transition, which phones therefore lose nothing of. The hoisted copy is outside
the pane's `SharedTransitionLayout` and has no bubble to pair with, so on
Desktop/tablet the hero becomes a crossfade run in step with the pane's.

Two things this deliberately does **not** do, because both are regressions:

- It does not hoist `SharedTransitionLayout` + `AnimatedContent` above the
  scaffold. That unmounts `ConversationMessagesPane`, so closing the viewer
  rebuilds `LazyListState` from `uiState.scrollPosition` — stale since the
  conversation was opened (scroll jumps to the bottom), and `null` there
  pre-inits at the `Int.MAX_VALUE` sentinel that froze the UI dispatcher in
  build 1419. Here the pane is never unmounted and `listState` survives.
- It does not mutate `scaffoldDirective.maxHorizontalPartitions`, which would
  re-fire `LaunchedEffect(partitions)`, `ColdStartDetailGuard` and
  `NotificationNavigationEffects` on every viewer open/close.

A `Dialog` is not an option either — `AppNavHost` already records that the feed
moved its viewer inline because a Dialog paints grey safe-area strips on iOS.

The pane still swaps `ConversationContent` out while a viewer is hoisted (same
mount/unmount as today), so the composer cannot keep keyboard focus behind the
viewer on Desktop.

`FullScreenOverlay.AttachmentData` is excluded from all of this. It is the
composer's attachment **editor** — the only store for just-picked files plus any
crop/draw/background-removal/trim edits — so it stays in the pane (it needs the
pane-scoped gallery/file/camera launchers) and is never cleared on a conversation
switch. The split is a `FullScreenOverlay.MediaViewer` sub-interface, so it lives
in the type rather than in `is` checks a future subtype would forget.

Known gap, unchanged: you can still switch conversations with the attachment
editor open and it stays up labelled "→ A" (it does send to A — it carries its
own `conversationId`). Odd but not destructive; clearing it would be. Worth its
own issue.

## Verification

```
./gradlew :homebase-chat:compileKotlinJvm :homebase-chat:compileAndroidMain \
          :homebase-chat:compileKotlinWasmJs :homebase-core:compileKotlinJvm
BUILD SUCCESSFUL in 1m 42s

./gradlew homebase-chat:jvmTest homebase-common:jvmTest homebase-core:jvmTest --rerun-tasks
BUILD SUCCESSFUL in 2m 9s
tests=2696 failures=0 errors=0 skipped=8      (baseline 2690)
```

Rendered on the JVM host renderer (`runDesktopComposeUiTest`, 1400×900) with a
viewer open: it fills the window — no list pane, no empty-detail placeholder.

New tests, and both were confirmed to fail without the change:

- `HoistedMediaViewerLayerTest` — *viewer chrome is drawn over the list pane*
  (the viewer's title lands at x < 300.dp, inside the 360.dp list pane; fails
  when the hoist is switched off), and *closed viewer layer does not swallow
  input* (a click reaches the list-pane search field through the always-mounted
  overlay layer; fails if that layer is given a `pointerInput` that consumes).
- `HoistedMediaViewerTest` — the hoist decision: two-pane hoists, single-pane
  does not, the attachment editor never does.
- `CloseMediaViewerTest` (from the first commit) still green, 5/5.

**Not verified on a device or simulator** — no emulator or phone was available.
Verified on a real Desktop window: image and video viewers both fill the whole
window (against the same video on main, which stayed confined to the detail
pane); the rail stands down while open and returns on close; closing restores the
exact scroll position; compact still renders in-pane; and the always-mounted
hoisted layer does not swallow input when closed.

An earlier revision of this section claimed that resizing across the 840dp gate
with a viewer open remounts it and loses pager page and zoom. That is
**pre-existing and unrelated to this PR** — the same round-trip with no viewer
open also discards the conversation selection and lands on "Select a
conversation". Worth its own issue.

What still needs a human pass: the crossfade-vs-hero animation quality on
Desktop, which still frames cannot judge, and an Android tablet in two-pane.

## Notes

`ConversationContent.kt` is untouched. The `ListDetailPaneScaffold` block in
`ConversationListUi` is indented one level by the new wrapping `Box` —
`git diff -w` shows no change there.

