### PR TITLE
Give iOS video an output route, and rebind the local server after a suspend

### DIFF
--- a/homebase-chat/src/nativeMain/kotlin/id/homebase/chat/widget/video/LocalVideoPlayerSurface.native.kt
+++ b/homebase-chat/src/nativeMain/kotlin/id/homebase/chat/widget/video/LocalVideoPlayerSurface.native.kt
@@ -27,6 +27,7 @@ import platform.AVKit.AVPlayerViewController
 import platform.CoreMedia.CMTimeGetSeconds
 import platform.CoreMedia.CMTimeMake
 import platform.Foundation.NSNotificationCenter
+import id.homebase.core.audio.AudioSession
 import platform.Foundation.NSURL
 
 @Composable
@@ -36,6 +37,7 @@ actual fun LocalVideoPlayerSurface(
     onFirstFrameRendered: () -> Unit,
 ) {
     val player = remember(filePath) {
+        AudioSession.ensurePlaybackCapable()
         val url = if (filePath.startsWith("file://")) {
             NSURL.URLWithString(filePath)!!
         } else {
@@ -101,6 +103,7 @@ actual fun TrimmableVideoPlayerSurface(
     val onPositionMsState = rememberUpdatedState(onPositionMs)
 
     val player = remember(filePath) {
+        AudioSession.ensurePlaybackCapable()
         val url = if (filePath.startsWith("file://")) {
             NSURL.URLWithString(filePath)!!
         } else {

--- a/homebase-chat/src/nativeMain/kotlin/id/homebase/chat/widget/video/LocalVideoServer.native.kt
+++ b/homebase-chat/src/nativeMain/kotlin/id/homebase/chat/widget/video/LocalVideoServer.native.kt
@@ -22,6 +22,9 @@ import io.ktor.server.routing.routing
 import io.ktor.server.routing.get
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import platform.Foundation.NSNotificationCenter
+import platform.Foundation.NSOperationQueue
+import platform.UIKit.UIApplicationDidEnterBackgroundNotification
 import kotlin.concurrent.Volatile
 import kotlin.io.encoding.Base64
 import kotlin.io.encoding.ExperimentalEncodingApi
@@ -63,6 +66,8 @@ class LocalVideoServer private constructor() {
         private set
 
     private var engine: EmbeddedServer<CIOApplicationEngine, CIOApplicationEngine.Configuration>? = null
+    @Volatile private var staleSinceBackground = false
+    private val bindMutex = Mutex()
     private val sessionsMutex = Mutex()
     private val sessions = mutableMapOf<String, Session>()
 
@@ -119,6 +124,7 @@ class LocalVideoServer private constructor() {
             return
         }
         val body = rewritePlaylist(s, sessionId)
+        Logger.d(tag = TAG) { "manifest served ${body.length} chars fileId=${s.fileId}" }
         call.response.header(HttpHeaders.CacheControl, "no-store")
         call.respondText(body, ContentType("application", "vnd.apple.mpegurl"))
     }
@@ -160,6 +166,37 @@ class LocalVideoServer private constructor() {
         )
     }
 
+    /**
+     * iOS tears the listening socket down while the app is suspended, so a server bound
+     * before a background trip answers nothing on the way back: AVURLAsset fails the
+     * playlist fetch in milliseconds and the asset comes back playable=false, tracks=0.
+     * Rebind whenever a suspension has happened since the last bind.
+     */
+    private suspend fun ensureListening() = bindMutex.withLock {
+        if (engine != null && !staleSinceBackground) return@withLock
+
+        engine?.let { old ->
+            Logger.i(tag = TAG) { "rebinding after background — dropping the socket on port $port" }
+            runCatching { old.stop(0, 0) }
+                .onFailure { Logger.w(tag = TAG) { "stopping the stale engine failed: ${it.message}" } }
+        }
+        engine = null
+
+        var lastError: Throwable? = null
+        repeat(MAX_PORT_ATTEMPTS) {
+            val candidate = START_PORT + Random.nextInt(END_PORT - START_PORT)
+            try {
+                startOnPort(candidate)
+                staleSinceBackground = false
+                Logger.i(tag = TAG) { "local video server listening on 127.0.0.1:$candidate" }
+                return@withLock
+            } catch (e: Throwable) {
+                lastError = e
+            }
+        }
+        error("LocalVideoServer failed to bind after $MAX_PORT_ATTEMPTS attempts: ${lastError?.message}")
+    }
+
     private fun startOnPort(port: Int) {
         engine = embeddedServer(CIO, port = port, host = "127.0.0.1") {
             routing {
@@ -168,6 +205,17 @@ class LocalVideoServer private constructor() {
             }
         }.also { it.start(wait = false) }
         this.port = port
+    }
+
+    private fun observeBackgrounding() {
+        NSNotificationCenter.defaultCenter.addObserverForName(
+            name = UIApplicationDidEnterBackgroundNotification,
+            `object` = null,
+            queue = NSOperationQueue.mainQueue,
+        ) {
+            // Only flags; rebinding here would race a player that is still tearing down.
+            staleSinceBackground = true
+        }
     }
 
     companion object {
@@ -182,25 +230,17 @@ class LocalVideoServer private constructor() {
         private val startMutex = Mutex()
 
         suspend fun shared(): LocalVideoServer {
-            instance?.let { return it }
-            startMutex.withLock {
-                instance?.let { return it }
-                val s = LocalVideoServer()
-                var lastError: Throwable? = null
-                repeat(MAX_PORT_ATTEMPTS) {
-                    val candidate = START_PORT + Random.nextInt(END_PORT - START_PORT)
-                    try {
-                        s.startOnPort(candidate)
-                        Logger.i(tag = TAG) { "local video server listening on 127.0.0.1:$candidate" }
-                        instance = s
-                        return s
-                    } catch (e: Throwable) {
-                        lastError = e
-                    }
-                }
-                error("LocalVideoServer failed to bind after $MAX_PORT_ATTEMPTS attempts: ${lastError?.message}")
+            val server = instance ?: startMutex.withLock {
+                instance ?: LocalVideoServer()
+                    .also { it.observeBackgrounding() }
+                    .also { instance = it }
             }
+            server.ensureListening()
+            return server
         }
+
+        /** Teardown-only accessor: never binds, so disposing a player can't revive the server. */
+        fun existing(): LocalVideoServer? = instance
 
         private fun parseRange(header: String?, total: Long): Pair<Long, Long> {
             // AVPlayer sends `bytes=a-b` or `bytes=a-`. Multi-range (comma-separated) is

--- a/homebase-chat/src/nativeMain/kotlin/id/homebase/chat/widget/video/VideoPlayerSurface.native.kt
+++ b/homebase-chat/src/nativeMain/kotlin/id/homebase/chat/widget/video/VideoPlayerSurface.native.kt
@@ -26,6 +26,7 @@ import id.homebase.api.client.peer.PeerFileByGlobalTransitProvider
 import id.homebase.api.video.VideoPreloader
 import id.homebase.api.video.resolveVideoContent
 import id.homebase.chat.conversationlist.FullScreenOverlay
+import id.homebase.core.audio.AudioSession
 import id.homebase.resources.MR
 import id.homebase.resources.video_error_generic
 import org.jetbrains.compose.resources.stringResource
@@ -165,7 +166,7 @@ actual fun VideoPlayerSurface(
                 playing.sessionId?.let { id ->
                     // Server itself stays alive for the app lifetime; just drop the session
                     // so the encrypted-bytes endpoint can't be hit on a stale id.
-                    scope.launch { LocalVideoServer.shared().unregister(id) }
+                    scope.launch { LocalVideoServer.existing()?.unregister(id) }
                 }
                 // Observers + sessionId must be torn down BEFORE returning
                 // the player to the pool — otherwise the recycled player
@@ -261,6 +262,10 @@ actual fun VideoPlayerSurface(
         onProgress(0f)
         withContext(Dispatchers.Main) {
             try {
+                // A finished voice memo leaves the process-wide session in Record, which has
+                // no output route — AVPlayer then decodes fine but never starts, posting
+                // FailedToPlayToEndTime(-66637) at t=0.
+                AudioSession.ensurePlaybackCapable()
                 val videoData = VideoPlayerData(
                     data.fileId, data.driveId, data.payloadKey, data.keyHeader,
                     data.payload.descriptorContent, data.remoteOdinId, data.globalTransitId,

--- a/homebase-common/src/nativeMain/kotlin/id/homebase/core/audio/AudioSession.kt
+++ b/homebase-common/src/nativeMain/kotlin/id/homebase/core/audio/AudioSession.kt
@@ -1,0 +1,85 @@
+@file:OptIn(ExperimentalForeignApi::class)
+
+package id.homebase.core.audio
+
+import co.touchlab.kermit.Logger
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.ObjCObjectVar
+import kotlinx.cinterop.alloc
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.ptr
+import kotlinx.cinterop.value
+import platform.AVFAudio.AVAudioSession
+import platform.AVFAudio.AVAudioSessionCategoryPlayback
+import platform.AVFAudio.AVAudioSessionCategoryRecord
+import platform.AVFAudio.AVAudioSessionSetActiveOptionNotifyOthersOnDeactivation
+import platform.AVFAudio.setActive
+import platform.Foundation.NSError
+
+/**
+ * The one place that touches the process-wide `AVAudioSession` category.
+ *
+ * `AVAudioSessionCategoryRecord` has no output route: a session left there by a
+ * finished voice memo silently kills every later `AVPlayer` in the process — the
+ * media decodes fine but the audio unit refuses to start, and AVPlayer posts
+ * `FailedToPlayToEndTime(CoreMediaErrorDomain -66637)` while stuck at t=0.
+ */
+object AudioSession {
+
+    fun configureForPlayback(): Boolean = activate(AVAudioSessionCategoryPlayback)
+
+    fun configureForRecording(): Boolean = activate(AVAudioSessionCategoryRecord)
+
+    /**
+     * For callers that only need the route to be output-capable. Deliberately does
+     * nothing when it already is, so a muted inline video never interrupts whatever
+     * the user is listening to.
+     */
+    fun ensurePlaybackCapable() {
+        val category = AVAudioSession.sharedInstance().category
+        if (category != AVAudioSessionCategoryRecord) {
+            Logger.d(tag = TAG) { "category=$category — output-capable, left alone" }
+            return
+        }
+        Logger.w(tag = TAG) { "category=Record — moving to Playback so the player can output" }
+        activate(AVAudioSessionCategoryPlayback)
+    }
+
+    /** Drop the route (and the Record category) once a recording is done with it. */
+    fun releaseAfterRecording() = memScoped {
+        val session = AVAudioSession.sharedInstance()
+        val err = alloc<ObjCObjectVar<NSError?>>()
+        session.setActive(
+            false,
+            AVAudioSessionSetActiveOptionNotifyOthersOnDeactivation,
+            err.ptr,
+        )
+        err.value?.let { Logger.w(tag = TAG) { "setActive(false) failed: ${it.localizedDescription}" } }
+        err.value = null
+        // Category, not activation, is what breaks later playback — reset it even when
+        // deactivation failed (another app holding the route, an in-flight interruption).
+        session.setCategory(AVAudioSessionCategoryPlayback, err.ptr)
+        err.value?.let { Logger.e(tag = TAG) { "reset to Playback failed: ${it.localizedDescription}" } }
+    }
+
+    private fun activate(category: String?): Boolean = memScoped {
+        val session = AVAudioSession.sharedInstance()
+        val err = alloc<ObjCObjectVar<NSError?>>()
+
+        session.setCategory(category, err.ptr)
+        err.value?.let {
+            Logger.e(tag = TAG) { "setCategory($category) failed: ${it.localizedDescription}" }
+            return@memScoped false
+        }
+
+        session.setActive(true, err.ptr)
+        err.value?.let {
+            Logger.e(tag = TAG) { "setActive(true) for $category failed: ${it.localizedDescription}" }
+            return@memScoped false
+        }
+
+        true
+    }
+
+    private const val TAG = "AudioSession"
+}

--- a/homebase-common/src/nativeMain/kotlin/id/homebase/core/audio/IOSAudioPlayer.kt
+++ b/homebase-common/src/nativeMain/kotlin/id/homebase/core/audio/IOSAudioPlayer.kt
@@ -17,9 +17,6 @@ import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import platform.AVFAudio.AVAudioPlayer
 import platform.AVFAudio.AVAudioPlayerDelegateProtocol
-import platform.AVFAudio.AVAudioSession
-import platform.AVFAudio.AVAudioSessionCategoryPlayback
-import platform.AVFAudio.setActive
 import platform.Foundation.NSError
 import platform.Foundation.NSFileManager
 import platform.Foundation.NSURL
@@ -34,22 +31,7 @@ class IOSAudioPlayer : AudioPlayer {
 
     @OptIn(ExperimentalForeignApi::class, BetaInteropApi::class)
     override fun play(filePath: String) {
-        // Configure audio session
-        val audioSession = AVAudioSession.sharedInstance()
-        memScoped {
-            val sessionError = alloc<ObjCObjectVar<NSError?>>()
-            audioSession.setCategory(AVAudioSessionCategoryPlayback, sessionError.ptr)
-            sessionError.value?.let { err ->
-                Logger.e { "Failed to set audio session category: ${err.localizedDescription}" }
-                return
-            }
-
-            audioSession.setActive(true, sessionError.ptr)
-            sessionError.value?.let { err ->
-                Logger.e { "Failed to activate audio session: ${err.localizedDescription}" }
-                return
-            }
-        }
+        if (!AudioSession.configureForPlayback()) return
 
         // Create and start player — AVAudioPlayer's ObjC init returns nil for
         // unplayable files, and K/N's interop bridge throws NPE for nil failable

--- a/homebase-common/src/nativeMain/kotlin/id/homebase/core/audio/IOSAudioRecorder.kt
+++ b/homebase-common/src/nativeMain/kotlin/id/homebase/core/audio/IOSAudioRecorder.kt
@@ -9,12 +9,9 @@ import kotlinx.cinterop.memScoped
 import kotlinx.cinterop.ptr
 import kotlinx.cinterop.value
 import platform.AVFAudio.AVAudioRecorder
-import platform.AVFAudio.AVAudioSession
-import platform.AVFAudio.AVAudioSessionCategoryRecord
 import platform.AVFAudio.AVFormatIDKey
 import platform.AVFAudio.AVNumberOfChannelsKey
 import platform.AVFAudio.AVSampleRateKey
-import platform.AVFAudio.setActive
 import platform.CoreAudioTypes.kAudioFormatMPEG4AAC
 import platform.Foundation.NSError
 import platform.Foundation.NSNumber
@@ -39,22 +36,9 @@ class IOSAudioRecorder: AudioRecorder {
         )
 
 
-        // Configure audio session first
-        val audioSession = AVAudioSession.sharedInstance()
+        if (!AudioSession.configureForRecording()) return
+
         memScoped {
-            val sessionError = alloc<ObjCObjectVar<NSError?>>()
-            audioSession.setCategory(AVAudioSessionCategoryRecord, sessionError.ptr)
-            sessionError.value?.let { err ->
-                Logger.e { "Failed to set audio session category: ${err.localizedDescription}" }
-                return
-            }
-
-            audioSession.setActive(true, sessionError.ptr)
-            sessionError.value?.let { err ->
-                Logger.e { "Failed to activate audio session: ${err.localizedDescription}" }
-                return
-            }
-
             val error = alloc<ObjCObjectVar<NSError?>>()
             recorder = AVAudioRecorder(url, settings, error.ptr)
 
@@ -69,6 +53,9 @@ class IOSAudioRecorder: AudioRecorder {
 
     override fun stopRecording(): String? {
         recorder?.stop()
+        // Record has no output route, so leaving the session there mutes every later
+        // AVPlayer in the process. See AudioSession.
+        AudioSession.releaseAfterRecording()
         return recorder?.url?.path
     }
 }


### PR DESCRIPTION
Two independent reasons an iOS video sat silent, both diagnosed from a single user log (`share_1788883596473_9861.log`, build 1.4.1799). Same file, two playback attempts, two different causes.

## 1. The audio session was stuck in `Record`

`IOSAudioRecorder.startRecording()` put the process-wide `AVAudioSession` into `AVAudioSessionCategoryRecord` and `stopRecording()` never took it back out. `Record` has no output route, so every later `AVPlayer` in the process decoded fine and then refused to start.

From the log — a voice memo at `15:25:07`, then a video at `15:49:34`:

```
asset playable=true  duration=48.333s
tick#3 status=ReadyToPlay tracks=2 presentationSize=720.0x1280.0
tick#3 track[0]: mediaType = vide   track[1]: mediaType = soun
Error: AVPlayerItem FailedToPlayToEndTime: CoreMediaErrorDomain:-66637
tick#3 rate=0.0 timeControl=Paused t=0.0s loaded=none
```

Playlist, AES-128 key, byte-ranges and demux all worked — real tracks at the right resolution. `play()` was called, playback never left 0.0 s, and the player paused itself. No `NewErrorLogEntry` was ever posted, so nothing was wrong with the transport or the segments. `-66637` is undocumented by Apple, but the only public reports of it are `AudioOutputUnitStart` failures.

Session handling now lives in one `AudioSession` object:

- the recorder releases the route on stop (covers both `handleStopRecording` and `handleCancelRecording`, which share `stopRecording()`), and resets the category even when deactivation fails — the category, not activation, is what breaks later playback;
- `VideoPlayerSurface` and both `LocalVideoPlayerSurface` composables ask for an output-capable category before creating their player;
- `IOSAudioPlayer` drops its own inline copy of the same code.

The video path intervenes **only** when the category is `Record`, so a muted inline tile still can't interrupt whatever the user is listening to.

## 2. The local video server was dead after a suspend

`LocalVideoServer.shared()` bound a port once and cached the instance forever. iOS drops the listening socket while the app is suspended, so the first playback after a background trip pointed `AVURLAsset` at a dead port:

```
15:49:48  transition fg->bg
16:05:03  transition bg->fg windowMs=915180
16:05:08  session registered …                 ← no "listening on …" line
16:05:08  asset.playable load status=3 (Failed) after 13ms
          asset playable=false tracks=0 duration=0.0s
```

Zero `segment range` lines, no manifest fetch — AVPlayer got nothing.

It now rebinds when a suspension has happened since the last bind, flagged from `UIApplicationDidEnterBackgroundNotification` (flag rather than rebind-in-place, so it can't race a player still tearing down). Teardown uses a new non-binding `existing()` accessor so disposing a player can't revive the server.

## Not needed elsewhere

- **Android** has no local server (ExoPlayer + a custom `HomebaseVideoDataSource`) and never touches `AudioManager` at all.
- **Desktop** creates a fresh `HttpServer` on port 0 per playback and stops it on dispose; `JvmAudioRecorder`'s `TargetDataLine` is a capture line, independent of playback, and is already closed on stop.

## Instrumentation added

Both failures were diagnosable only by inference. Now:

- `AudioSession.ensurePlaybackCapable()` logs the category on every playback, so a log says outright what the session was in.
- `handleManifest` logs — a missing manifest fetch was previously visible only as silence.

## Verification

- `:homebase-common:` and `:homebase-chat:` `compileKotlinIosSimulatorArm64` + `compileKotlinIosArm64` — pass.
- `:homebase-common:compileTestKotlinIosSimulatorArm64` — pass.
- `:homebase-chat:jvmTest :homebase-common:jvmTest` — pass.
- `:homebase-chat:compileTestKotlinIosSimulatorArm64` fails, **pre-existing on main** — backtick test names containing commas in `commonTest/.../contactcard/*` and `widget/MediaPageSourcePlaintextTest.kt`, which the native compiler rejects. `git diff main -- homebase-chat/src/commonTest` is empty.

Not verified on device: the `-66637` attribution is matched against the log and Apple-forum reports, not reproduced under a debugger. The new category logging is what will confirm it on the next capture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)