### PR TITLE
Re-enable reply from an Android chat notification (#1143)

### DIFF
--- a/androidApp/src/main/kotlin/id/homebase/feed/receivers/NotificationReplyReceiver.kt
+++ b/androidApp/src/main/kotlin/id/homebase/feed/receivers/NotificationReplyReceiver.kt
@@ -1,13 +1,20 @@
 package id.homebase.feed.receivers
 
 import android.app.NotificationManager
+import android.app.PendingIntent
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import androidx.core.app.NotificationCompat
 import androidx.core.app.RemoteInput
 import co.touchlab.kermit.Logger
 import id.homebase.chat.services.ChatMessageSenderService
+import id.homebase.core.localization.TranslationUtil
 import id.homebase.core.notifications.RichNotificationDisplayer
+import id.homebase.feed.R
+import id.homebase.resources.MR
+import id.homebase.resources.notification_reply_failed_hint
+import id.homebase.resources.notification_reply_failed_title
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -38,9 +45,7 @@ class NotificationReplyReceiver : BroadcastReceiver(), KoinComponent {
 
         if (replyText.isNullOrEmpty()) return
 
-        Logger.i(tag = "NotificationReply") {
-            "Replying to conversation $conversationId: $replyText"
-        }
+        Logger.i(tag = TAG) { "Replying to conversation $conversationId" }
 
         val pendingResult = goAsync()
         CoroutineScope(Dispatchers.IO).launch {
@@ -60,12 +65,64 @@ class NotificationReplyReceiver : BroadcastReceiver(), KoinComponent {
                     context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
                 nm.cancel(notificationId)
             } catch (e: Exception) {
-                Logger.e(tag = "NotificationReply") {
-                    "Failed to send reply: ${e.message}"
-                }
+                Logger.e(tag = TAG, throwable = e) { "Failed to send reply" }
+                // The typed text only exists here — a cold wake with a locked identity
+                // would otherwise drop it silently.
+                postReplyFailedNotification(context, conversationId, replyText)
             } finally {
                 pendingResult.finish()
             }
         }
+    }
+
+    private suspend fun postReplyFailedNotification(
+        context: Context,
+        conversationId: String,
+        replyText: String,
+    ) {
+        try {
+            val title = TranslationUtil.getString(MR.string.notification_reply_failed_title)
+            val hint = TranslationUtil.getString(MR.string.notification_reply_failed_hint)
+
+            val launchIntent = context.packageManager
+                .getLaunchIntentForPackage(context.packageName) ?: Intent()
+            launchIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+
+            val failedId = replyFailedNotificationId(conversationId, replyText)
+            val notification = NotificationCompat.Builder(context, MESSAGES_CHANNEL_ID)
+                .setSmallIcon(R.mipmap.ic_launcher_monochrome)
+                .setContentTitle(title)
+                .setContentText(replyText)
+                .setStyle(
+                    NotificationCompat.BigTextStyle()
+                        .bigText(replyText)
+                        .setSummaryText(hint)
+                )
+                .setCategory(NotificationCompat.CATEGORY_ERROR)
+                .setAutoCancel(true)
+                .setContentIntent(
+                    PendingIntent.getActivity(
+                        context,
+                        failedId,
+                        launchIntent,
+                        PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+                    )
+                )
+                .build()
+
+            val nm = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            nm.notify(failedId, notification)
+        } catch (e: Exception) {
+            Logger.e(tag = TAG, throwable = e) { "Failed to surface the reply failure" }
+        }
+    }
+
+    private companion object {
+        const val TAG = "NotificationReply"
+        const val MESSAGES_CHANNEL_ID = "messages"
+
+        /** Keyed on the text too, so a second failed reply can't overwrite (and lose) the first. */
+        fun replyFailedNotificationId(conversationId: String, replyText: String): Int =
+            "reply-failed:$conversationId:$replyText".hashCode()
     }
 }

--- a/homebase-common/src/androidMain/kotlin/id/homebase/core/notifications/RichNotificationDisplayer.android.kt
+++ b/homebase-common/src/androidMain/kotlin/id/homebase/core/notifications/RichNotificationDisplayer.android.kt
@@ -212,8 +212,9 @@ actual class RichNotificationDisplayer actual constructor() {
     ) {
         val conversationId = data.conversationId ?: return
 
-        // Direct Reply action — dormant until REPLY_FROM_NOTIFICATION_ENABLED (#1048).
-        if (REPLY_FROM_NOTIFICATION_ENABLED) {
+        // Replying blind to a redacted/placeholder push is meaningless, so Reply rides
+        // on the same content level that shows the message being replied to.
+        if (data.allowsReplyAction) {
             val remoteInput = RemoteInput.Builder(EXTRA_REPLY_TEXT)
                 .setLabel("Reply")
                 .build()
@@ -266,14 +267,6 @@ actual class RichNotificationDisplayer actual constructor() {
     }
 
     companion object {
-        /**
-         * Reply-from-notification is disabled until the flow is hardened (#1048): the send can
-         * silently fail from a cold/headless BroadcastReceiver wake, and replying blind to the
-         * content-less "You have a new message" push (#859) is nonsensical. Flip to `true` to
-         * re-enable once those land. The receiver ([NotificationReplyReceiver]) is kept dormant.
-         */
-        const val REPLY_FROM_NOTIFICATION_ENABLED = false
-
         /** Recent messages kept in a conversation's stacked notification (Android shows ~7). */
         private const val MAX_STACKED_MESSAGES = 6
 

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -2195,4 +2195,6 @@
     <string name="webdrop_error_create">Couldn't create the drop link</string>
     <string name="webdrop_error_source_unreadable">Couldn't read %1$s — please pick it again</string>
     <string name="webdrop_error_too_many">A drop can hold at most %1$d files</string>
+    <string name="notification_reply_failed_title">Couldn't send your reply</string>
+    <string name="notification_reply_failed_hint">Tap to open Homebase and send it again</string>
 </resources>

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/notifications/RichNotificationData.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/notifications/RichNotificationData.kt
@@ -38,6 +38,13 @@ data class RichNotificationData(
     val showsRealContent: Boolean = false,
 )
 
+/**
+ * Whether a notification may offer the direct-reply action. Replying blind to a redacted or
+ * placeholder push has nothing to reply to, so reply rides on the level that shows real text.
+ */
+val RichNotificationData.allowsReplyAction: Boolean
+    get() = showsRealContent && hasContent
+
 /** Extension to generate a stable notification ID from the conversation ID or a random one. */
 internal val PushNotificationPayloadOptions.conversationNotificationId: Int
     get() = typeId.hashCode().let { if (it == 0) kotlin.random.Random.nextInt() else it }

--- a/homebase-common/src/jvmTest/kotlin/id/homebase/core/notifications/ReplyActionGateTest.kt
+++ b/homebase-common/src/jvmTest/kotlin/id/homebase/core/notifications/ReplyActionGateTest.kt
@@ -1,0 +1,47 @@
+package id.homebase.core.notifications
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The direct-reply action must never be offered on a redacted or placeholder push — there is
+ * nothing on screen to reply to, and the user would be answering blind.
+ */
+class ReplyActionGateTest {
+
+    private fun data(hasContent: Boolean, showsRealContent: Boolean) = RichNotificationData(
+        notificationId = 1,
+        channelId = "messages",
+        conversationId = "conversation",
+        title = "Sender",
+        body = "body",
+        senderName = "Sender",
+        senderId = "sender.example.com",
+        senderImageBytes = null,
+        timestamp = 0L,
+        payloadData = emptyMap(),
+        hasContent = hasContent,
+        showsRealContent = showsRealContent,
+    )
+
+    @Test
+    fun allowsReply_onlyWhenRealContentIsShown() {
+        assertTrue(data(hasContent = true, showsRealContent = true).allowsReplyAction)
+    }
+
+    @Test
+    fun blocksReply_onPlaceholderBody() {
+        assertFalse(data(hasContent = false, showsRealContent = true).allowsReplyAction)
+    }
+
+    @Test
+    fun blocksReply_onRedactedContentLevel() {
+        assertFalse(data(hasContent = true, showsRealContent = false).allowsReplyAction)
+    }
+
+    @Test
+    fun blocksReply_byDefault() {
+        assertFalse(data(hasContent = false, showsRealContent = false).allowsReplyAction)
+    }
+}


### PR DESCRIPTION
Fixes #1143 (Android steps 1–4). **iOS (step 5) stays deferred on #1091** — nothing in `iosApp/` is touched and `replyFromNotificationEnabled` remains `false`.

## What changed

**1. The Reply action is gated on content, not on a blanket flag**

`RichNotificationDisplayer.android.kt`'s `addNotificationActions` used to check
`REPLY_FROM_NOTIFICATION_ENABLED`, a `const val false`. It now checks the notification's own
content level:

```kotlin
val RichNotificationData.allowsReplyAction: Boolean
    get() = showsRealContent && hasContent
```

- `showsRealContent` — the user's notification-content preference is `name_content_actions`
  (false at `name_only` / `no_name_or_content`).
- `hasContent` — the body is a real decrypted message, not the sender-side
  `"You have a new message"` placeholder or a `NotificationBodyFormer` fallback.

Both are already set by `NotificationService` (#1070) and are independent, so Reply is offered
only when the message being replied to is actually on screen. It is never offered on a redacted
or placeholder push.

The predicate lives in `commonMain` next to the flags it reads, so iOS can reuse the same gate
when #1091 lands.

**2. A failed send no longer vanishes silently**

`NotificationReplyReceiver` caught the exception and only logged it. `sendNewMessage` throws on
every non-`Enqueued` outbox outcome (`sendMessageInternal` maps `AlreadyQueued` /
`WouldStrandCreate` / `Failed` to `error(...)` and `SourceMissing` to
`SourceUnavailableException`), so the single `catch` is the whole failure surface.

On failure the receiver now re-posts a notification on the `messages` channel:

- title: *Couldn't send your reply*
- body / `BigTextStyle`: **the user's typed text, verbatim**
- summary line: *Tap to open Homebase and send it again*
- `CATEGORY_ERROR`, `setAutoCancel(true)`, tap opens the app via the launcher intent

This is Option A from the issue — a simple re-post, not a composer-prefill deep link. Two
deliberate choices worth reviewing:

- The notification id is `"reply-failed:$conversationId:$replyText".hashCode()`. Keying on the
  text means a second failed reply cannot overwrite (and destroy) the first one's text; an
  identical retry still coalesces.
- The tap opens the app, not the specific conversation. Routing to the conversation needs the
  original push `data` map (`handleNotificationClicked` consumes the raw payload; `typeId` +
  `tagId` alone are not enough), and round-tripping that through the broadcast intent is more
  machinery than Option A calls for. The text is preserved on the notification for copy/paste,
  which is what the issue asked for.

Also dropped the user's reply text from the `Logger.i` line — it was writing plaintext message
content into the persistent on-device `homebase.log`, which is at odds with the deliberate
"never put real message text on the wire" design the issue calls out.

**3. Gate flipped on. 4. `REPLY_FROM_NOTIFICATION_ENABLED` removed** — nothing else read it
(`grep` across `*.kt` / `*.swift` found only its declaration and its one use).

## New strings

`homebase-common/src/commonMain/composeResources/values/strings.xml`, read from the receiver
(non-Compose context) via the existing `TranslationUtil.getString`:

```xml
<string name="notification_reply_failed_title">Couldn't send your reply</string>
<string name="notification_reply_failed_hint">Tap to open Homebase and send it again</string>
```

## Not re-litigated (per the issue)

The send is durable once enqueued — persistent SQLDelight outbox drained by DriveSync with
retries; #1048's "10s `goAsync` window too short for network" was a misdiagnosis. No real message
text goes on the push wire. Mark-as-Read is unchanged.

## Verification

Static only.

```
$ ./gradlew :homebase-common:compileAndroidMain :androidApp:compileDebugKotlin
...
> Task :androidApp:compileDebugKotlin

BUILD SUCCESSFUL in 2m 16s
85 actionable tasks: 61 executed, 24 from cache
```

```
$ ./gradlew homebase-chat:jvmTest homebase-common:jvmTest --rerun-tasks
...
> Task :homebase-chat:jvmTest

BUILD SUCCESSFUL in 3m 7s
60 actionable tasks: 60 executed
```

Aggregated from the JUnit XML of both modules: `tests=2012 failures+errors=0 skipped=6`.

New test `ReplyActionGateTest` (`homebase-common/src/jvmTest`) pins the gate's truth table:

```
ReplyActionGateTest[jvm] tests=4 failures=0 errors=0
  allowsReply_onlyWhenRealContentIsShown[jvm] OK
  blocksReply_onPlaceholderBody[jvm] OK
  blocksReply_byDefault[jvm] OK
  blocksReply_onRedactedContentLevel[jvm] OK
```

## Not verified on device — needs an on-device cold-wake reply test (issue step 2)

No device was available for this change. Step 2 of the issue — kill the app, fire a push, reply
from the notification, confirm the outbox insert and eventual delivery — has **not** been run,
and neither has the failure path (force a locked identity on a cold wake and confirm the
"Couldn't send your reply" notification appears with the typed text intact). Both should be
exercised before this ships.
