### PR TITLE
Show the year in chat date separators for prior-year messages

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationContent.kt
@@ -2305,16 +2305,34 @@ private val FloatingDateShape = RoundedCornerShape(12.dp)
 private fun getDateSectionLabel(messageDate: LocalDate): String {
     val timezone = TimeZone.currentSystemDefault()
     val today = Clock.System.now().toLocalDateTime(timezone).date
+    return dateSectionLabel(
+        messageDate = messageDate,
+        today = today,
+        todayLabel = stringResource(MR.string.time_today),
+        yesterdayLabel = stringResource(MR.string.time_yesterday),
+    )
+}
+
+internal fun dateSectionLabel(
+    messageDate: LocalDate,
+    today: LocalDate,
+    todayLabel: String,
+    yesterdayLabel: String,
+): String {
     val yesterday = today.minus(1, DateTimeUnit.DAY)
 
     return when (messageDate) {
-        today -> stringResource(MR.string.time_today)
-        yesterday -> stringResource(MR.string.time_yesterday)
+        today -> todayLabel
+        yesterday -> yesterdayLabel
         else -> {
             val format = LocalDate.Format {
                 monthName(MonthNames.ENGLISH_ABBREVIATED)
                 char(' ')
                 day()
+                if (messageDate.year != today.year) {
+                    chars(", ")
+                    year()
+                }
             }
             messageDate.format(format)
         }

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/widget/DateSectionLabelTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/widget/DateSectionLabelTest.kt
@@ -1,0 +1,54 @@
+package id.homebase.chat.widget
+
+import kotlinx.datetime.LocalDate
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DateSectionLabelTest {
+
+    private val today = LocalDate(2026, 9, 9)
+
+    @Test
+    fun label_isTodayLabel_forToday() {
+        val result = dateSectionLabel(
+            messageDate = today,
+            today = today,
+            todayLabel = "Today",
+            yesterdayLabel = "Yesterday",
+        )
+        assertEquals("Today", result)
+    }
+
+    @Test
+    fun label_isYesterdayLabel_forYesterday() {
+        val result = dateSectionLabel(
+            messageDate = LocalDate(2026, 9, 8),
+            today = today,
+            todayLabel = "Today",
+            yesterdayLabel = "Yesterday",
+        )
+        assertEquals("Yesterday", result)
+    }
+
+    @Test
+    fun label_omitsYear_forDateEarlierThisYear() {
+        val result = dateSectionLabel(
+            messageDate = LocalDate(2026, 1, 1),
+            today = today,
+            todayLabel = "Today",
+            yesterdayLabel = "Yesterday",
+        )
+        assertEquals("Jan 01", result)
+    }
+
+    @Test
+    fun label_includesYear_forDateInPreviousYear() {
+        val result = dateSectionLabel(
+            messageDate = LocalDate(2025, 1, 1),
+            today = today,
+            todayLabel = "Today",
+            yesterdayLabel = "Yesterday",
+        )
+        assertEquals("Jan 01, 2025", result)
+    }
+}


### PR DESCRIPTION
## Problem

The date-separator chip between message groups in the chat screen shows e.g. `Jan 01` with no year. For a message from a previous year, the chip looks identical to one from this year — the reader has no way to tell it's old.

## Before / after

| Message date | Before | After |
|---|---|---|
| Today | `Today` | `Today` (unchanged) |
| Yesterday | `Yesterday` | `Yesterday` (unchanged) |
| Earlier this year | `Jan 01` | `Jan 01` (unchanged) |
| A previous year | `Jan 01` | `Jan 01, 2025` |

## Change

`getDateSectionLabel()` in `ConversationContent.kt` built the fallback date string with a fixed `LocalDate.Format { monthName(...); char(' '); day() }`, with no year component at all. Added the year to that format when `messageDate.year != today.year`.

Pulled the pure formatting logic (previously inline in the `@Composable`, which also resolves the Today/Yesterday string resources) out into an internal `dateSectionLabel(messageDate, today, todayLabel, yesterdayLabel)` function so it's unit-testable without a Compose runtime; the composable now just resolves the two string resources and delegates to it. Both existing call sites (the inline section header and the floating date chip) go through the same `getDateSectionLabel()`, so both pick up the fix.

## Verification

```
./gradlew :homebase-chat:compileKotlinJvm :homebase-chat:compileAndroidMain :homebase-chat:compileKotlinWasmJs
...
BUILD SUCCESSFUL in 1m 16s
93 actionable tasks: 68 executed, 25 from cache
```

```
./gradlew homebase-chat:jvmTest --rerun-tasks
...
BUILD SUCCESSFUL in 2m 47s
56 actionable tasks: 56 executed
```

New test `DateSectionLabelTest` (4 cases: today, yesterday, earlier-this-year, previous-year) all pass.

Mutation check: temporarily removed the `if (messageDate.year != today.year) { ... }` block (function still compiles, matching the old always-no-year behavior) and reran the targeted test:

```
DateSectionLabelTest[jvm] > label_includesYear_forDateInPreviousYear[jvm] FAILED
4 tests completed, 1 failed
```

The other three cases still passed, confirming the new test isolates the year-inclusion behavior. Restored the fix and reran the full suite — `BUILD SUCCESSFUL`, all green.

No issue filed for this; reported directly by a user screenshot showing a `Jan 01` chip above messages that are actually years old.