### PR TITLE
Stop chat info and new-conversation from taking over the desktop window

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListScreen.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListScreen.kt
@@ -48,6 +48,7 @@ import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
@@ -180,6 +181,12 @@ fun ConversationListScreen(
     onNavigateToDrawer: (requestId: Uuid) -> Unit = {},
     onDetailPaneVisibilityChanged: (Boolean) -> Unit = {},
     onSaveContactCard: (ContactCardDescriptor) -> Unit = {},
+    /** Hosts the new-conversation flow inside the list pane on an expanded window instead of
+     *  pushing [onNavigateToNewConversation]. Null keeps the full-screen route on every width. */
+    newConversationPane: (@Composable (
+        onDismiss: () -> Unit,
+        onConversationOpened: (Uuid) -> Unit,
+    ) -> Unit)? = null,
 ) {
     val conversationsUiState by viewModel.uiState.collectAsStateWithLifecycle()
     val messagesUiState by viewModel.messagesUiState.collectAsStateWithLifecycle()
@@ -187,6 +194,10 @@ fun ConversationListScreen(
     val snackbarHostState = remember { SnackbarHostState() }
     val scope = rememberCoroutineScope()
     val fileSystemHandler = getUriHandler()
+    var newConversationInPane by remember { mutableStateOf(false) }
+    // Read through rememberUpdatedState: the event collector below is keyed on Unit, so a plain
+    // capture would pin whatever width the first composition saw.
+    val paneCapable = rememberUpdatedState(newConversationPane != null && isExpandedLayout())
     // Check for missing permissions and show dialog if needed
     ExtendPermissionDialog(
         viewModel = extendPermissionViewModel,
@@ -241,7 +252,9 @@ fun ConversationListScreen(
                     }
                 }
 
-                is ConversationListUiEvent.NavigateToNewConversation -> onNavigateToNewConversation()
+                is ConversationListUiEvent.NavigateToNewConversation ->
+                    if (paneCapable.value) newConversationInPane = true
+                    else onNavigateToNewConversation()
 
                 is ConversationListUiEvent.NavigateToLiveLocationMap -> onNavigateToLiveLocationMap()
 
@@ -539,7 +552,10 @@ fun ConversationListScreen(
             messagesSearchTextState = viewModel.messagesSearchTextState,
             onUiAction = viewModel::onAction,
             onNavigateToSettingsScreen = onNavigateToSettingsScreen,
-            onDetailPaneVisibilityChanged = onDetailPaneVisibilityChanged
+            onDetailPaneVisibilityChanged = onDetailPaneVisibilityChanged,
+            newConversationPane = newConversationPane,
+            showNewConversationPane = newConversationInPane,
+            onNewConversationPaneDismissed = { newConversationInPane = false },
         )
 
         conversationsUiState.inFlightOperationLabel?.let { label ->
@@ -757,6 +773,12 @@ fun ConversationListUi(
      *  caller that doesn't drive events still compiles. */
     onNavigateToSettingsScreen: () -> Unit,
     onDetailPaneVisibilityChanged: (Boolean) -> Unit = {},
+    newConversationPane: (@Composable (
+        onDismiss: () -> Unit,
+        onConversationOpened: (Uuid) -> Unit,
+    ) -> Unit)? = null,
+    showNewConversationPane: Boolean = false,
+    onNewConversationPaneDismissed: () -> Unit = {},
 ) {
     val windowAdaptiveInfo = currentWindowAdaptiveInfo()
     val defaultDirective = calculatePaneScaffoldDirective(windowAdaptiveInfo)
@@ -917,6 +939,22 @@ fun ConversationListUi(
             scaffoldState = scaffoldNavigator.scaffoldState,
             listPane = {
                 AnimatedPane(modifier = Modifier) {
+                    val pane = newConversationPane
+                    if (showNewConversationPane && pane != null) {
+                        pane(onNewConversationPaneDismissed) { conversationId ->
+                            onNewConversationPaneDismissed()
+                            onUiAction(
+                                ConversationListUiAction.ConversationClicked(conversationId, null)
+                            )
+                            scope.launch {
+                                scaffoldNavigator.navigateTo(
+                                    ListDetailPaneScaffoldRole.Detail,
+                                    conversationId,
+                                )
+                            }
+                        }
+                        return@AnimatedPane
+                    }
                     ConversationListPane(
                         uiState = uiState,
                         selectedConversationId = scaffoldNavigator.currentDestination?.contentKey,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListScreen.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListScreen.kt
@@ -73,6 +73,7 @@ import id.homebase.chat.archivedconversations.ArchivedConversationsUiState
 import id.homebase.chat.archivedconversations.ArchivedConversationsViewModel
 import id.homebase.chat.contactcard.ContactCardDescriptor
 import id.homebase.chat.widget.ConversationListPane
+import id.homebase.chat.widget.paneTrailingEdge
 import id.homebase.chat.widget.ConversationMessagesPane
 import id.homebase.chat.widget.EmptyDetailPane
 import id.homebase.chat.widget.ExtendPermissionDialog
@@ -941,16 +942,21 @@ fun ConversationListUi(
                 AnimatedPane(modifier = Modifier) {
                     val pane = newConversationPane
                     if (showNewConversationPane && pane != null) {
-                        pane(onNewConversationPaneDismissed) { conversationId ->
-                            onNewConversationPaneDismissed()
-                            onUiAction(
-                                ConversationListUiAction.ConversationClicked(conversationId, null)
-                            )
-                            scope.launch {
-                                scaffoldNavigator.navigateTo(
-                                    ListDetailPaneScaffoldRole.Detail,
-                                    conversationId,
+                        Box(modifier = Modifier.fillMaxSize().paneTrailingEdge()) {
+                            pane(onNewConversationPaneDismissed) { conversationId ->
+                                onNewConversationPaneDismissed()
+                                onUiAction(
+                                    ConversationListUiAction.ConversationClicked(
+                                        conversationId,
+                                        null,
+                                    )
                                 )
+                                scope.launch {
+                                    scaffoldNavigator.navigateTo(
+                                        ListDetailPaneScaffoldRole.Detail,
+                                        conversationId,
+                                    )
+                                }
                             }
                         }
                         return@AnimatedPane

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationListPane.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/ConversationListPane.kt
@@ -113,6 +113,25 @@ import id.homebase.resources.search
 import org.jetbrains.compose.resources.stringResource
 import kotlin.uuid.Uuid
 
+@Composable
+internal fun Modifier.paneTrailingEdge(): Modifier {
+    val twoPaneWindow = isExpandedLayout()
+    val paneEdgeColor = MaterialTheme.colorScheme.outlineVariant
+    return drawWithContent {
+        drawContent()
+        if (!twoPaneWindow) return@drawWithContent
+        val stroke = 1.dp.toPx()
+        val x = if (layoutDirection == LayoutDirection.Rtl) stroke / 2f
+        else size.width - stroke / 2f
+        drawLine(
+            color = paneEdgeColor,
+            start = Offset(x, 0f),
+            end = Offset(x, size.height),
+            strokeWidth = stroke,
+        )
+    }
+}
+
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalComposeUiApi::class)
 @Composable
 fun ConversationListPane(
@@ -131,7 +150,6 @@ fun ConversationListPane(
     val searchTyping by remember(searchTextState) { derivedStateOf { searchTextState.text.isNotEmpty() } }
     val searchActive = uiState.isSearchActive || (persistentSearch && searchTyping)
     val paneContainerColor = MaterialTheme.colorScheme.surfaceContainerLowest
-    val paneEdgeColor = MaterialTheme.colorScheme.outlineVariant
     val topBarState = rememberTopAppBarState()
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior(topBarState)
     val listState = rememberLazyListState()
@@ -185,19 +203,7 @@ fun ConversationListPane(
         Scaffold(
             modifier = Modifier
                 .nestedScroll(scrollBehavior.nestedScrollConnection)
-                .drawWithContent {
-                    drawContent()
-                    if (!twoPaneWindow) return@drawWithContent
-                    val stroke = 1.dp.toPx()
-                    val x = if (layoutDirection == LayoutDirection.Rtl) stroke / 2f
-                    else size.width - stroke / 2f
-                    drawLine(
-                        color = paneEdgeColor,
-                        start = Offset(x, 0f),
-                        end = Offset(x, size.height),
-                        strokeWidth = stroke,
-                    )
-                },
+                .paneTrailingEdge(),
             topBar = {
                 if (uiState.showArchived) {
                     TopAppBar(

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
@@ -1132,7 +1132,7 @@ fun AppNavHost(
                             }
                         }
 
-                        composable<Route.ContactBookDetail> {
+                        paneDestination<Route.ContactBookDetail>(onDismiss = { navController.popBackStack() }) {
                             if (isAuthenticated) {
                                 ContactDetailScreen(
                                     viewModel = koinViewModel(),
@@ -1155,7 +1155,15 @@ fun AppNavHost(
                                         navController.navigate(Route.ConversationMedia(conversationId))
                                     },
                                     onOpenContact = { uniqueId, odinId ->
-                                        navController.navigate(Route.ContactBookDetail(uniqueId, odinId))
+                                        navController.navigate(
+                                            Route.ContactBookDetail(uniqueId, odinId)
+                                        ) {
+                                            if (isDesktopOrWeb()) {
+                                                popUpTo<Route.ContactBookDetail> {
+                                                    inclusive = true
+                                                }
+                                            }
+                                        }
                                     },
                                 )
                             }
@@ -1315,6 +1323,26 @@ fun AppNavHost(
                                         showingOnlyDetailPane = it
                                     },
                                     onSaveContactCard = { pendingContactCard = it },
+                                    newConversationPane = { onDismiss, onConversationOpened ->
+                                        NewConversationPaneHost(
+                                            onDismiss = onDismiss,
+                                            onShowConversation = onConversationOpened,
+                                            onCreateGroup = { ids ->
+                                                // Closed before the hand-off: naming the group is
+                                                // a destination, so returning from it lands on the
+                                                // list, not a half-finished picker behind it.
+                                                onDismiss()
+                                                navController.navigate(
+                                                    Route.CreateConversationGroup(ids)
+                                                )
+                                            },
+                                            onAddContact = {
+                                                navController.navigate(
+                                                    Route.AddContact(identityOnly = true)
+                                                )
+                                            },
+                                        )
+                                    },
                                 )
                             }
                         }
@@ -1354,7 +1382,7 @@ fun AppNavHost(
                             }
                         }
 
-                        composable<Route.CreateConversationGroup> {
+                        paneDestination<Route.CreateConversationGroup>(onDismiss = { navController.popBackStack() }) {
                             if (isAuthenticated) {
                                 CreateConversationGroupScreen(
                                     viewModel = koinViewModel(),
@@ -1435,7 +1463,7 @@ fun AppNavHost(
                             }
                         }
 
-                        composable<Route.ConversationSettings> {
+                        paneDestination<Route.ConversationSettings>(onDismiss = { navController.popBackStack() }) {
                             if (isAuthenticated) {
                                 ConversationSettingsScreen(
                                     viewModel = koinViewModel(),
@@ -1474,7 +1502,7 @@ fun AppNavHost(
                             }
                         }
 
-                        composable<Route.GroupSettings> {
+                        paneDestination<Route.GroupSettings>(onDismiss = { navController.popBackStack() }) {
                             if (isAuthenticated) {
                                 GroupSettingsScreen(
                                     viewModel = koinViewModel(),
@@ -1529,7 +1557,7 @@ fun AppNavHost(
                             }
                         }
 
-                        settingsDestination<Route.Settings>(
+                        paneDestination<Route.Settings>(
                             onDismiss = { navController.popBackStack() },
                             paneContent = {
                                 if (isAuthenticated) {

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/NewConversationPaneHost.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/NewConversationPaneHost.kt
@@ -1,0 +1,65 @@
+@file:OptIn(ExperimentalUuidApi::class)
+
+package id.homebase.core.ui.navigation
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModelStore
+import androidx.lifecycle.ViewModelStoreOwner
+import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
+import id.homebase.chat.createconversation.CreateConversationScreen
+import id.homebase.chat.selectmembers.SelectMembersScreen
+import org.koin.compose.viewmodel.koinViewModel
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+private enum class NewConversationStep { PickContact, SelectMembers }
+
+/**
+ * The new-conversation flow rendered inside the conversation-list pane on an expanded window.
+ *
+ * Only the two steps whose ViewModels take no route arguments live here; naming the group reads
+ * its member list from [id.homebase.core.ui.navigation.Route.CreateConversationGroup], so it stays
+ * a destination and [onCreateGroup] hands it over.
+ */
+@Composable
+internal fun NewConversationPaneHost(
+    onDismiss: () -> Unit,
+    onShowConversation: (Uuid) -> Unit,
+    onCreateGroup: (contactIds: List<String>) -> Unit,
+    onAddContact: () -> Unit,
+) {
+    // A destination clears its ViewModelStore when it pops; this pane has no destination of its
+    // own, so without a scoped store the picker would reopen holding the last run's selection.
+    val storeOwner = remember { NewConversationPaneStoreOwner() }
+    DisposableEffect(storeOwner) { onDispose { storeOwner.viewModelStore.clear() } }
+
+    var step by remember { mutableStateOf(NewConversationStep.PickContact) }
+
+    CompositionLocalProvider(LocalViewModelStoreOwner provides storeOwner) {
+        when (step) {
+            NewConversationStep.PickContact -> CreateConversationScreen(
+                viewModel = koinViewModel(),
+                onNavigateBack = onDismiss,
+                onShowConversation = onShowConversation,
+                onShowCreateGroup = { step = NewConversationStep.SelectMembers },
+                onAddContact = onAddContact,
+            )
+
+            NewConversationStep.SelectMembers -> SelectMembersScreen(
+                viewModel = koinViewModel(),
+                onNavigateBack = { step = NewConversationStep.PickContact },
+                onMembersSelected = onCreateGroup,
+            )
+        }
+    }
+}
+
+private class NewConversationPaneStoreOwner : ViewModelStoreOwner {
+    override val viewModelStore = ViewModelStore()
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/PaneDestination.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/PaneDestination.kt
@@ -42,22 +42,26 @@ private const val PaneHeightFraction = 0.9f
  *
  * Gated on the platform, not the window width, because `NavHost` rebuilds its graph when the
  * builder lambda changes and that resets the back stack; width is decided inside
- * [SettingsPaneContainer], which falls back to [content] below the expanded breakpoint.
+ * [FloatingPaneContainer], which falls back to [content] below the expanded breakpoint.
  *
- * [paneContent] must host its own sub-pages rather than pushing routes: a second dialog layer
- * stacks a second platform scrim (`Color.Black` @ 0.6 each, not settable from commonMain) and the
- * app behind goes near-black, which is the thing this pane exists to avoid.
+ * [paneContent] defaults to [content]; pass it only when the floating form needs a different
+ * layout (as settings does, which turns its list of sub-pages into a sidebar).
+ *
+ * Every stacked pane adds a platform scrim (`Color.Black` @ 0.6, not settable from commonMain), so
+ * a pane that can reach itself must replace rather than push — otherwise repeated drill-down walks
+ * the backdrop to black. A pushed ordinary `composable` route costs nothing here: it hides the
+ * pane until it pops.
  */
-internal inline fun <reified T : Any> NavGraphBuilder.settingsDestination(
+internal inline fun <reified T : Any> NavGraphBuilder.paneDestination(
     noinline onDismiss: () -> Unit,
-    noinline paneContent: @Composable () -> Unit,
+    noinline paneContent: (@Composable () -> Unit)? = null,
     noinline content: @Composable () -> Unit,
 ) {
     if (isDesktopOrWeb()) {
         dialog<T>(dialogProperties = DialogProperties(usePlatformDefaultWidth = false)) {
-            SettingsPaneContainer(
+            FloatingPaneContainer(
                 onDismiss = onDismiss,
-                paneContent = paneContent,
+                paneContent = paneContent ?: content,
                 content = content,
             )
         }
@@ -67,7 +71,7 @@ internal inline fun <reified T : Any> NavGraphBuilder.settingsDestination(
 }
 
 @Composable
-internal fun SettingsPaneContainer(
+internal fun FloatingPaneContainer(
     onDismiss: () -> Unit,
     paneContent: @Composable () -> Unit,
     content: @Composable () -> Unit,


### PR DESCRIPTION
Two Desktop (expanded-layout) navigation bugs reported with screenshots. No issue exists for
either, so they're described here. Both are the same root cause — phone navigation leaking onto
an expanded window — so they're one PR.

## Bug 1 — conversation info took over the whole window

**Before:** clicking the conversation header on Desktop replaced the entire two-pane layout with a
full-window screen and a back arrow: `GroupSettingsScreen` for a group, `ContactDetailScreen` for a
1:1, `ConversationSettingsScreen` for note-to-self.

**After:** all three open as a floating pane over the intact layout — the conversation list and the
open conversation stay mounted and visible behind it. Compact/phone is unchanged (full screen with
a back arrow, which is correct there).

### Third pane vs dialog

Dialog, reusing the settings pattern — it was by far the smaller change and the consistent one.

`settingsDestination` already did exactly this: register as `dialog<T>` on desktop/web and as an
ordinary `composable<T>` everywhere else, with `SettingsPaneContainer` deciding floating vs
full-bleed off `isExpandedLayout()`. Generalising it was a rename plus one nullable parameter:
`paneDestination`, with `paneContent` defaulting to `content` so a screen that needs no separate
floating layout passes nothing. Settings keeps its sidebar `paneContent` untouched.

A third pane would have meant threading an Extra role through `ListDetailPaneScaffold` and moving
these screens out of `AppNavHost` into the scaffold. That is blocked anyway: all three info
ViewModels read their arguments via `savedStateHandle.toRoute<Route…>()`, so they must stay
NavHost destinations.

### One thing worth reviewing

Every stacked pane adds a platform scrim (`Color.Black` @ 0.6). It is only settable on the skiko
`DialogProperties` actual, not from commonMain, so the existing KDoc's warning still holds and I
kept it (reworded to name the real hazard).

`ContactBookDetail` can reach *itself* (`onOpenContact`, from the mutual-contacts row), which is the
unbounded case — repeated drill-down would walk the backdrop to black. On desktop/web that hop now
replaces the pane instead of pushing; phone keeps the push and its back behaviour.

Group info -> member -> contact detail still stacks one pane on another. I left it: the depth is
fixed at one, the lower pane is an opaque surface so it reads as a normal nested modal, and `back`
correctly returns to group info. Collapsing it would have cost that.

Note this makes `ContactBookDetail` a pane everywhere on desktop, including from the contact book —
a wider blast radius than the reported bug, but the same "don't destroy the layout" behaviour, and
consistent with how it now opens from chat.

## Bug 2 — "New conversation" switched the entire screen

**Before:** the compose/pencil button in the chat-list header pushed `Route.CreateConversation`,
replacing the whole window with the new-conversation flow.

**After:** it opens inside the conversation-list pane (the left column) and stays there. Picking a
contact opens that conversation in the detail pane on the right; the layout is never destroyed.

`NewConversationPane.kt` exists but is dead and is a strict subset of the real screen (no "New
group", no "Note to Self", no add-contact), so reviving it would have dropped functionality. I
hosted the real screens in the pane instead and left that file alone.

`NewConversationPaneHost` (homebase-core, where `koinViewModel()` and the nav callbacks already
live) hosts the two steps whose ViewModels take no route arguments — the contact picker and
select-members — under a **scoped `ViewModelStore`**. That part is load-bearing: a destination
clears its store when it pops, so without one the picker would reopen holding the previous run's
search text and member selection, which is not how it behaves today on phone.

`ConversationListScreen` takes the flow as a composable slot, so homebase-chat gains no new
dependency and no navigation knowledge. The expanded check is read through `rememberUpdatedState`
— the event collector is keyed on `Unit`, so a plain capture would pin whatever width the first
composition saw, and the size class this repo already knows is stale right after a resize.

**Where it stops:** naming the group (`CreateConversationGroup`) reads its member list off the
route, so it stays a destination — but registered through `paneDestination`, so it floats over the
intact layout rather than taking the window. The picker closes before handing over, so returning
from it lands on the conversation list rather than a half-finished picker. Compact keeps the
original full-screen route on every step.

## Verification

Per-target compiles:

```
./gradlew :homebase-chat:compileKotlinJvm :homebase-chat:compileAndroidMain \
  :homebase-chat:compileKotlinWasmJs :homebase-core:compileKotlinJvm \
  :homebase-core:compileAndroidMain :homebase-core:compileKotlinWasmJs

BUILD SUCCESSFUL in 4m 8s
```

Tests (`--rerun-tasks`), including the Konsist `ArchitectureTest` that fails on hardcoded
Composable strings — no new user-facing strings were added:

```
./gradlew homebase-chat:jvmTest homebase-common:jvmTest homebase-core:jvmTest --rerun-tasks

BUILD SUCCESSFUL in 2m 15s

homebase-chat:   1386 tests, 0 failures, 6 skipped
homebase-common:  622 tests, 0 failures, 0 skipped
homebase-core:    677 tests, 0 failures, 2 skipped
```

### Visual pass — what I actually saw, and what I didn't

I could **not** drive the live Desktop app: the installed `Homebase Chat.app` was running and holds
the `SingleInstanceManager` lock, so `desktopApp:run` booted and exited immediately every time.
Killing it would have dropped a live logged-in session, so I didn't.

Instead I used the `runDesktopComposeUiTest` + `captureToImage()` harness this repo has used
before, at 1440x900, and read the PNGs. The harness confirmed `isExpandedLayout() == true` at that
size, so the floating branch was genuinely the one exercised — not the compact fallback.

- **Bug 1:** the real `FloatingPaneContainer` renders a centred rounded surface at its 92%/90%
  fractions under the 980x800 cap, with the conversation list and conversation still visible behind
  the scrim. Content was a stand-in shaped like the group-info screen (avatar, title, "4 members",
  Leave group, Group files) — the real `GroupSettingsUi` needs a populated `ConversationUiModel`,
  and pane geometry was the thing under test.
- **Bug 2:** the **real** `CreateConversationUi` rendered in a 360dp left column beside a
  conversation — back arrow, search field, New group / Note to Self / New contact all fitting
  cleanly, layout intact.

The harness was deleted before committing; it is not in this diff.

## Verified on the live Desktop app

Since re-checked against a real window (the installed app was quit to release the
`SingleInstanceManager` lock):

| Check | Result |
|---|---|
| Group info from header | Floats over an intact 2-pane layout, single scrim |
| 1:1 conversation info | Same |
| New conversation | Opens inside the list pane; detail pane keeps the open conversation |
| New group -> select members | Stays in the list pane |
| Name-this-group | Floating pane, picker correctly closed behind it |
| Escape / back from a stacked pane | Returns to group info, scrim depth back to one |
| Compact (<840dp) | Pane goes full-bleed; compose FAB still pushes the full-screen route |
| Resize back across 840dp | Re-floats correctly |
| Pane scrolling | All members, Heal group, Leave group, Group files reachable |

**The double scrim is cosmetic.** Measured on an unobscured backdrop pixel: 149 with
no pane, 60 with one, 24 with two - 0.6 applied twice. Both panes are the same size
and exactly aligned, so you never see two overlapping dim rectangles, only a darker
backdrop behind one card. It reads as a normal nested modal.

**Fixed after review:** the new-conversation pane had no vertical divider against
the detail pane. `ConversationListPane` drew that hairline itself, so replacing the
pane took the edge with it. The draw is now a `Modifier.paneTrailingEdge()` used by
both branches.

**One wart this introduces, worth a follow-up:** the member bottom sheet inside group
info anchors to the *window*, not to the floating pane, so it hangs outside the pane's
rounded card and its bottom action ("Remove from group") clips at the window edge on
an 870px-tall window. This looked fine before because group settings was full-screen.

**Still not verified:**

- `ContactBookDetail` opened from the contact book itself - this identity's contact
  book is not onboarded and onboarding writes data. By code it takes the same
  `paneDestination` branch and floats at 92%/90% over the full-screen contact book.
- Phone and tablet (no device or emulator was available).
  The compact path is unchanged by construction: `paneDestination` falls through to
  `composable<T>` off `isDesktopOrWeb()`, and the pane slot is gated on `isExpandedLayout()`.
- Web/wasmJs, which takes the same `isDesktopOrWeb()` branch as Desktop. Compiles only.


