### PR TITLE
Keep the resolved snippet when a post-sync reload replaces the conversation list

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationFileMerge.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationFileMerge.kt
@@ -130,3 +130,75 @@ internal fun mergeConversationFileUpdate(
 
     return ConversationFileMergeResult(merged = merged, isNewlyRemoved = isNewlyRemoved)
 }
+
+/**
+ * Result of reconciling one disk row from a full reload against its prior in-memory row.
+ *
+ * @property merged            the reconciled conversation model.
+ * @property remoteLastReadAdvanced true when the disk row carried a lastRead ahead of ours
+ *                           (a peer-device read echo pulled by DriveSync). The caller owns
+ *                           the side effect — marking the row unread-dirty so the recount
+ *                           corrects it; the pure merge only reports it.
+ */
+internal data class ConversationReloadMergeResult(
+    val merged: ConversationUiModel,
+    val remoteLastReadAdvanced: Boolean,
+)
+
+/**
+ * Pure merge of one freshly mapped disk row ([disk], straight out of
+ * [ConversationMapper.mapToBasic]) against the [prior] in-memory row it replaces during a
+ * full reload ([ConversationStream.loadBasicConversations]).
+ *
+ * Enforces the same ownership rule as [mergeConversationFileUpdate], on the other path that
+ * produces basic rows: `mapToBasic` seeds `lastMessage = " "` and no payload/typed content,
+ * so a wholesale replace blanks every resolved snippet — the rows render the
+ * "No messages yet" fallback until `enrichWithLastMessages` re-runs its JOIN (115-343ms on
+ * a Redmi Note 5 Pro), which is the list-wide snippet flash on app open. Derived state that
+ * only lives in memory (`unreadCount`, an un-flushed lastRead advance and its owe-push
+ * `dirty`) is carried across for the same reason.
+ *
+ * Deleted/Invalid placeholders carry nothing: they are not the same conversation any more,
+ * and `enrichWithLastMessages` has no message row to correct a stale preview with.
+ */
+internal fun mergeReloadedConversationRow(
+    disk: ConversationUiModel,
+    prior: ConversationUiModel?,
+): ConversationReloadMergeResult {
+    if (prior == null) return ConversationReloadMergeResult(disk, remoteLastReadAdvanced = false)
+
+    val reconciled = prior.reconciledWithRemoteLastRead(disk.lastRead)
+    val withLocalState = disk.copy(
+        lastRead = reconciled.lastRead,
+        dirty = reconciled.dirty,
+        unreadCount = prior.unreadCount,
+    )
+
+    val merged = if (
+        disk.conversationState == ConversationState.Deleted ||
+        disk.conversationState == ConversationState.Invalid
+    ) {
+        withLocalState
+    } else {
+        withLocalState.copy(
+            lastMessage = prior.lastMessage,
+            lastMessageDeliveryStatus = prior.lastMessageDeliveryStatus,
+            lastMessageIsPendingSend = prior.lastMessageIsPendingSend,
+            lastMessageIsDeleted = prior.lastMessageIsDeleted,
+            lastMessageFirstPayload = prior.lastMessageFirstPayload,
+            lastMessageHasMultiplePayloads = prior.lastMessageHasMultiplePayloads,
+            lastMessageContent = prior.lastMessageContent,
+            lastMessageIsFromActiveUser = prior.lastMessageIsFromActiveUser,
+            lastMessageSender = prior.lastMessageSender,
+            latestMessageTimestamp = maxOf(
+                disk.latestMessageTimestamp,
+                prior.latestMessageTimestamp,
+            ),
+        )
+    }
+
+    return ConversationReloadMergeResult(
+        merged = merged,
+        remoteLastReadAdvanced = reconciled.lastRead != prior.lastRead,
+    )
+}

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/services/convo/ConversationStream.kt
@@ -967,26 +967,13 @@ class ConversationStream(
                     ui.copy(conversationState = ConversationState.Left)
                 } else ui
 
-                // Reconcile the disk row against the prior in-memory row so the
-                // reload doesn't throw away local state:
-                //  - lastRead = max, dirty kept only while our local read still
-                //    leads disk (same rule as the WS receive merge), so an
-                //    un-flushed local advance survives and still flushes.
-                //  - unreadCount carried forward to avoid a flicker-to-0 (the
-                //    disk row is always 0); when lastRead actually changed vs.
-                //    the prior (a peer advance pulled to disk), mark it
-                //    unread-dirty so the Stopped pipeline's recount corrects it.
-                val prior = priorById[withLeft.id]
-                val finalUi = if (prior != null) {
-                    val reconciled = prior.reconciledWithRemoteLastRead(withLeft.lastRead)
-                    if (reconciled.lastRead != prior.lastRead) markUnreadDirty(withLeft.id)
-                    withLeft.copy(
-                        lastRead = reconciled.lastRead,
-                        dirty = reconciled.dirty,
-                        unreadCount = prior.unreadCount,
-                    )
-                } else withLeft
-                finalUi to file
+                // Reconcile the disk row against the prior in-memory row so the reload
+                // doesn't throw away state the disk row cannot carry — the message
+                // preview, the computed unreadCount, an un-flushed lastRead advance.
+                // See [mergeReloadedConversationRow].
+                val reload = mergeReloadedConversationRow(withLeft, priorById[withLeft.id])
+                if (reload.remoteLastReadAdvanced) markUnreadDirty(withLeft.id)
+                reload.merged to file
             }
 
         val basic = basicWithSource.map { it.first }

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/ConversationReloadMergeTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/services/convo/ConversationReloadMergeTest.kt
@@ -1,0 +1,220 @@
+package id.homebase.chat.services.convo
+
+import id.homebase.api.client.drives.files.PayloadDescriptor
+import id.homebase.api.common.OdinId
+import id.homebase.chat.data.ConversationState
+import id.homebase.chat.data.ConversationUiModel
+import id.homebase.core.avatars.ConversationAvatarModel
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.time.Instant
+import kotlin.uuid.Uuid
+
+/**
+ * Locks down [mergeReloadedConversationRow] — the per-row reconcile of
+ * [ConversationStream.loadBasicConversations], which replaces the whole in-memory list
+ * with freshly mapped disk rows on every chat-drive `DriveEvent.Stopped(totalCount > 0)`.
+ *
+ * The regression this exists to guard against: on app open the reload wiped every resolved
+ * snippet back to the `mapToBasic` `" "` placeholder, so populated rows rendered the
+ * "No messages yet" fallback until `enrichWithLastMessages` re-ran its JOIN — measured at
+ * 115-452ms on a Redmi Note 5 Pro.
+ *
+ * The most important test here is [reloadKeepsResolvedPreview].
+ */
+class ConversationReloadMergeTest {
+
+    private val me = OdinId("owner.test")
+    private val alice = OdinId("alice.test")
+    private val convoId = Uuid.parse("11111111-1111-1111-1111-111111111111")
+
+    private val videoPayload = PayloadDescriptor(key = "chat_web0", contentType = "video/mp4")
+
+    /** A row as it lives in memory once the message pipeline has enriched it. */
+    private fun enrichedInMemory(
+        lastMessage: String = "hello there",
+        latestMs: Long = 10_000L,
+        lastRead: Long = 0L,
+        dirty: Boolean = false,
+        unreadCount: Int = 3,
+        firstPayload: PayloadDescriptor? = null,
+        state: ConversationState = ConversationState.Active,
+    ) = ConversationUiModel(
+        id = convoId,
+        name = "alice",
+        lastMessage = lastMessage,
+        latestMessageTimestamp = Instant.fromEpochMilliseconds(latestMs),
+        unreadCount = unreadCount,
+        avatarInitials = "",
+        avatarUrl = "",
+        avatarTiny = null,
+        participants = listOf(me, alice),
+        lastRead = Instant.fromEpochMilliseconds(lastRead),
+        dirty = dirty,
+        avatarModel = ConversationAvatarModel(
+            type = ConversationAvatarModel.Type.Connection,
+            odinId = alice,
+        ),
+        lastMessageDeliveryStatus = 40,
+        lastMessageIsPendingSend = false,
+        lastMessageIsDeleted = false,
+        lastMessageFirstPayload = firstPayload,
+        lastMessageHasMultiplePayloads = false,
+        lastMessageIsFromActiveUser = true,
+        lastMessageSender = alice,
+        admins = emptySet(),
+        conversationState = state,
+    )
+
+    /**
+     * A row straight out of `ConversationMapper.mapToBasic` — the shape
+     * `loadBasicConversations` produces. No preview data of any kind: the mapper does one
+     * plain SELECT and hardcodes `lastMessage = " "`, leaving every other `lastMessage*`
+     * field on its default. `unreadCount` is always 0 (the disk row cannot know it).
+     */
+    private fun diskBasic(
+        latestMs: Long = 10_000L,
+        lastRead: Long = 0L,
+        state: ConversationState = ConversationState.Active,
+    ) = ConversationUiModel(
+        id = convoId,
+        name = "alice",
+        lastMessage = " ",
+        latestMessageTimestamp = Instant.fromEpochMilliseconds(latestMs),
+        unreadCount = 0,
+        avatarInitials = "",
+        avatarUrl = "",
+        avatarTiny = null,
+        participants = listOf(me, alice),
+        lastRead = Instant.fromEpochMilliseconds(lastRead),
+        dirty = false,
+        avatarModel = ConversationAvatarModel(
+            type = ConversationAvatarModel.Type.Connection,
+            odinId = alice,
+        ),
+        admins = emptySet(),
+        conversationState = state,
+    )
+
+    /**
+     * THE regression guard. A post-sync reload maps the conversation file again and gets
+     * the `" "` placeholder back. The reconcile must keep the preview the message pipeline
+     * resolved, or the row renders "No messages yet" for the width of the enrich JOIN.
+     */
+    @Test
+    fun reloadKeepsResolvedPreview() {
+        val result = mergeReloadedConversationRow(
+            disk = diskBasic(),
+            prior = enrichedInMemory(lastMessage = "hello there"),
+        )
+
+        assertEquals("hello there", result.merged.lastMessage)
+        assertTrue(
+            result.merged.lastMessage.isNotBlank(),
+            "a reloaded row must never fall back to the mapToBasic placeholder — " +
+                "that is the 'No messages yet' flash",
+        )
+        assertEquals(40, result.merged.lastMessageDeliveryStatus)
+        assertEquals(alice, result.merged.lastMessageSender)
+        assertTrue(result.merged.lastMessageIsFromActiveUser)
+    }
+
+    /**
+     * A media-only message has a blank `lastMessage` and renders from its payload icon
+     * instead. Dropping the payload blanks the row just as visibly, so it is carried too.
+     */
+    @Test
+    fun reloadKeepsPayloadOnlyPreview() {
+        val result = mergeReloadedConversationRow(
+            disk = diskBasic(),
+            prior = enrichedInMemory(lastMessage = "", firstPayload = videoPayload),
+        )
+
+        assertEquals(videoPayload, result.merged.lastMessageFirstPayload)
+    }
+
+    @Test
+    fun reloadKeepsUnreadCountAndLocalReadState() {
+        val result = mergeReloadedConversationRow(
+            disk = diskBasic(lastRead = 0L),
+            prior = enrichedInMemory(unreadCount = 3, lastRead = 5_000L, dirty = true),
+        )
+
+        assertEquals(3, result.merged.unreadCount)
+        assertEquals(Instant.fromEpochMilliseconds(5_000L), result.merged.lastRead)
+        assertTrue(result.merged.dirty, "an un-flushed lastRead advance still owes a push")
+        assertFalse(result.remoteLastReadAdvanced)
+    }
+
+    /** A peer device's read echo arrives on disk ahead of ours: adopt it and report it. */
+    @Test
+    fun remoteReadAdvanceIsAdoptedAndReported() {
+        val result = mergeReloadedConversationRow(
+            disk = diskBasic(lastRead = 9_000L),
+            prior = enrichedInMemory(lastRead = 5_000L, dirty = true),
+        )
+
+        assertEquals(Instant.fromEpochMilliseconds(9_000L), result.merged.lastRead)
+        assertFalse(result.merged.dirty, "the remote read caught up with ours; nothing to push")
+        assertTrue(result.remoteLastReadAdvanced)
+    }
+
+    /** The sort key never regresses behind what the message pipeline resolved. */
+    @Test
+    fun sortKeyNeverRegresses() {
+        val result = mergeReloadedConversationRow(
+            disk = diskBasic(latestMs = 8_000L),
+            prior = enrichedInMemory(latestMs = 10_000L),
+        )
+
+        assertEquals(Instant.fromEpochMilliseconds(10_000L), result.merged.latestMessageTimestamp)
+    }
+
+    @Test
+    fun newerDiskSortKeyWins() {
+        val result = mergeReloadedConversationRow(
+            disk = diskBasic(latestMs = 12_000L),
+            prior = enrichedInMemory(latestMs = 10_000L),
+        )
+
+        assertEquals(Instant.fromEpochMilliseconds(12_000L), result.merged.latestMessageTimestamp)
+    }
+
+    /** Cold start: no prior row to carry anything from, the disk row stands as mapped. */
+    @Test
+    fun coldStartPassesTheDiskRowThrough() {
+        val disk = diskBasic()
+        val result = mergeReloadedConversationRow(disk = disk, prior = null)
+
+        assertEquals(disk, result.merged)
+        assertFalse(result.remoteLastReadAdvanced)
+    }
+
+    /**
+     * A conversation that became a Deleted placeholder is not the same thread any more,
+     * and no enrich pass will correct a carried-over preview — so it carries none.
+     */
+    @Test
+    fun deletedPlaceholderCarriesNoPreview() {
+        val result = mergeReloadedConversationRow(
+            disk = diskBasic(state = ConversationState.Deleted),
+            prior = enrichedInMemory(lastMessage = "hello there", firstPayload = videoPayload),
+        )
+
+        assertEquals(" ", result.merged.lastMessage)
+        assertNull(result.merged.lastMessageFirstPayload)
+    }
+
+    @Test
+    fun invalidPlaceholderCarriesNoPreview() {
+        val result = mergeReloadedConversationRow(
+            disk = diskBasic(state = ConversationState.Invalid),
+            prior = enrichedInMemory(lastMessage = "hello there"),
+        )
+
+        assertEquals(" ", result.merged.lastMessage)
+    }
+}


### PR DESCRIPTION
Fixes #1277

## Measured root cause — (C), confirmed

The flashed string really is `chat_no_messages` = "No messages yet", and it comes from a
populated row's preview genuinely going non-empty → empty → non-empty. The source is one
line in `ConversationStream.loadBasicConversations()`.

`ConversationMapper.mapToBasic` is the fast first-paint mapper: one plain SELECT, and it
hardcodes

```kotlin
lastMessage = " ",   // ConversationMapper.kt:213
```

leaving `lastMessageFirstPayload` / `lastMessageContent` / `lastMessageSender` / … on their
defaults. `" "` survives `stripComposerLineBreakArtifacts()` as `""` (it drops blank lines),
`messageContentLabel(...)` returns null with no payload and no typed content, so
`ConversationMessagePreview` takes its `text.isEmpty() && iconRes == null` branch and draws
the `no_messages_text` fallback.

`loadBasicConversations()` then replaces the **entire** in-memory list with those basic rows:

```kotlin
_conversations.value = ConversationsData(dataReady = true, items = basic, enrichment = EnrichmentState())
```

Its `priorById` reconcile already carries `lastRead`, `dirty` and `unreadCount` across
(with a comment about avoiding a "flicker-to-0") — but never the message-preview fields,
which the disk row equally cannot carry. And it is **not** a cold-start-only path: the
`BackendEvent.DriveEvent.Stopped` handler (`ConversationStream.kt` init block) runs
`loadBasicConversations() → enrichWithLastMessages() → enrichWithAdmins()` on every
chat-drive sync round that landed records. So on app open the list blanks and un-blanks.

This is the same defect that was already fixed once on the other path that produces basic
rows. `ConversationFileMerge.kt` says so verbatim:

> a conversation FILE never carries real preview data … `mapToBasic` hardcodes
> `lastMessage = " "`. This merge therefore leaves all of those fields on their `existing`
> values.

The reload path never got that rule.

### On-device evidence

Physical Redmi Note 5 Pro (`6057f11e`), debug build, real account, 85 conversations. Temporary
`SnippetFlash` instrumentation (removed before this commit) counted rows whose prior in-memory
`lastMessage` was non-blank and whose reloaded row is the placeholder.

Genuine trigger — force-stop, relaunch, the catch-up sync lands records:

```
23:57:20.412  loadBasicConversations REPLACE items=85 priorRows=0  previewRegressions=0
23:57:20.537  enrichWithLastMessages RESTORE blankBefore=85 blankAfter=82
23:57:22.139  ConversationStream: Stopped(totalCount=2)
23:57:22.259  loadBasicConversations REPLACE items=85 priorRows=85 previewRegressions=3 ids=[a8a2c9c0-…, e4ef2382-…, bd4d9e2f-…]
23:57:22.384  enrichWithLastMessages RESTORE blankBefore=85 blankAfter=82
```

`priorRows=85 previewRegressions=3` — every row that had a resolved snippet lost it, for the
125 ms the enrich JOIN took. (The counter only tracks *text* regressions; the two media rows
regress too — they lose `lastMessageFirstPayload`, so their icon goes as well and they fall
into the same fallback.) `enrichWithLastMessages` was measured at 115 ms / 130 ms / 191 ms /
234 ms / 343 ms / 452 ms across runs on this device, so the blank window scales with
conversation count and DB size.

### Before/after A/B, same trigger

The device PIN-locked itself mid-session and I could not drive the UI to create the network
condition on demand, so for the A/B I invoked the *identical* call sequence the `Stopped`
handler runs (`loadBasicConversations(); enrichWithLastMessages()`, 4 s after cold load) —
same production code, synthetic trigger. It reproduces the real numbers exactly, including
the same three conversation ids:

**Before** (carry-forward disabled, everything else identical):
```
00:28:23.350  PROBE forcing the post-sync reload sequence (identical to the DriveEvent.Stopped handler)
00:28:23.578  loadBasicConversations REPLACE items=85 priorRows=85 previewRegressions=3 ids=[a8a2c9c0-…, e4ef2382-…, bd4d9e2f-…]
00:28:23.775  enrichWithLastMessages RESTORE blankBefore=85 blankAfter=82
```

**After**:
```
00:30:08.570  PROBE forcing the post-sync reload sequence (identical to the DriveEvent.Stopped handler)
00:30:08.788  loadBasicConversations REPLACE items=85 priorRows=85 previewRegressions=0 ids=[]
00:30:08.930  enrichWithLastMessages RESTORE blankBefore=82 blankAfter=82
```

`blankBefore` drops from 85 to 82 — the list the reload publishes now holds exactly the same
blank rows as the steady state (the 82 conversations on this account that genuinely have no
message), and the blank window is gone rather than shortened.

## The fix

Extract the reload's per-row reconcile into a pure `mergeReloadedConversationRow`, next to
the `mergeConversationFileUpdate` that already owns this rule, and apply the same ownership
there: a basic row never overwrites message-pipeline-owned state. It carries the prior row's
`lastMessage*` fields plus `maxOf` on the `latestMessageTimestamp` sort key, alongside the
`unreadCount` / `lastRead` / `dirty` the reload was already carrying.
`enrichWithLastMessages()` overwrites them with fresh values from disk a beat later, exactly
as before, so nothing goes stale.

This is deliberately not a guard that hides the blank frame. The list never publishes blank
previews in the first place, so it does not depend on winning a race with the VM's 50 ms
leading-edge debounce.

Deleted/Invalid placeholders carry nothing: they are not the same conversation any more, and
`enrichWithLastMessages` has no message row with which to correct a stale preview.

## Verification

```
$ ./gradlew :homebase-chat:compileKotlinJvm :homebase-chat:compileAndroidMain
BUILD SUCCESSFUL in 35s
80 actionable tasks: 16 executed, 64 up-to-date
```

```
$ ./gradlew homebase-chat:jvmTest homebase-common:jvmTest --rerun-tasks
BUILD SUCCESSFUL in 1m 43s
60 actionable tasks: 60 executed

homebase-chat:   tests=1395 failures/errors=0 skipped=6
homebase-common: tests=622  failures/errors=0 skipped=0
TOTAL:           tests=2017 failures/errors=0 skipped=6
```

New `ConversationReloadMergeTest` (9 tests), mutation-validated — with the carry-forward
removed:

```
ConversationReloadMergeTest[jvm] > reloadKeepsResolvedPreview[jvm] FAILED
ConversationReloadMergeTest[jvm] > reloadKeepsPayloadOnlyPreview[jvm] FAILED
ConversationReloadMergeTest[jvm] > sortKeyNeverRegresses[jvm] FAILED
9 tests completed, 3 failed
```

Restored, all 9 pass. It also pins that rows whose snippet actually changed still update
(`newerDiskSortKeyWins`), that a peer read advance is still adopted and reported
(`remoteReadAdvanceIsAdoptedAndReported`), and that cold start passes the disk row through
untouched.

The clean, instrumentation-free build was reinstalled on the device and cold-starts healthy
(85 rows, no crash).

## Device A/B on a physical Redmi Note 5 Pro

Captured after this branch was opened, on the same account with the same trigger:
**5 -> 0** preview regressions and **5 -> 0** paints of the "No messages yet"
fallback. The pre-fix frame shows every row reading "No messages yet" while still
displaying its "4m ago" / "01:48" / "Yesterday" timestamp alongside. A video frame
diff over the snippet column goes flat `0.000` -> `2.945` for ~250 ms -> `0.016`;
with the fix the maximum over a 33 s window is `0.390`, and its profile is a
monotonic staircase that settles (a "Just now" -> "1m ago" label), not a
spike-and-return.

The A/B isolated one variable rather than checking out main: `mergeReloadedConversationRow`
was made to return `withLocalState` unconditionally, which is exactly what main's
inline reconcile did. Everything else in the two builds was identical.

**Reproducing it by hand is network-gated**, which is why the report says
"sometimes". Sending a message does not trigger it - that routes through the
incremental path. `Stopped(totalCount>0)` needs a cold start whose catch-up pull
is behind, and a plain relaunch often wins the race and hides the bug. Determinstic
recipe: send a message, force-stop, launch with the radio off so the VM comes up and
publishes the resolved list, then re-enable the network so the boot catch-up fires
with the list on screen.

No regressions: the 80 genuinely-empty conversations still show "No messages yet"
(no over-suppression), ordering by `latestMessageTimestamp` stayed correct after
every reload, and the `unreadCount` / `lastRead` carry-forward is byte-identical to
main. Blast radius on the test account was 5 rows of 85, because only 5 have
messages - the mechanism blanks every resolved row, so it scales with how many
conversations a user actually has.

## Not verified

- **iOS / Desktop / Web.** The change is in `commonMain` and platform-independent, but it was only
  measured on Android.
- **Acceptance criterion "unchanged rows no longer recompose on a burst".** The reload still
  rebuilds `Items(list)` and the combine still re-enriches on every source emit. With the
  preview no longer regressing there is nothing visible to flash, but the issue's other
  candidates (`distinctUntilChanged` on the enriched output, reusing unchanged model
  instances) are untouched — they address recomposition cost, not the measured blank, and
  are worth their own change if the burst still shows up in a profile.

