### PR TITLE
Keep the data-upgrade and pending-upgrade notices clear of the chat composer (#1517)

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListScreen.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationlist/ConversationListScreen.kt
@@ -191,6 +191,7 @@ fun ConversationListScreen(
     onNavigateToDrawer: (requestId: Uuid) -> Unit = {},
     onDetailPaneVisibilityChanged: (Boolean) -> Unit = {},
     onMediaViewerVisibilityChanged: (Boolean) -> Unit = {},
+    onComposerVisibilityChanged: (Boolean) -> Unit = {},
     onSaveContactCard: (ContactCardDescriptor) -> Unit = {},
     /** Hosts the new-conversation flow inside the list pane on an expanded window instead of
      *  pushing [onNavigateToNewConversation]. Null keeps the full-screen route on every width. */
@@ -568,6 +569,7 @@ fun ConversationListScreen(
             showNewConversationPane = newConversationInPane,
             onNewConversationPaneDismissed = { newConversationInPane = false },
             onMediaViewerVisibilityChanged = onMediaViewerVisibilityChanged,
+            onComposerVisibilityChanged = onComposerVisibilityChanged,
         )
 
         conversationsUiState.inFlightOperationLabel?.let { label ->
@@ -792,6 +794,7 @@ fun ConversationListUi(
     showNewConversationPane: Boolean = false,
     onNewConversationPaneDismissed: () -> Unit = {},
     onMediaViewerVisibilityChanged: (Boolean) -> Unit = {},
+    onComposerVisibilityChanged: (Boolean) -> Unit = {},
 ) {
     val windowAdaptiveInfo = currentWindowAdaptiveInfo()
     val defaultDirective = calculatePaneScaffoldDirective(windowAdaptiveInfo)
@@ -911,13 +914,24 @@ fun ConversationListUi(
     // Notify parent about detail pane visibility in compact view
     LaunchedEffect(showingOnlyDetail) { onDetailPaneVisibilityChanged(showingOnlyDetail) }
 
+    // Unlike showingOnlyDetail this is also true on an expanded two-pane window, where the
+    // composer is on screen while the list still is.
+    val isComposerVisible =
+        isDetailPaneVisible && scaffoldNavigator.currentDestination?.contentKey != null
+    LaunchedEffect(isComposerVisible) { onComposerVisibilityChanged(isComposerVisible) }
+
     val hoistedMediaViewer = messagesUiState.hoistedMediaViewer(isExpanded)
     // The rail lives above this screen, so the viewer can only own the window if the rail is told
     // to stand down — same contract the feed and the Vault gallery already use.
     LaunchedEffect(hoistedMediaViewer != null) {
         onMediaViewerVisibilityChanged(hoistedMediaViewer != null)
     }
-    DisposableEffect(Unit) { onDispose { onMediaViewerVisibilityChanged(false) } }
+    DisposableEffect(Unit) {
+        onDispose {
+            onMediaViewerVisibilityChanged(false)
+            onComposerVisibilityChanged(false)
+        }
+    }
 
     // Installs the coupled cleanup + swap effects that drive notification-tap navigation.
     // See NotificationNavigationEffects.kt for why the two effects must be coordinated.

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
@@ -393,6 +393,24 @@ fun AppNavHost(
     // navigation rail to own the whole window.
     var isChatMediaOpen by remember { mutableStateOf(false) }
 
+    // This Scaffold's SnackbarHost is anchored to the bottom of the window, where the chat
+    // composer is: a notice raised here would sit on top of the input field.
+    var isChatComposerOpen by remember { mutableStateOf(false) }
+
+    // Latched out of the composer gate below so the notice survives being suppressed on a chat
+    // screen, and is consumed only once it has actually run its course.
+    val dbUpgrade by DatabaseManager.databaseUpgradeState.collectAsStateWithLifecycle()
+    var pendingDbUpgradeNotice by remember { mutableStateOf(false) }
+    val dbUpgradeSnapshot = dbUpgrade
+    if (dbUpgradeSnapshot is DatabaseUpgradeState.JustUpgraded &&
+        dbUpgradeSnapshot.fromVersion > 0
+    ) {
+        LaunchedEffect(dbUpgradeSnapshot) {
+            pendingDbUpgradeNotice = true
+            DatabaseManager.markUpgradeConsumed()
+        }
+    }
+
     // Check if current destination is a top-level route. Uses the static route-type
     // check (not topLevelRoutes) so the bottom nav still shows on the Vault screen even
     // when the user has hidden the Vault icon from the nav bar.
@@ -869,7 +887,7 @@ fun AppNavHost(
                             )
                         }
                         val pendingUpgrade = uiState.pendingUpgrade
-                        if (pendingUpgrade is PendingUpgradeState.ShowSnackbar) {
+                        if (pendingUpgrade is PendingUpgradeState.ShowSnackbar && !isChatComposerOpen) {
                             LaunchedEffect(pendingUpgrade) {
                                 val result = snackbarHostState.showSnackbar(
                                     message = snackbarMessage,
@@ -882,24 +900,17 @@ fun AppNavHost(
                             }
                         }
 
-                        // Snackbar fired once per process after DatabaseManager wipes the local
-                        // DB on a schema-version bump. Tells the user why their conversations /
-                        // vault / feed appear empty while DriveSync repopulates from the server.
-                        // Skipped on fresh installs (fromVersion == 0): no prior data, nothing
-                        // to "restore". markUpgradeConsumed() flips state back to Idle so
-                        // recomposition doesn't re-fire the effect.
-                        val dbUpgrade by DatabaseManager.databaseUpgradeState.collectAsStateWithLifecycle()
-                        val dbUpgradeSnapshot = dbUpgrade
-                        if (dbUpgradeSnapshot is DatabaseUpgradeState.JustUpgraded &&
-                            dbUpgradeSnapshot.fromVersion > 0
-                        ) {
+                        // Shown once per process after DatabaseManager wipes the local DB on a
+                        // schema-version bump. Tells the user why their conversations / vault /
+                        // feed appear empty while DriveSync repopulates from the server.
+                        if (pendingDbUpgradeNotice && !isChatComposerOpen) {
                             val dbUpgradeMsg = stringResource(MR.string.database_upgrade_snackbar)
-                            LaunchedEffect(dbUpgradeSnapshot) {
+                            LaunchedEffect(Unit) {
                                 snackbarHostState.showSnackbar(
                                     message = dbUpgradeMsg,
                                     duration = SnackbarDuration.Long,
                                 )
-                                DatabaseManager.markUpgradeConsumed()
+                                pendingDbUpgradeNotice = false
                             }
                         }
 
@@ -1330,6 +1341,10 @@ fun AppNavHost(
                                     onMediaViewerVisibilityChanged = {
                                         @Suppress("AssignedValueIsNeverRead")
                                         isChatMediaOpen = it
+                                    },
+                                    onComposerVisibilityChanged = {
+                                        @Suppress("AssignedValueIsNeverRead")
+                                        isChatComposerOpen = it
                                     },
                                     onSaveContactCard = { pendingContactCard = it },
                                     newConversationPane = { onDismiss, onConversationOpened ->


### PR DESCRIPTION
Fixes #1517.

## Root cause

The upgrade notices are raised on the **app-level** `SnackbarHostState` (`AppNavHost.kt`), hosted by the outer `Scaffold` and anchored to the bottom of the window. Both are fired inside `if (isOnTopLevelScreen) { … }`, and

```kotlin
val isOnTopLevelScreen = isAuthenticated && isTopLevelRoute && !showingOnlyDetailPane
```

`showingOnlyDetailPane` is fed by `ConversationListScreen`'s `showingOnlyDetail = isListPaneHidden && isDetailPaneVisible` — which is only ever true on a **compact** window. On an expanded/two-pane window (desktop, tablet, wide window) the list pane is never hidden, so `showingOnlyDetailPane` stays `false`, `isOnTopLevelScreen` stays `true`, and the snackbar renders straight over the conversation's message composer.

Secondary defect: on compact, navigating into a conversation flips `isOnTopLevelScreen` to `false`, which removes the `LaunchedEffect` from composition and cancels `showSnackbar` — so `DatabaseManager.markUpgradeConsumed()` was never reached and the sticky `JustUpgraded` state re-fired the notice on every return to the list.

## Fix

Per the maintainer's decision: the app-level upgrade notices are simply not shown while a chat conversation (i.e. a composer) is visible. Every other screen — conversation list, feed, vault, settings — is unchanged.

1. `ConversationListUi` reports one new flag up through the existing "screen reports it up" callback contract that `isFeedMediaOpen` / `isChatMediaOpen` already use:

   ```kotlin
   val isComposerVisible =
       isDetailPaneVisible && scaffoldNavigator.currentDestination?.contentKey != null
   ```

   - **Compact:** the detail pane is only non-`Hidden` after navigating into a conversation, and `contentKey` is the selected `Uuid` → `true` in a chat, `false` on the list.
   - **Expanded:** both panes are always `Expanded`, so this reduces to `contentKey != null`. The initial two-pane destination history pushes `Detail` with a `null` content key (and `navigateTo(Detail, selectedConversationId)` passes `null` when nothing is selected), which is exactly the case that renders `EmptyDetailPane` instead of `ConversationMessagesPane` → `false` with no conversation selected, `true` once one is.

   It is reset on dispose alongside `onMediaViewerVisibilityChanged`, so leaving the screen entirely cannot leave it stuck.

   `showingOnlyDetailPane` is untouched — the bottom bar and navigation rail still depend on its existing meaning.

2. Both upgrade snackbars are gated on `!isChatComposerOpen`.

3. The database-upgrade notice is latched into a local `pendingDbUpgradeNotice` as soon as the sticky `JustUpgraded` state is observed, and `markUpgradeConsumed()` is called there — so the process-level state is never left unconsumed by a cancelled `showSnackbar`. The local latch is cleared only after the snackbar has run its full duration or been dismissed, so a notice that was suppressed (chat open) or interrupted (navigation) still appears on the next screen without a composer. No new persistence — a notice not shown before process death is simply not shown, same as before.

The pending-app-upgrade snackbar keeps its `ActionPerformed` → `uriHandler.openUrl(pendingUpgrade.upgradeUrl)` handling, and its `PendingUpgradeState.ShowSnackbar` is not consumed on suppression, so it re-fires on the next composer-free screen.

The chat screen's own `SnackbarHostState` (`ConversationContent.kt`) is not touched — chat-raised snackbars still position themselves above the composer as before.

## Verification

- `./gradlew :homebase-core:compileKotlinJvm :homebase-chat:compileKotlinJvm` — BUILD SUCCESSFUL
- `./gradlew homebase-core:jvmTest homebase-chat:jvmTest homebase-common:jvmTest` — BUILD SUCCESSFUL (`homebase-common:jvmTest` also re-run with `--rerun-tasks`, which is where the Konsist `ArchitectureTest` lives; no new user-facing strings were added)

Not verified on a device or simulator — this change was made in an isolated worktree without device access. The expanded and compact behaviour above is reasoned from the pane-scaffold state, not observed.
