### PR TITLE
Draw voice-note waveforms as vector bars instead of a stretched raster

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationmedia/ConversationMediaScreen.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/conversationmedia/ConversationMediaScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.lazy.grid.GridCells
@@ -55,6 +56,7 @@ import id.homebase.chat.widget.MediaItem
 import id.homebase.chat.widget.rememberSharedMediaSaver
 import id.homebase.core.config.chatTargetDrive
 import id.homebase.core.image.ImageSize
+import id.homebase.core.ui.theme.Dimens
 import id.homebase.core.util.formatMediumDate
 import id.homebase.core.widget.AudioPlayerWidget
 import id.homebase.resources.MR
@@ -297,7 +299,10 @@ private fun AudioListTab(
                     JumpToMessageButton(onClick = { onNavigateToMessage(item.messageId) })
                 }
                 AudioPlayerWidget(
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier = Modifier.widthIn(
+                        min = Dimens.MediaBubble.audioMinWidth,
+                        max = Dimens.MediaBubble.audioMaxWidth,
+                    ),
                     driveId = chatTargetDrive.alias,
                     fileId = item.fileId,
                     keyHeader = item.keyHeader,

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MediaMessage.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MediaMessage.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CheckCircle
@@ -179,11 +180,25 @@ fun MediaMessage(
                 // content — no media height (neither the maxHeight fill nor the minHeight floor),
                 // or the card floats atop a grey void (#1103).
                 val isDocument = remember(payloads) { payloads[0].rendersAsDocumentCard() }
+                // Capped here, not inside AudioPlayerWidget, so the bubble background is capped too.
+                val isAudio = remember(payloads) {
+                    payloads[0].contentType?.startsWith("audio/") == true
+                }
                 val sizedModifier = when {
                     isDocument ->
                         widthModifier
                     fillsBubble ->
                         widthModifier.fillMaxWidth().height(Dimens.MediaBubble.maxHeight)
+                    isAudio ->
+                        widthModifier
+                            .widthIn(
+                                min = Dimens.MediaBubble.audioMinWidth,
+                                max = Dimens.MediaBubble.audioMaxWidth,
+                            )
+                            .heightIn(
+                                min = Dimens.MediaBubble.minHeight,
+                                max = Dimens.MediaBubble.maxHeight,
+                            )
                     narrowCaptioned ->
                         widthModifier.size(
                             width = Dimens.MediaBubble.minWidthWithContent,

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/widget/BubbleLayoutInvariantTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/widget/BubbleLayoutInvariantTest.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.test.getUnclippedBoundsInRoot
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpRect
 import androidx.compose.ui.unit.dp
 import coil3.ImageLoader
@@ -63,6 +64,16 @@ class BubbleLayoutInvariantTest {
     // Bounded conversation column so a long caption has a width to fill and the bubble
     // stays deterministic (mirrors the real caller which hands the bubble a max width).
     private val columnWidth = 400.dp
+
+    // A maximised desktop conversation pane. The Skiko test surface is 1024dp, so the bubble
+    // actually gets 1024 here — still far past the cap, which is the point.
+    private val desktopWidth = 1400.dp
+
+    // A 360dp phone less the 48dp of chrome MessageBubble puts around the bubble
+    // (16dp row padding each side + the 16dp gutter Spacer); this harness renders
+    // MessageBubbleRaw directly, so the column IS the width the bubble gets.
+    private val phoneWidth = 312.dp
+
     private val tol = 1.0f // dp; text layout produces sub-pixel widths
 
     private val koin = koinConfiguration {
@@ -76,11 +87,11 @@ class BubbleLayoutInvariantTest {
     }
 
     @Composable
-    private fun Host(content: @Composable () -> Unit) {
+    private fun Host(width: Dp = columnWidth, content: @Composable () -> Unit) {
         KoinApplication(configuration = koin) {
             HomebaseTheme(darkTheme = false) {
                 CompositionLocalProvider(LocalCurrentOdinId provides "me.example.com") {
-                    Box(Modifier.width(columnWidth)) { content() }
+                    Box(Modifier.width(width)) { content() }
                 }
             }
         }
@@ -132,6 +143,9 @@ class BubbleLayoutInvariantTest {
         // previewThumbnail/aspect and a non-image contentType, so it renders as the
         // compact DocumentMediaItem file card — the #1103 regression dimension.
         val document: Boolean = false,
+        // A single voice-note payload instead of images. Renders via AudioPlayerWidget,
+        // which has no intrinsic width and fills whatever the bubble offers.
+        val audio: Boolean = false,
     )
 
     private fun imagePayload(i: Int, aspect: Aspect = Aspect.LANDSCAPE) = PayloadDescriptor(
@@ -151,6 +165,14 @@ class BubbleLayoutInvariantTest {
         iv = Base64.encode(ByteArray(16)),
         descriptorContent = "server.log",
         bytesWritten = 3_300_000,
+    )
+
+    // A voice note: no thumbnail (so no waveform image is subcomposed) and an audio/* type,
+    // which is how every audio branch in the layout identifies one.
+    private fun audioPayload() = PayloadDescriptor(
+        key = "chat_aud0",
+        contentType = "audio/mp4",
+        iv = Base64.encode(ByteArray(16)),
     )
 
     // Stable so a test can hand the bubble the quoted message itself (which is what makes the
@@ -178,10 +200,10 @@ class BubbleLayoutInvariantTest {
             messageAppData = MessageAppData(replyPreview = reply),
             reactionPreview = null,
             previewThumbnail = null,
-            payloads = if (document) {
-                listOf(documentPayload()).toPersistentList()
-            } else {
-                (0 until images).map { imagePayload(it, aspect) }.toPersistentList()
+            payloads = when {
+                document -> listOf(documentPayload()).toPersistentList()
+                audio -> listOf(audioPayload()).toPersistentList()
+                else -> (0 until images).map { imagePayload(it, aspect) }.toPersistentList()
             },
             keyHeader = KeyHeader(iv = ByteArray(16), aesKey = SecureByteArray(ByteArray(16))),
             versionTag = Uuid.random(),
@@ -195,8 +217,9 @@ class BubbleLayoutInvariantTest {
         authorName: String? = null,
         cluster: MessageClusterPosition = MessageClusterPosition.ALONE,
         quoted: MessageUiModel? = null,
+        width: Dp = columnWidth,
     ) = setContent {
-        Host {
+        Host(width) {
             MessageBubbleRaw(
                 message = case.message(),
                 replyMessages = quoted?.let { persistentMapOf(quotedId to it) } ?: persistentMapOf(),
@@ -612,6 +635,77 @@ class BubbleLayoutInvariantTest {
             failures += "media -> text gap is ${caption.top.value - media.bottom.value}dp, expected 12dp"
 
         assertTrue(failures.isEmpty(), "author gap failures:\n" + failures.joinToString("\n"))
+    }
+
+    /**
+     * A voice note has no intrinsic width — AudioPlayerWidget's inner row fills whatever it is
+     * handed — and nothing between the bubble Row and the player lowered maxWidth, so on a
+     * maximised desktop pane the bubble stretched to nearly the full pane. It is now capped at
+     * [Dimens.MediaBubble.audioMaxWidth], the same 240..320dp band the location card uses, and
+     * the bubble background is capped with it.
+     */
+    @Test
+    fun voiceNote_cappedOnWideDesktopWindow() = runComposeUiTest {
+        val cap = Dimens.MediaBubble.audioMaxWidth.value
+        val failures = mutableListOf<String>()
+        for (sent in listOf(true, false)) {
+            val who = if (sent) "sent" else "recv"
+            render(
+                Case("audio/$who", sent, images = 0, caption = Caption.NONE, audio = true),
+                width = desktopWidth,
+            )
+            val bubble = boundsOf(ChatBubbleTestTags.BUBBLE)
+            val media = boundsOf(ChatBubbleTestTags.MEDIA)
+            val mediaWidth = media.right.value - media.left.value
+            val bubbleWidth = bubble.right.value - bubble.left.value
+
+            if (mediaWidth > cap + tol)
+                failures += "[$who] voice note is ${mediaWidth}dp wide in a " +
+                    "${desktopWidth.value}dp column, cap is ${cap}dp"
+            // The bubble background must be capped with the player, not left stretched behind it.
+            if (bubbleWidth > cap + tol)
+                failures += "[$who] bubble behind the voice note is ${bubbleWidth}dp wide, " +
+                    "cap is ${cap}dp"
+            // The cap is what binds here — a collapsed player would pass the checks above.
+            if (mediaWidth < cap - tol)
+                failures += "[$who] voice note collapsed to ${mediaWidth}dp, expected the ${cap}dp cap"
+        }
+        assertTrue(failures.isEmpty(), "voice-note desktop cap failures:\n" + failures.joinToString("\n"))
+    }
+
+    /**
+     * Regression guard: at phone width the cap is inert. The bubble gets less than
+     * [Dimens.MediaBubble.audioMaxWidth] there, so the voice note still fills it edge-to-edge
+     * exactly as before — neither shrunk to the cap nor pushed past the column by the
+     * [Dimens.MediaBubble.audioMinWidth] floor.
+     */
+    @Test
+    fun voiceNote_unchangedAtPhoneWidth() = runComposeUiTest {
+        val failures = mutableListOf<String>()
+        for (sent in listOf(true, false)) {
+            val who = if (sent) "sent" else "recv"
+            render(
+                Case("audio/$who", sent, images = 0, caption = Caption.NONE, audio = true),
+                width = phoneWidth,
+            )
+            val bubble = boundsOf(ChatBubbleTestTags.BUBBLE)
+            val media = boundsOf(ChatBubbleTestTags.MEDIA)
+            val mediaWidth = media.right.value - media.left.value
+
+            if (!approx(mediaWidth, phoneWidth.value))
+                failures += "[$who] voice note is ${mediaWidth}dp at a ${phoneWidth.value}dp " +
+                    "phone width; the cap must not bite here"
+            if (!approx(media.left.value, bubble.left.value) ||
+                !approx(media.right.value, bubble.right.value)
+            )
+                failures += "[$who] voice note no longer fills its bubble: " +
+                    "media=[${media.left.value},${media.right.value}] " +
+                    "bubble=[${bubble.left.value},${bubble.right.value}]"
+            if (bubble.right.value > phoneWidth.value + tol)
+                failures += "[$who] the min-width floor pushed the bubble past the column: " +
+                    "bubble.right=${bubble.right.value} > ${phoneWidth.value}"
+        }
+        assertTrue(failures.isEmpty(), "voice-note phone-width failures:\n" + failures.joinToString("\n"))
     }
 
     /**

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -110,6 +110,7 @@
     <string name="not_available">Not available</string>
     <string name="error">Error</string>
     <string name="audio_waveform">Audio waveform</string>
+    <string name="audio_waveform_seek">Audio waveform, drag to seek</string>
     <string name="update">Updates</string>
     <string name="update_not_supported">Update check not supported on this version</string>
     <string name="update_available">New version available</string>

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/audio/AudioWaveFormGenerator.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/audio/AudioWaveFormGenerator.kt
@@ -27,7 +27,7 @@ fun DrawScope.drawWaveform(amplitudes: List<Float>) {
     val availableHeight = size.height - (verticalPadding * 2)
 
     amplitudes.forEachIndexed { index, amplitude ->
-        val x = index * barWidth
+        val x = (index + 0.5f) * barWidth
 
         // Apply minimum height constraint
         val adjustedAmplitude = amplitude.coerceAtLeast(AudioWaveFormGenerator.MIN_BAR_HEIGHT_PERCENT)

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/audio/WaveformRaster.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/audio/WaveformRaster.kt
@@ -1,0 +1,140 @@
+package id.homebase.core.audio
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.toPixelMap
+import co.touchlab.kermit.Logger
+import id.homebase.api.client.KeyHeader
+import id.homebase.api.client.drives.files.PayloadDescriptor
+import id.homebase.api.client.drives.files.ThumbnailDescriptor
+import id.homebase.core.image.HomebaseImageData
+import id.homebase.core.image.HomebaseImageLoader
+import id.homebase.core.image.ImageSize
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import org.jetbrains.compose.resources.decodeToImageBitmap
+import org.koin.compose.koinInject
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
+import kotlin.math.abs
+import kotlin.uuid.Uuid
+
+private const val TAG = "WaveformRaster"
+
+// The lossy WebP re-encode of the uploaded raster blurs the bar edges, so a bare
+// "any alpha at all" test overstates every bar by a pixel or two.
+private const val ALPHA_THRESHOLD = 0.35f
+private const val MAX_CACHED_WAVEFORMS = 200
+
+fun ImageBitmap.toWaveformAmplitudes(
+    barCount: Int = AudioWaveFormGenerator.BAR_COUNT
+): FloatArray {
+    if (barCount < 1 || width < 4 || height < 4) return FloatArray(0)
+
+    val strokeWidth = (width.toFloat() / barCount) * 0.8f
+    val span = height - strokeWidth
+    if (span <= 0f) return FloatArray(0)
+
+    val pixels = toPixelMap()
+    val centre = height / 2f
+    val out = FloatArray(barCount)
+    var any = false
+
+    for (index in 0 until barCount) {
+        val from = (index * width) / barCount
+        val to = (((index + 1) * width) / barCount).coerceAtMost(width)
+        var furthest = 0f
+        for (x in from until to) {
+            for (y in 0 until height) {
+                if (pixels[x, y].alpha <= ALPHA_THRESHOLD) continue
+                val distance = abs((y + 0.5f) - centre) + 0.5f
+                if (distance > furthest) furthest = distance
+            }
+        }
+        if (furthest > 0f) {
+            val amplitude = ((2f * furthest) - strokeWidth) / span
+            out[index] = amplitude.coerceIn(0f, 1f)
+            if (out[index] > 0f) any = true
+        }
+    }
+
+    return if (any) out else FloatArray(0)
+}
+
+private val waveformCache = LinkedHashMap<String, FloatArray>()
+private val waveformCacheLock = Mutex()
+
+private suspend fun cachedWaveform(key: String): FloatArray? =
+    waveformCacheLock.withLock { waveformCache[key] }
+
+private suspend fun storeWaveform(key: String, value: FloatArray) {
+    waveformCacheLock.withLock {
+        waveformCache.remove(key)
+        waveformCache[key] = value
+        while (waveformCache.size > MAX_CACHED_WAVEFORMS) {
+            val eldest = waveformCache.keys.firstOrNull() ?: break
+            waveformCache.remove(eldest)
+        }
+    }
+}
+
+@OptIn(ExperimentalEncodingApi::class)
+@Composable
+fun rememberWaveformAmplitudes(
+    driveId: Uuid,
+    fileId: Uuid,
+    payload: PayloadDescriptor,
+    thumbnail: ThumbnailDescriptor,
+    keyHeader: KeyHeader,
+): FloatArray? {
+    val imageLoader: HomebaseImageLoader = koinInject()
+    var amplitudes by remember(fileId, payload.key) { mutableStateOf<FloatArray?>(null) }
+
+    LaunchedEffect(fileId, payload.key, thumbnail.pixelWidth, thumbnail.pixelHeight) {
+        val cacheKey = "$fileId-${payload.key}"
+        val hit = cachedWaveform(cacheKey)
+        if (hit != null) {
+            amplitudes = hit
+            return@LaunchedEffect
+        }
+
+        val decoded = withContext(Dispatchers.Default) {
+            runCatching {
+                val payloadIv = payload.iv?.let { Base64.decode(it) }
+                val requestedSize = ImageSize(
+                    pixelWidth = thumbnail.pixelWidth ?: 320,
+                    pixelHeight = thumbnail.pixelHeight ?: 64,
+                )
+                val data = HomebaseImageData(
+                    driveId = driveId,
+                    fileId = fileId,
+                    payloadKey = payload.key,
+                    previewThumbnail = thumbnail.toEmbeddedThumb(),
+                    requestedSize = requestedSize,
+                    keyHeader = if (payloadIv != null) {
+                        KeyHeader(iv = payloadIv, aesKey = keyHeader.aesKey)
+                    } else {
+                        keyHeader
+                    },
+                    lastModified = payload.lastModified,
+                )
+                val bytes = imageLoader.loadThumbnail(data, requestedSize)?.bytes
+                bytes?.decodeToImageBitmap()?.toWaveformAmplitudes()?.takeIf { it.isNotEmpty() }
+            }.onFailure {
+                Logger.d(tag = TAG, throwable = it) { "Waveform decode failed" }
+            }.getOrNull()
+        }
+
+        if (decoded != null) storeWaveform(cacheKey, decoded)
+        amplitudes = decoded
+    }
+
+    return amplitudes
+}

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/ui/theme/Dimens.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/ui/theme/Dimens.kt
@@ -24,6 +24,8 @@ object Dimens {
         val minHeight = 100.dp
         val maxHeight = 320.dp
         val galleryWidth = 210.dp
+        val audioMinWidth = 240.dp
+        val audioMaxWidth = 320.dp
     }
 
     object Sticker {

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/widget/AudioPlayerWidget.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/widget/AudioPlayerWidget.kt
@@ -1,14 +1,11 @@
 package id.homebase.core.widget
 
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -18,11 +15,9 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Pause
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Slider
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
@@ -33,32 +28,25 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.BlendMode
-import androidx.compose.ui.graphics.ColorFilter
-import androidx.compose.ui.graphics.RectangleShape
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
 import co.touchlab.kermit.Logger
 import id.homebase.api.client.KeyHeader
 import id.homebase.api.client.drives.files.DescriptorContent
 import id.homebase.api.client.drives.files.PayloadDescriptor
-import id.homebase.api.client.drives.files.ThumbnailDescriptor
 import id.homebase.core.audio.AudioPlaybackObserver
 import id.homebase.core.audio.getAudioPlayer
-import id.homebase.core.image.HomebaseImage
-import id.homebase.core.image.HomebaseImageData
-import id.homebase.core.image.ImageSize
+import id.homebase.core.audio.rememberWaveformAmplitudes
 import id.homebase.core.ui.theme.Dimens
 import id.homebase.resources.MR
 import id.homebase.resources.audio_pause
 import id.homebase.resources.audio_play
-import id.homebase.resources.audio_waveform
 import org.jetbrains.compose.resources.stringResource
-import kotlin.io.encoding.Base64
-import kotlin.io.encoding.ExperimentalEncodingApi
 import kotlin.uuid.Uuid
 
-@OptIn(ExperimentalMaterial3Api::class)
+// 320px is the smallest uploaded waveform raster that still gives the column scan
+// ~7px per bar; anything bigger is a pointless fetch.
+private const val MIN_WAVEFORM_RASTER_WIDTH = 320
+
 @Composable
 fun AudioPlayerWidget(
     modifier: Modifier = Modifier,
@@ -87,6 +75,9 @@ fun AudioPlayerWidget(
         audioPlayer.setPlaybackObserver(object : AudioPlaybackObserver {
             override fun onComplete() {
                 isPlaying = false
+                // Park at the end so the next press restarts instead of resuming a drained line;
+                // a late progress tick also clamps here, so there is no race to guard.
+                if (totalFileSeconds > 0) currentFileSeconds = totalFileSeconds
             }
 
             override fun onProgressUpdate(progressSeconds: Int, totalSeconds: Int) {
@@ -107,148 +98,116 @@ fun AudioPlayerWidget(
         }
     }
 
-    // Find the largest waveform thumbnail
     val waveformThumbnail = remember(payload.thumbnails) {
-        payload.thumbnails
+        val images = payload.thumbnails
             ?.filter { it.contentType?.startsWith("image/") == true }
-            ?.maxByOrNull { (it.pixelWidth ?: 0) * (it.pixelHeight ?: 0) }
+            .orEmpty()
+        images.filter { (it.pixelWidth ?: 0) >= MIN_WAVEFORM_RASTER_WIDTH }
+            .minByOrNull { it.pixelWidth ?: 0 }
+            ?: images.maxByOrNull { (it.pixelWidth ?: 0) * (it.pixelHeight ?: 0) }
     }
 
-    Column(
+    val amplitudes = if (waveformThumbnail != null) {
+        rememberWaveformAmplitudes(
+            driveId = driveId,
+            fileId = fileId,
+            payload = payload,
+            thumbnail = waveformThumbnail,
+            keyHeader = keyHeader,
+        )
+    } else {
+        null
+    }
+
+    val progress = if (totalFileSeconds > 0) {
+        currentFileSeconds.toFloat() / totalFileSeconds.toFloat()
+    } else {
+        0f
+    }
+
+    // AudioPlaybackObserver reports whole seconds every 500ms, so the raw value steps
+    // visibly. Glide between samples until the observer carries millis.
+    val sweptProgress by animateFloatAsState(
+        targetValue = progress,
+        animationSpec = tween(durationMillis = 500, easing = LinearEasing),
+    )
+
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
         modifier = modifier
-            .widthIn(min = Dimens.MediaBubble.minWidthSolo)
+            .widthIn(
+                min = Dimens.MediaBubble.audioMinWidth,
+                max = Dimens.MediaBubble.audioMaxWidth,
+            )
             .background(MaterialTheme.colorScheme.surfaceContainerHigh)
-            .padding(12.dp)
+            .padding(horizontal = 12.dp, vertical = 12.dp)
     ) {
-        // First row: Play button, progress info, slider, overflow menu
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier.fillMaxWidth()
-        ) {
-            // Play/Pause Button
-            IconButton(
-                onClick = {
-                    if (audioFile == null && !fileRequested) {
-                        fileRequested = true
-                        isLoading = true
-                        onRequestDecryptedFile?.invoke()
-                    } else if (audioFile != null) {
-                        if (isPlaying) {
-                            audioPlayer.pause()
-                            isPlaying = false
+        IconButton(
+            onClick = {
+                if (audioFile == null && !fileRequested) {
+                    fileRequested = true
+                    isLoading = true
+                    onRequestDecryptedFile?.invoke()
+                } else if (audioFile != null) {
+                    if (isPlaying) {
+                        audioPlayer.pause()
+                        isPlaying = false
+                    } else {
+                        val atEnd = totalFileSeconds > 0 && currentFileSeconds >= totalFileSeconds
+                        if (currentFileSeconds == 0 || atEnd) {
+                            currentFileSeconds = 0
+                            audioPlayer.play(audioFile)
                         } else {
-                            if (currentFileSeconds == 0) {
-                                audioPlayer.play(audioFile)
-                            } else {
-                                audioPlayer.resume()
-                            }
-                            isPlaying = true
+                            audioPlayer.resume()
                         }
+                        isPlaying = true
                     }
-                },
-                enabled = (audioFile != null || !fileRequested) && onRequestDecryptedFile != null
-            ) {
-                if (isLoading && audioFile == null) {
-                    CircularProgressIndicator(
-                        modifier = Modifier.size(24.dp),
-                        strokeWidth = 2.dp
-                    )
-                } else {
-                    Icon(
-                        imageVector = if (isPlaying) Icons.Default.Pause else Icons.Default.PlayArrow,
-                        contentDescription = if (isPlaying) stringResource(MR.string.audio_pause) else stringResource(MR.string.audio_play),
-                        modifier = Modifier.size(32.dp),
-                        tint = MaterialTheme.colorScheme.onSurface,
-                    )
                 }
+            },
+            enabled = (audioFile != null || !fileRequested) && onRequestDecryptedFile != null,
+            modifier = Modifier
+                .size(36.dp)
+                .background(MaterialTheme.colorScheme.primary, CircleShape),
+        ) {
+            if (isLoading && audioFile == null) {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(20.dp),
+                    strokeWidth = 2.dp,
+                    color = MaterialTheme.colorScheme.onPrimary,
+                )
+            } else {
+                Icon(
+                    imageVector = if (isPlaying) Icons.Default.Pause else Icons.Default.PlayArrow,
+                    contentDescription = if (isPlaying) stringResource(MR.string.audio_pause) else stringResource(MR.string.audio_play),
+                    modifier = Modifier.size(24.dp),
+                    tint = MaterialTheme.colorScheme.onPrimary,
+                )
             }
-
-            Spacer(modifier = Modifier.width(8.dp))
-
-            // Time display
-            Text(
-                text = if (totalFileSeconds > 0) formatAudioTime(currentFileSeconds) + " / " + formatAudioTime(totalFileSeconds) else "--:--",
-                style = MaterialTheme.typography.bodySmall,
-                modifier = Modifier.widthIn(min = 40.dp),
-                color = MaterialTheme.colorScheme.onSurface,
-            )
-
-            Spacer(modifier = Modifier.width(8.dp))
-
-            var progress = if (totalFileSeconds > 0) {
-                currentFileSeconds.toFloat() / totalFileSeconds.toFloat()
-            } else 0f
-
-
-            Slider(
-                value = progress,
-                enabled = onRequestDecryptedFile != null,
-                onValueChange = {
-                    progress = it
-                    audioPlayer.jump((it * totalFileSeconds).toInt())
-                },
-                modifier = Modifier
-                    .weight(1f)
-                    .height(4.dp),
-                thumb = {
-                    // Round thumb
-                    Box(
-                        modifier = Modifier
-                            .size(16.dp)
-                            .background(
-                                color = MaterialTheme.colorScheme.primary,
-                                shape = CircleShape
-                            )
-                    )
-                },
-                track = { _ ->
-                    // Square-edged track
-                    Box(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .height(4.dp)
-                    ) {
-                        // Inactive track (background)
-                        Box(
-                            modifier = Modifier
-                                .fillMaxSize()
-                                .background(
-                                    color = MaterialTheme.colorScheme.surfaceContainerLowest,
-                                    shape = RectangleShape
-                                )
-                        )
-                        // Active track (progress)
-                        Box(
-                            modifier = Modifier
-                                .fillMaxWidth(progress)
-                                .fillMaxHeight()
-                                .background(
-                                    color = MaterialTheme.colorScheme.primary,
-                                    shape = RectangleShape
-                                )
-                        )
-                    }
-                }
-            )
-
-            Spacer(modifier = Modifier.width(8.dp))
         }
-        // Second row: Waveform visualization
-        if (waveformThumbnail != null) {
-            Spacer(modifier = Modifier.height(8.dp))
-            WaveformImage(
-                driveId = driveId,
-                fileId = fileId,
-                payload = payload,
-                thumbnail = waveformThumbnail,
-                keyHeader = keyHeader,
-                progress = if (totalFileSeconds > 0) currentFileSeconds.toFloat() / totalFileSeconds.toFloat() else 0f,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(60.dp)
-            )
-            Spacer(modifier = Modifier.height(16.dp))
-        }
+
+        Spacer(modifier = Modifier.width(12.dp))
+
+        AudioWaveform(
+            amplitudes = amplitudes,
+            progress = sweptProgress,
+            onSeek = if (audioFile != null && totalFileSeconds > 0) {
+                { fraction -> audioPlayer.jump((fraction * totalFileSeconds).toInt()) }
+            } else {
+                null
+            },
+            modifier = Modifier.weight(1f),
+        )
+
+        Spacer(modifier = Modifier.width(12.dp))
+
+        Text(
+            text = formatAudioTime(
+                if (currentFileSeconds > 0) currentFileSeconds else totalFileSeconds
+            ),
+            style = MaterialTheme.typography.bodySmall,
+            modifier = Modifier.widthIn(min = 36.dp),
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
     }
 
     // Update loading state when file is loaded
@@ -260,60 +219,6 @@ fun AudioPlayerWidget(
                 audioPlayer.play(audioFile)
             }
         }
-    }
-}
-
-@OptIn(ExperimentalEncodingApi::class)
-@Composable
-private fun WaveformImage(
-    driveId: Uuid,
-    fileId: Uuid,
-    payload: PayloadDescriptor,
-    thumbnail: ThumbnailDescriptor,
-    keyHeader: KeyHeader,
-    progress: Float,
-    modifier: Modifier = Modifier
-) {
-    // Create HomebaseImageData for the waveform thumbnail
-    val imageData = remember(driveId, fileId, payload.key, thumbnail.pixelWidth, thumbnail.pixelHeight) {
-        val payloadIv = Base64.decode(
-            payload.iv ?: throw IllegalStateException("encrypted payload requires key header")
-        )
-
-        HomebaseImageData(
-            driveId = driveId,
-            fileId = fileId,
-            payloadKey = payload.key,
-            previewThumbnail = thumbnail.toEmbeddedThumb(),
-            requestedSize = ImageSize(
-                pixelWidth = thumbnail.pixelWidth ?: 320,
-                pixelHeight = thumbnail.pixelHeight ?: 60
-            ),
-            keyHeader = KeyHeader(iv = payloadIv, aesKey = keyHeader.aesKey),
-            lastModified = payload.lastModified
-        )
-    }
-
-    Box(modifier = modifier) {
-        // Display the waveform image
-        HomebaseImage(
-            imageData = imageData,
-            contentDescription = stringResource(MR.string.audio_waveform),
-            modifier = Modifier.fillMaxSize(),
-            contentScale = ContentScale.FillBounds,
-            colorFilter = ColorFilter.tint(
-                color = MaterialTheme.colorScheme.primary,  // or any color you want
-                blendMode = BlendMode.SrcIn  // This replaces the original color
-            )
-        )
-
-//        // Overlay progress indicator
-//        Box(
-//            modifier = Modifier
-//                .fillMaxWidth(progress.coerceIn(0f, 1f))
-//                .fillMaxHeight()
-//                .background(MaterialTheme.colorScheme.primary.copy(alpha = 0.3f))
-//        )
     }
 }
 

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/widget/AudioPlayerWidget.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/widget/AudioPlayerWidget.kt
@@ -1,8 +1,5 @@
 package id.homebase.core.widget
 
-import androidx.compose.animation.core.LinearEasing
-import androidx.compose.animation.core.animateFloatAsState
-import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -63,6 +60,7 @@ fun AudioPlayerWidget(
     var totalFileSeconds by remember { mutableStateOf(0) }
     var fileRequested by remember { mutableStateOf(false) }
     var isLoading by remember { mutableStateOf(false) }
+    var completed by remember { mutableStateOf(false) }
 
     when (val info = payload.descriptorInfo()) {
         is DescriptorContent.AudioFile -> {
@@ -75,14 +73,13 @@ fun AudioPlayerWidget(
         audioPlayer.setPlaybackObserver(object : AudioPlaybackObserver {
             override fun onComplete() {
                 isPlaying = false
-                // Park at the end so the next press restarts instead of resuming a drained line;
-                // a late progress tick also clamps here, so there is no race to guard.
-                if (totalFileSeconds > 0) currentFileSeconds = totalFileSeconds
+                completed = true
+                currentFileSeconds = 0
             }
 
             override fun onProgressUpdate(progressSeconds: Int, totalSeconds: Int) {
-                Logger.i { "Progress: $progressSeconds / $totalSeconds" }
-                currentFileSeconds = progressSeconds
+                // A tick can land up to one interval after onComplete; it must not undo the reset.
+                if (!completed) currentFileSeconds = progressSeconds
                 // 0 means the player couldn't determine a duration (web: a stream muxed with no
                 // duration box) — keep the length the payload descriptor already gave us.
                 if (totalSeconds > 0) totalFileSeconds = totalSeconds
@@ -119,18 +116,15 @@ fun AudioPlayerWidget(
         null
     }
 
-    val progress = if (totalFileSeconds > 0) {
-        currentFileSeconds.toFloat() / totalFileSeconds.toFloat()
-    } else {
-        0f
+    // Whole seconds: AudioPlaybackObserver carries no finer resolution, so the head steps
+    // once a second. Smoothing needs millisecond progress, not interpolation on top of this.
+    val livePosition: () -> Float = {
+        if (totalFileSeconds > 0) {
+            (currentFileSeconds.toFloat() / totalFileSeconds).coerceIn(0f, 1f)
+        } else {
+            0f
+        }
     }
-
-    // AudioPlaybackObserver reports whole seconds every 500ms, so the raw value steps
-    // visibly. Glide between samples until the observer carries millis.
-    val sweptProgress by animateFloatAsState(
-        targetValue = progress,
-        animationSpec = tween(durationMillis = 500, easing = LinearEasing),
-    )
 
     Row(
         verticalAlignment = Alignment.CenterVertically,
@@ -153,8 +147,8 @@ fun AudioPlayerWidget(
                         audioPlayer.pause()
                         isPlaying = false
                     } else {
-                        val atEnd = totalFileSeconds > 0 && currentFileSeconds >= totalFileSeconds
-                        if (currentFileSeconds == 0 || atEnd) {
+                        if (completed || currentFileSeconds == 0) {
+                            completed = false
                             currentFileSeconds = 0
                             audioPlayer.play(audioFile)
                         } else {
@@ -189,9 +183,14 @@ fun AudioPlayerWidget(
 
         AudioWaveform(
             amplitudes = amplitudes,
-            progress = sweptProgress,
+            progress = livePosition,
             onSeek = if (audioFile != null && totalFileSeconds > 0) {
-                { fraction -> audioPlayer.jump((fraction * totalFileSeconds).toInt()) }
+                { fraction ->
+                    val target = (fraction * totalFileSeconds).toInt()
+                    completed = false
+                    currentFileSeconds = target
+                    audioPlayer.jump(target)
+                }
             } else {
                 null
             },

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/widget/AudioWaveform.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/widget/AudioWaveform.kt
@@ -57,7 +57,7 @@ private object WaveformGeometry {
 @Composable
 fun AudioWaveform(
     amplitudes: FloatArray?,
-    progress: Float,
+    progress: () -> Float,
     onSeek: ((Float) -> Unit)?,
     modifier: Modifier = Modifier,
     playedColor: Color = MaterialTheme.colorScheme.primary,
@@ -116,7 +116,7 @@ fun AudioWaveform(
             .then(seekModifier)
     ) {
         val dragging = dragProgress != null
-        val shown = (dragProgress ?: progress).coerceIn(0f, 1f)
+        val shown = (dragProgress ?: progress()).coerceIn(0f, 1f)
         if (isRtl) {
             scale(scaleX = -1f, scaleY = 1f) {
                 drawWaveformBars(amplitudes, shown, dragging, grow.value, playedColor, unplayedColor)

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/widget/AudioWaveform.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/widget/AudioWaveform.kt
@@ -1,0 +1,213 @@
+package id.homebase.core.widget
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.gestures.detectHorizontalDragGestures
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.scale
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import id.homebase.core.audio.AudioWaveFormGenerator
+import id.homebase.resources.MR
+import id.homebase.resources.audio_waveform_seek
+import org.jetbrains.compose.resources.stringResource
+import kotlin.math.floor
+
+private object WaveformGeometry {
+    val barWidth = 2.5.dp
+    val barMinGap = 1.dp
+    val height = 40.dp
+    val thumbWidth = 2.dp
+    val thumbCorner = 1.dp
+
+    // The near-black surfaceContainerHigh swallows the light-theme alpha.
+    const val UNPLAYED_ALPHA_LIGHT = 0.30f
+    const val UNPLAYED_ALPHA_DARK = 0.45f
+
+    const val GROW_MS = 450f
+    const val BAR_STAGGER_MS = 12f
+    const val OVERSHOOT_TENSION = 2.0f
+
+    val totalGrowMs =
+        (GROW_MS + (AudioWaveFormGenerator.BAR_COUNT - 1) * BAR_STAGGER_MS).toInt()
+}
+
+@Composable
+fun AudioWaveform(
+    amplitudes: FloatArray?,
+    progress: Float,
+    onSeek: ((Float) -> Unit)?,
+    modifier: Modifier = Modifier,
+    playedColor: Color = MaterialTheme.colorScheme.primary,
+    unplayedColor: Color = MaterialTheme.colorScheme.onSurfaceVariant.copy(
+        alpha = if (isSystemInDarkTheme()) {
+            WaveformGeometry.UNPLAYED_ALPHA_DARK
+        } else {
+            WaveformGeometry.UNPLAYED_ALPHA_LIGHT
+        }
+    ),
+) {
+    val isRtl = LocalLayoutDirection.current == LayoutDirection.Rtl
+    val description = stringResource(MR.string.audio_waveform_seek)
+    val grow = remember { Animatable(0f) }
+    var dragProgress by remember { mutableStateOf<Float?>(null) }
+
+    LaunchedEffect(amplitudes) {
+        grow.snapTo(0f)
+        if (amplitudes != null) {
+            grow.animateTo(
+                targetValue = 1f,
+                animationSpec = tween(WaveformGeometry.totalGrowMs, easing = LinearEasing),
+            )
+        }
+    }
+
+    val seekModifier = if (onSeek == null) {
+        Modifier
+    } else {
+        Modifier
+            .pointerInput(onSeek, isRtl) {
+                detectTapGestures { offset ->
+                    onSeek(fractionOf(offset.x, size.width.toFloat(), isRtl))
+                }
+            }
+            .pointerInput(onSeek, isRtl) {
+                detectHorizontalDragGestures(
+                    onDragStart = { offset ->
+                        dragProgress = fractionOf(offset.x, size.width.toFloat(), isRtl)
+                    },
+                    onDragEnd = {
+                        dragProgress?.let(onSeek)
+                        dragProgress = null
+                    },
+                    onDragCancel = { dragProgress = null },
+                ) { change, _ ->
+                    dragProgress = fractionOf(change.position.x, size.width.toFloat(), isRtl)
+                }
+            }
+    }
+
+    Canvas(
+        modifier = modifier
+            .height(WaveformGeometry.height)
+            .semantics { contentDescription = description }
+            .then(seekModifier)
+    ) {
+        val dragging = dragProgress != null
+        val shown = (dragProgress ?: progress).coerceIn(0f, 1f)
+        if (isRtl) {
+            scale(scaleX = -1f, scaleY = 1f) {
+                drawWaveformBars(amplitudes, shown, dragging, grow.value, playedColor, unplayedColor)
+            }
+        } else {
+            drawWaveformBars(amplitudes, shown, dragging, grow.value, playedColor, unplayedColor)
+        }
+    }
+}
+
+private fun DrawScope.drawWaveformBars(
+    amplitudes: FloatArray?,
+    progress: Float,
+    dragging: Boolean,
+    grow: Float,
+    playedColor: Color,
+    unplayedColor: Color,
+) {
+    val width = size.width
+    if (width <= 0f || size.height <= 0f) return
+
+    val barWidth = WaveformGeometry.barWidth.toPx()
+    val minGap = WaveformGeometry.barMinGap.toPx()
+
+    var barCount = amplitudes?.size?.takeIf { it > 0 } ?: AudioWaveFormGenerator.BAR_COUNT
+    if (width < barCount * barWidth + (barCount - 1) * minGap) {
+        barCount = floor((width + minGap) / (barWidth + minGap)).toInt()
+    }
+    if (barCount < 1) return
+
+    val values = when {
+        amplitudes == null -> null
+        barCount < amplitudes.size -> resampleAverage(amplitudes, barCount)
+        else -> amplitudes
+    }
+
+    val gap = if (barCount > 1) (width - barCount * barWidth) / (barCount - 1) else 0f
+    val mid = size.height / 2f
+    val maxHalfHeight = (size.height - barWidth) / 2f
+    val minHalfHeight = barWidth / 2f
+    val elapsedMs = grow * WaveformGeometry.totalGrowMs
+
+    for (index in 0 until barCount) {
+        val x = index * (barWidth + gap) + barWidth / 2f
+        val amplitude = values?.getOrNull(index)?.coerceIn(0f, 1f) ?: 0f
+        val t = ((elapsedMs - index * WaveformGeometry.BAR_STAGGER_MS) / WaveformGeometry.GROW_MS)
+            .coerceIn(0f, 1f)
+        val halfHeight =
+            maxOf(amplitude * maxHalfHeight, minHalfHeight) * overshoot(t)
+        drawLine(
+            color = if (x / width < progress) playedColor else unplayedColor,
+            start = Offset(x, mid - halfHeight),
+            end = Offset(x, mid + halfHeight),
+            strokeWidth = barWidth,
+            cap = StrokeCap.Round,
+        )
+    }
+
+    if (progress > 0f || dragging) {
+        val thumbWidth = WaveformGeometry.thumbWidth.toPx()
+        val thumbX = (progress * width).coerceIn(thumbWidth / 2f, width - thumbWidth / 2f)
+        drawRoundRect(
+            color = playedColor,
+            topLeft = Offset(thumbX - thumbWidth / 2f, 0f),
+            size = Size(thumbWidth, size.height),
+            cornerRadius = CornerRadius(WaveformGeometry.thumbCorner.toPx()),
+        )
+    }
+}
+
+private fun overshoot(t: Float): Float {
+    val p = t - 1f
+    return p * p * ((WaveformGeometry.OVERSHOOT_TENSION + 1f) * p + WaveformGeometry.OVERSHOOT_TENSION) + 1f
+}
+
+private fun resampleAverage(source: FloatArray, barCount: Int): FloatArray {
+    val out = FloatArray(barCount)
+    for (index in 0 until barCount) {
+        val from = (index * source.size) / barCount
+        val to = ((index + 1) * source.size / barCount)
+            .coerceAtLeast(from + 1)
+            .coerceAtMost(source.size)
+        var sum = 0f
+        for (j in from until to) sum += source[j]
+        out[index] = sum / (to - from)
+    }
+    return out
+}
+
+private fun fractionOf(x: Float, width: Float, isRtl: Boolean): Float {
+    if (width <= 0f) return 0f
+    val logical = if (isRtl) width - x else x
+    return (logical / width).coerceIn(0f, 1f)
+}

--- a/homebase-common/src/jvmTest/kotlin/id/homebase/core/audio/WaveformRasterTest.kt
+++ b/homebase-common/src/jvmTest/kotlin/id/homebase/core/audio/WaveformRasterTest.kt
@@ -1,0 +1,55 @@
+package id.homebase.core.audio
+
+import org.jetbrains.compose.resources.decodeToImageBitmap
+import kotlin.math.abs
+import kotlin.math.sin
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class WaveformRasterTest {
+
+    // Measured worst-case round-trip error is 0.021 at 320x64 and 0.007 at 1000x200.
+    private val tolerance = 0.03f
+
+    private fun sampleAmplitudes(): FloatArray = FloatArray(AudioWaveFormGenerator.BAR_COUNT) { i ->
+        when (i) {
+            0 -> 0f
+            7 -> 1f
+            20 -> 0f
+            45 -> 1f
+            else -> (0.5f + 0.5f * sin(i * 0.4f)) * (i / 45f)
+        }
+    }
+
+    private fun assertRoundTrip(width: Int, height: Int) {
+        val expected = sampleAmplitudes()
+        val png = JvmWaveFormGenerator().saveWaveformToPng(expected, width, height)
+        assertTrue(png.isNotEmpty(), "rasteriser produced no bytes at ${width}x$height")
+
+        val decoded = png.decodeToImageBitmap().toWaveformAmplitudes()
+        assertEquals(AudioWaveFormGenerator.BAR_COUNT, decoded.size)
+
+        for (i in expected.indices) {
+            // The rasteriser floors every bar, so that is what a faithful decode returns.
+            val floored = expected[i].coerceAtLeast(AudioWaveFormGenerator.MIN_BAR_HEIGHT_PERCENT)
+            val error = abs(decoded[i] - floored)
+            assertTrue(
+                error <= tolerance,
+                "bar $i at ${width}x$height: expected $floored, decoded ${decoded[i]}, error $error"
+            )
+        }
+    }
+
+    @Test
+    fun `round trips 46 bars through a 320x64 raster`() = assertRoundTrip(320, 64)
+
+    @Test
+    fun `round trips 46 bars through a 1000x200 raster`() = assertRoundTrip(1000, 200)
+
+    @Test
+    fun `returns an empty array for a degenerate bitmap`() {
+        val png = JvmWaveFormGenerator().saveWaveformToPng(FloatArray(2) { 1f }, 2, 2)
+        assertEquals(0, png.decodeToImageBitmap().toWaveformAmplitudes().size)
+    }
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/widget/MomentMediaItem.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/moments/widget/MomentMediaItem.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.PlayCircle
@@ -492,15 +493,22 @@ fun MomentMediaItem(
         }
 
         contentType.startsWith("audio/") -> {
-            AudioPlayerWidget(
-                modifier = baseModifier,
-                driveId = driveId,
-                fileId = fileId,
-                keyHeader = keyHeader,
-                audioFile = decryptedFiles[DecryptedFileKey(fileId, payload.key)],
-                payload = payload,
-                onRequestDecryptedFile = onRequestDecryptedFile,
-            )
+            // The caller hands this a fillMaxSize modifier, which pins min == max width, so the
+            // cap only bites on a child inside it.
+            Box(modifier = baseModifier, contentAlignment = Alignment.Center) {
+                AudioPlayerWidget(
+                    modifier = Modifier.widthIn(
+                        min = Dimens.MediaBubble.audioMinWidth,
+                        max = Dimens.MediaBubble.audioMaxWidth,
+                    ),
+                    driveId = driveId,
+                    fileId = fileId,
+                    keyHeader = keyHeader,
+                    audioFile = decryptedFiles[DecryptedFileKey(fileId, payload.key)],
+                    payload = payload,
+                    onRequestDecryptedFile = onRequestDecryptedFile,
+                )
+            }
         }
 
         contentType == "application/zip" ||


### PR DESCRIPTION
Voice-note waveforms rendered as a row of fat boxes, worst on desktop where the bubble had no maximum width and spanned most of the pane.

## Cause

The 46 amplitudes computed at record time were rasterised to a hardcoded 1000x200 PNG, uploaded as the audio payload's thumbnail set, and **discarded** — they were persisted nowhere. At playback the largest thumbnail was fetched and drawn with `ContentScale.FillBounds` into `bubbleWidth x 60.dp`, a non-uniform squash of a lossy WebP re-encode. Played/unplayed colouring was commented out, and seeking lived in a separate `Slider` above the waveform.

Amplitude extraction was never the problem — it already matches Signal exactly (46 bars, mean-|PCM16| per bar, divided by the loudest bar, quantised 0-255). This is a rendering fix.

## Approach

Recover the amplitudes by column-scanning the raster we already download, then draw them with Canvas. **No protocol change and no schema change**, so every voice note already sent renders correctly too — not just new ones. Adding the bytes to `DescriptorContent.AudioFile` was considered and rejected: it would only help future messages, for a second code path.

- `AudioWaveform.kt` — 46 bars, 2.5dp wide, gap computed to fill the measured width, round caps, symmetric about the midpoint. Two-tone played/unplayed with a hard cut, a 2dp rounded thumb, and Signal's staggered grow-in (450ms, 12ms/bar, overshoot) fired only when the amplitude array identity changes.
- `WaveformRaster.kt` — `ImageBitmap.toWaveformAmplitudes()` plus a 200-entry LRU, fetching via the existing `HomebaseImageLoader.loadThumbnail` on `Dispatchers.Default`.
- The `Slider` is gone; the waveform is the scrub surface (tap or drag).
- Thumbnail selection now takes the smallest raster at least 320px wide rather than the largest — 7px per bar is ample for the scan and roughly 10x cheaper to fetch.
- Audio bubbles capped at 240-320dp, matching the existing location-card cap.
- `drawWaveform` positioned bars at `index * barWidth`, the left edge of the slot, while `drawLine` centres the stroke on it — bar 0 was half-clipped off the left edge. Now `(index + 0.5f) * barWidth`.
- Separately: a finished note parked its head at the end while the play button chose resume-vs-restart from that position, so it could only ever resume a drained line. It now resets to the start.

## Verification

- `WaveformRasterTest` — rasterise a known array, re-decode it, assert every bar within tolerance. Worst-bar error 0.021 at 320x64 and 0.007 at 1000x200; asserts at 0.03.
- `BubbleLayoutInvariantTest` — a voice note in a 1400dp column stays within the cap, and is unchanged at phone width. Proved non-vacuous by disabling the fix and confirming the failure (1024dp against a 320dp cap).
- Geometry was picked by rendering four candidates at 240/320/720dp in light and dark and comparing.
- `homebase-common:jvmTest` and `homebase-chat:jvmTest` green; all four targets compile.

## Known limitations

- **The head steps once per second.** `AudioPlaybackObserver` carries whole seconds only. Interpolating on top of that was tried and reverted — it cannot be made both smooth and monotonic without real sub-second data. The fix is millisecond progress on the observer, which is a four-platform API change and belongs with the player-service work.
- **`JvmAudioPlayer.play()` blocks the main thread** on an `ffprobe` subprocess (`waitFor(10, SECONDS)`) before spawning ffmpeg, straight from `onClick`. Pre-existing, not introduced here, but it makes the first frame of playback late on Desktop.
- **Legacy notes decode slightly smeared.** Notes rasterised before the bar-centring fix put bar `i` at its bucket's left edge, so the scan also catches half of bar `i+1`'s cap — a legacy waveform decodes as roughly `max(amp_i, amp_i+1)`. Envelope shape is right; new sends are exact.
- **Dark-theme alpha reads the OS, not the app's theme setting.** Uses `isSystemInDarkTheme()`, matching the only existing widget-level signal in the repo. Forcing a theme in app settings picks the wrong unplayed alpha. Fixing it properly means a composition-local for `HomebaseTheme`'s `darkTheme`.
- **Pre-existing, untouched:** an audio message with a *block* markdown caption hits the `fillsBubble` branch and gets `.height(MediaBubble.maxHeight)` — a 320dp-tall audio player.
