### PR TITLE
Play voice notes through one app-scoped player

### DIFF
--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -23,6 +23,8 @@
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.VIBRATE" />
+    <!-- Raise-to-ear voice notes: PROXIMITY_SCREEN_OFF_WAKE_LOCK blanks the screen. -->
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <!-- Location add-on: background tracking (requires the Play Console

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/widget/BubbleLayoutInvariantTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/widget/BubbleLayoutInvariantTest.kt
@@ -28,6 +28,10 @@ import id.homebase.chat.services.LocalAttachmentContextStore
 import id.homebase.chat.services.MessageAppData
 import id.homebase.chat.services.ReplyPreview
 import id.homebase.core.ui.theme.Dimens
+import id.homebase.core.audio.DefaultVoiceNotePlayback
+import id.homebase.core.audio.JvmAudioPlayer
+import id.homebase.core.audio.VoiceNotePlayback
+import id.homebase.core.audio.getProximityAudioRouter
 import id.homebase.core.ui.theme.HomebaseTheme
 import kotlinx.collections.immutable.persistentMapOf
 import kotlinx.collections.immutable.toPersistentList
@@ -78,11 +82,18 @@ class BubbleLayoutInvariantTest {
 
     private val koin = koinConfiguration {
         modules(module {
-            // The two Koin singletons any rendered MediaItem resolves. An empty Coil
+            // The Koin singletons any rendered MediaItem resolves. An empty Coil
             // ImageLoader is enough — the images never need to decode; the invariants
             // are about the media container's laid-out bounds, not pixel content.
             single { ImageLoader.Builder(PlatformContext.INSTANCE).build() }
             single { LocalAttachmentContextStore(EventBus(), CoroutineScope(SupervisorJob())) }
+            single<VoiceNotePlayback> {
+                DefaultVoiceNotePlayback(
+                    player = JvmAudioPlayer(),
+                    proximityRouter = getProximityAudioRouter(),
+                    scope = CoroutineScope(SupervisorJob()),
+                )
+            }
         })
     }
 

--- a/homebase-common/src/androidMain/kotlin/id/homebase/core/audio/AndroidAudioPlayer.kt
+++ b/homebase-common/src/androidMain/kotlin/id/homebase/core/audio/AndroidAudioPlayer.kt
@@ -1,6 +1,7 @@
 package id.homebase.core.audio
 
 import android.media.MediaPlayer
+import co.touchlab.kermit.Logger
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -13,6 +14,7 @@ class AndroidAudioPlayer: AudioPlayer {
     private var observer: AudioPlaybackObserver? = null
     private var positionJob: Job? = null
     private val scope = CoroutineScope(Dispatchers.IO)
+    private var speed = 1f
 
     override fun play(filePath: String) {
         release()
@@ -22,18 +24,24 @@ class AndroidAudioPlayer: AudioPlayer {
             prepare()
             start()
         }
+        applySpeed()
         startPositionPolling()
     }
 
-    override fun jump(seconds: Int) {
+    override fun jumpTo(positionMs: Long) {
         mediaPlayer?.let {
-            val newPosition = (seconds * 1000).coerceIn(0, it.duration)
-            it.seekTo(newPosition)
+            it.seekTo(positionMs.toInt().coerceIn(0, it.duration))
         }
     }
 
     override fun resume() {
         mediaPlayer?.start()
+        applySpeed()
+    }
+
+    override fun setSpeed(speed: Float) {
+        this.speed = speed.coerceToPlaybackSpeed()
+        applySpeed()
     }
 
     override fun pause() {
@@ -55,14 +63,27 @@ class AndroidAudioPlayer: AudioPlayer {
         this.observer = observer
     }
 
+    // MediaPlayer.playbackParams resumes a paused player as a side effect, so only touch it
+    // while it is already running.
+    private fun applySpeed() {
+        val player = mediaPlayer ?: return
+        if (!player.isPlaying) return
+        runCatching { player.playbackParams = player.playbackParams.setSpeed(speed) }
+            .onFailure { Logger.w(it) { "setPlaybackParams($speed) rejected" } }
+    }
+
     private fun startPositionPolling() {
         positionJob = scope.launch {
             while (isActive) {
                 val position = mediaPlayer?.currentPosition ?: 0
                 val duration = mediaPlayer?.duration ?: 0
-                observer?.onProgressUpdate(position / 1000, duration / 1000)
-                delay(500)
+                observer?.onProgressUpdate(position.toLong(), duration.toLong())
+                delay(PROGRESS_INTERVAL_MS)
             }
         }
+    }
+
+    private companion object {
+        const val PROGRESS_INTERVAL_MS = 80L
     }
 }

--- a/homebase-common/src/androidMain/kotlin/id/homebase/core/audio/ProximityAudioRouter.android.kt
+++ b/homebase-common/src/androidMain/kotlin/id/homebase/core/audio/ProximityAudioRouter.android.kt
@@ -1,0 +1,157 @@
+package id.homebase.core.audio
+
+import android.content.Context
+import android.hardware.Sensor
+import android.hardware.SensorEvent
+import android.hardware.SensorEventListener
+import android.hardware.SensorManager
+import android.media.AudioDeviceInfo
+import android.media.AudioManager
+import android.os.Build
+import android.os.PowerManager
+import co.touchlab.kermit.Logger
+import id.homebase.api.ActivityProvider
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+actual fun getProximityAudioRouter(): ProximityAudioRouter = AndroidProximityAudioRouter
+
+private object AndroidProximityAudioRouter : ProximityAudioRouter, SensorEventListener {
+    private val logger = Logger.withTag(TAG)
+
+    private val _isNearEar = MutableStateFlow(false)
+    override val isNearEar: StateFlow<Boolean> = _isNearEar.asStateFlow()
+
+    private var running = false
+    private var sensorManager: SensorManager? = null
+    private var proximitySensor: Sensor? = null
+    private var wakeLock: PowerManager.WakeLock? = null
+
+    private var routedToEarpiece = false
+    private var previousMode: Int? = null
+    private var previousSpeakerphoneOn = false
+
+    private val context: Context get() = ActivityProvider.requireApplicationContext()
+    private val audioManager: AudioManager?
+        get() = context.getSystemService(Context.AUDIO_SERVICE) as? AudioManager
+
+    @Synchronized
+    override fun start() {
+        if (running) return
+
+        val sensors = context.getSystemService(Context.SENSOR_SERVICE) as? SensorManager
+        val sensor = sensors?.getDefaultSensor(Sensor.TYPE_PROXIMITY)
+        if (sensors == null || sensor == null) {
+            logger.d { "No proximity sensor — raise-to-ear disabled" }
+            return
+        }
+
+        running = true
+        sensorManager = sensors
+        proximitySensor = sensor
+        acquireWakeLock()
+
+        val registered = try {
+            sensors.registerListener(this, sensor, SensorManager.SENSOR_DELAY_NORMAL)
+        } catch (t: Throwable) {
+            logger.w(t) { "registerListener failed" }
+            false
+        }
+        if (!registered) stop()
+    }
+
+    @Synchronized
+    override fun stop() {
+        if (!running) return
+        running = false
+        try {
+            sensorManager?.unregisterListener(this)
+            restoreLoudspeaker()
+        } finally {
+            releaseWakeLock()
+            sensorManager = null
+            proximitySensor = null
+            _isNearEar.value = false
+        }
+    }
+
+    @Synchronized
+    override fun onSensorChanged(event: SensorEvent) {
+        if (!running) return
+        val sensor = proximitySensor ?: return
+        val reading = event.values.firstOrNull() ?: return
+
+        // Most proximity sensors are binary and report only 0 or maximumRange, so the sensor's
+        // own range is the threshold — a fixed centimetre value misreads them.
+        val near = reading < sensor.maximumRange
+        _isNearEar.value = near
+        if (near) routeToEarpiece() else restoreLoudspeaker()
+    }
+
+    override fun onAccuracyChanged(sensor: Sensor?, accuracy: Int) = Unit
+
+    @Suppress("DEPRECATION")
+    private fun routeToEarpiece() {
+        if (routedToEarpiece) return
+        val audio = audioManager ?: return
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            val earpiece = audio.availableCommunicationDevices
+                .firstOrNull { it.type == AudioDeviceInfo.TYPE_BUILTIN_EARPIECE }
+            if (earpiece == null || !audio.setCommunicationDevice(earpiece)) {
+                logger.w { "Could not select the built-in earpiece" }
+                return
+            }
+        } else {
+            previousMode = audio.mode
+            previousSpeakerphoneOn = audio.isSpeakerphoneOn
+            audio.mode = AudioManager.MODE_IN_COMMUNICATION
+            audio.isSpeakerphoneOn = false
+        }
+        routedToEarpiece = true
+    }
+
+    @Suppress("DEPRECATION")
+    private fun restoreLoudspeaker() {
+        if (!routedToEarpiece) return
+        routedToEarpiece = false
+        val audio = audioManager ?: return
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            audio.clearCommunicationDevice()
+        } else {
+            audio.isSpeakerphoneOn = previousSpeakerphoneOn
+            audio.mode = previousMode ?: AudioManager.MODE_NORMAL
+            previousMode = null
+        }
+    }
+
+    private fun acquireWakeLock() {
+        if (wakeLock != null) return
+        val power = context.getSystemService(Context.POWER_SERVICE) as? PowerManager ?: return
+        if (!power.isWakeLockLevelSupported(PowerManager.PROXIMITY_SCREEN_OFF_WAKE_LOCK)) {
+            logger.d { "PROXIMITY_SCREEN_OFF_WAKE_LOCK unsupported — no screen blanking" }
+            return
+        }
+        wakeLock = power.newWakeLock(PowerManager.PROXIMITY_SCREEN_OFF_WAKE_LOCK, WAKE_LOCK_TAG)
+            .apply {
+                setReferenceCounted(false)
+                acquire()
+            }
+    }
+
+    private fun releaseWakeLock() {
+        val held = wakeLock ?: return
+        wakeLock = null
+        try {
+            if (held.isHeld) held.release()
+        } catch (t: Throwable) {
+            // A leaked proximity lock keeps the user's screen off — surface it, never swallow it.
+            logger.e(t) { "Proximity wake lock release failed" }
+        }
+    }
+
+    private const val TAG = "ProximityAudioRouter"
+    private const val WAKE_LOCK_TAG = "homebase:proximity-audio"
+}

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -1519,6 +1519,10 @@
 
     <!-- Audio player -->
     <string name="audio_pause">Pause</string>
+    <string name="audio_speed">Playback speed</string>
+    <string name="audio_speed_1x">1x</string>
+    <string name="audio_speed_1_5x">1.5x</string>
+    <string name="audio_speed_2x">2x</string>
     <string name="audio_play">Play</string>
 
     <!-- Bottom navigation -->

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/audio/AudioPlayer.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/audio/AudioPlayer.kt
@@ -2,20 +2,24 @@ package id.homebase.core.audio
 
 interface AudioPlayer {
     fun play(filePath: String)
-    fun jump(seconds: Int)
+    fun jumpTo(positionMs: Long)
     fun resume()
     fun pause()
     fun stop()
     fun release()
+    fun setSpeed(speed: Float)
 
     fun setPlaybackObserver(observer: AudioPlaybackObserver)
 }
 
 interface AudioPlaybackObserver {
     fun onComplete()
-    fun onProgressUpdate(progressSeconds: Int, totalSeconds: Int)
+    fun onProgressUpdate(positionMs: Long, durationMs: Long)
 }
 
+const val MIN_PLAYBACK_SPEED = 0.5f
+const val MAX_PLAYBACK_SPEED = 2.0f
+
+fun Float.coerceToPlaybackSpeed(): Float = coerceIn(MIN_PLAYBACK_SPEED, MAX_PLAYBACK_SPEED)
+
 expect fun getAudioPlayer(): AudioPlayer
-
-

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/audio/ProximityAudioRouter.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/audio/ProximityAudioRouter.kt
@@ -1,0 +1,20 @@
+package id.homebase.core.audio
+
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Raise-to-ear for voice-note playback: while [start]ed, the device's proximity sensor
+ * moves audio between the loudspeaker and the earpiece and blanks the screen when covered.
+ *
+ * [start] and [stop] are idempotent — they are driven by playback lifecycle and will be
+ * called repeatedly.
+ */
+interface ProximityAudioRouter {
+    val isNearEar: StateFlow<Boolean>
+
+    fun start()
+
+    fun stop()
+}
+
+expect fun getProximityAudioRouter(): ProximityAudioRouter

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/audio/VoiceNotePlayback.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/audio/VoiceNotePlayback.kt
@@ -1,0 +1,116 @@
+package id.homebase.core.audio
+
+import androidx.compose.runtime.Immutable
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+@Immutable
+data class VoiceNotePlaybackState(
+    val playingKey: String? = null,
+    val positionMs: Long = 0,
+    val durationMs: Long = 0,
+    val isPlaying: Boolean = false,
+    val speed: Float = 1f,
+)
+
+interface VoiceNotePlayback {
+    val state: StateFlow<VoiceNotePlaybackState>
+
+    suspend fun play(key: String, filePath: String)
+    fun pause()
+    fun resume()
+    fun seekTo(fraction: Float)
+    fun stop()
+    fun setSpeed(speed: Float)
+}
+
+class DefaultVoiceNotePlayback(
+    private val player: AudioPlayer,
+    private val proximityRouter: ProximityAudioRouter,
+    private val scope: CoroutineScope,
+) : VoiceNotePlayback {
+
+    private val _state = MutableStateFlow(VoiceNotePlaybackState())
+    override val state: StateFlow<VoiceNotePlaybackState> = _state.asStateFlow()
+
+    init {
+        player.setPlaybackObserver(object : AudioPlaybackObserver {
+            override fun onComplete() {
+                proximityRouter.stop()
+                _state.update { it.copy(positionMs = 0, isPlaying = false) }
+            }
+
+            override fun onProgressUpdate(positionMs: Long, durationMs: Long) {
+                _state.update { current ->
+                    if (current.playingKey == null) {
+                        current
+                    } else {
+                        current.copy(
+                            positionMs = positionMs,
+                            // 0 means the player couldn't determine a duration (web: a stream muxed
+                            // with no duration box) — keep whatever length we already had.
+                            durationMs = if (durationMs > 0) durationMs else current.durationMs,
+                        )
+                    }
+                }
+            }
+        })
+    }
+
+    override suspend fun play(key: String, filePath: String) {
+        _state.update {
+            it.copy(playingKey = key, positionMs = 0, durationMs = 0, isPlaying = true)
+        }
+        val speed = _state.value.speed
+        withContext(Dispatchers.Default) {
+            player.stop()
+            player.play(filePath)
+            player.setSpeed(speed)
+        }
+        proximityRouter.start()
+    }
+
+    override fun pause() {
+        if (_state.value.playingKey == null) return
+        player.pause()
+        proximityRouter.stop()
+        _state.update { it.copy(isPlaying = false) }
+    }
+
+    override fun resume() {
+        if (_state.value.playingKey == null) return
+        player.resume()
+        proximityRouter.start()
+        _state.update { it.copy(isPlaying = true) }
+    }
+
+    override fun seekTo(fraction: Float) {
+        val current = _state.value
+        if (current.playingKey == null || current.durationMs <= 0) return
+        val target = (fraction.coerceIn(0f, 1f) * current.durationMs).toLong()
+        _state.update { it.copy(positionMs = target) }
+        // The injected app scope is Dispatchers.Default; both of these restart a decoder.
+        scope.launch { player.jumpTo(target) }
+    }
+
+    override fun stop() {
+        proximityRouter.stop()
+        player.stop()
+        _state.update {
+            it.copy(playingKey = null, positionMs = 0, durationMs = 0, isPlaying = false)
+        }
+    }
+
+    override fun setSpeed(speed: Float) {
+        val clamped = speed.coerceToPlaybackSpeed()
+        if (clamped == _state.value.speed) return
+        _state.update { it.copy(speed = clamped) }
+        scope.launch { player.setSpeed(clamped) }
+    }
+}

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/widget/AudioPlayerWidget.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/widget/AudioPlayerWidget.kt
@@ -1,8 +1,13 @@
 package id.homebase.core.widget
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -17,32 +22,55 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
-import co.touchlab.kermit.Logger
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import id.homebase.api.client.KeyHeader
 import id.homebase.api.client.drives.files.DescriptorContent
 import id.homebase.api.client.drives.files.PayloadDescriptor
-import id.homebase.core.audio.AudioPlaybackObserver
-import id.homebase.core.audio.getAudioPlayer
+import id.homebase.core.audio.VoiceNotePlayback
 import id.homebase.core.audio.rememberWaveformAmplitudes
 import id.homebase.core.ui.theme.Dimens
 import id.homebase.resources.MR
 import id.homebase.resources.audio_pause
 import id.homebase.resources.audio_play
+import id.homebase.resources.audio_speed
+import id.homebase.resources.audio_speed_1_5x
+import id.homebase.resources.audio_speed_1x
+import id.homebase.resources.audio_speed_2x
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.stringResource
+import org.koin.compose.koinInject
 import kotlin.uuid.Uuid
 
 // 320px is the smallest uploaded waveform raster that still gives the column scan
 // ~7px per bar; anything bigger is a pointless fetch.
 private const val MIN_WAVEFORM_RASTER_WIDTH = 320
+
+private val PLAYBACK_SPEEDS = floatArrayOf(1f, 1.5f, 2f)
+
+@Immutable
+private data class VoiceNoteBubbleState(
+    val isCurrent: Boolean = false,
+    val isPlaying: Boolean = false,
+    val canResume: Boolean = false,
+    val speed: Float = 1f,
+    val elapsedSeconds: Int = 0,
+    val durationSeconds: Int = 0,
+)
 
 @Composable
 fun AudioPlayerWidget(
@@ -54,46 +82,36 @@ fun AudioPlayerWidget(
     payload: PayloadDescriptor,
     onRequestDecryptedFile: (() -> Unit)? = null,
 ) {
-    val audioPlayer = remember { getAudioPlayer() }
-    var isPlaying by remember { mutableStateOf(false) }
-    var currentFileSeconds by remember { mutableStateOf(0) }
-    var totalFileSeconds by remember { mutableStateOf(0) }
+    val playback: VoiceNotePlayback = koinInject()
+    val coroutineScope = rememberCoroutineScope()
+    val playbackKey = remember(fileId, payload.key) { "$fileId-${payload.key}" }
+
     var fileRequested by remember { mutableStateOf(false) }
     var isLoading by remember { mutableStateOf(false) }
-    var completed by remember { mutableStateOf(false) }
 
-    when (val info = payload.descriptorInfo()) {
-        is DescriptorContent.AudioFile -> {
-            totalFileSeconds = info.lengthSeconds
-        }
-        else -> {}
+    val descriptorSeconds = remember(payload) {
+        (payload.descriptorInfo() as? DescriptorContent.AudioFile)?.lengthSeconds ?: 0
     }
 
-    LaunchedEffect(Unit) {
-        audioPlayer.setPlaybackObserver(object : AudioPlaybackObserver {
-            override fun onComplete() {
-                isPlaying = false
-                completed = true
-                currentFileSeconds = 0
-            }
+    // Held as a State object and read only inside the Canvas draw lambda below, so a position
+    // tick invalidates the waveform's draw pass instead of recomposing every visible bubble.
+    val playbackState = playback.state.collectAsStateWithLifecycle()
 
-            override fun onProgressUpdate(progressSeconds: Int, totalSeconds: Int) {
-                // A tick can land up to one interval after onComplete; it must not undo the reset.
-                if (!completed) currentFileSeconds = progressSeconds
-                // 0 means the player couldn't determine a duration (web: a stream muxed with no
-                // duration box) — keep the length the payload descriptor already gave us.
-                if (totalSeconds > 0) totalFileSeconds = totalSeconds
-            }
-        })
-    }
+    val bubble by remember(playback, playbackKey) {
+        playback.state.map { state ->
+            val current = state.playingKey == playbackKey
+            VoiceNoteBubbleState(
+                isCurrent = current,
+                isPlaying = current && state.isPlaying,
+                canResume = current && !state.isPlaying && state.positionMs > 0,
+                speed = state.speed,
+                elapsedSeconds = if (current) (state.positionMs / 1000).toInt() else 0,
+                durationSeconds = if (current) (state.durationMs / 1000).toInt() else 0,
+            )
+        }.distinctUntilChanged()
+    }.collectAsStateWithLifecycle(VoiceNoteBubbleState())
 
-    // Cleanup on dispose
-    DisposableEffect(Unit) {
-        onDispose {
-            audioPlayer.stop()
-            audioPlayer.release()
-        }
-    }
+    val totalSeconds = if (bubble.durationSeconds > 0) bubble.durationSeconds else descriptorSeconds
 
     val waveformThumbnail = remember(payload.thumbnails) {
         val images = payload.thumbnails
@@ -116,11 +134,10 @@ fun AudioPlayerWidget(
         null
     }
 
-    // Whole seconds: AudioPlaybackObserver carries no finer resolution, so the head steps
-    // once a second. Smoothing needs millisecond progress, not interpolation on top of this.
     val livePosition: () -> Float = {
-        if (totalFileSeconds > 0) {
-            (currentFileSeconds.toFloat() / totalFileSeconds).coerceIn(0f, 1f)
+        val state = playbackState.value
+        if (state.playingKey == playbackKey && state.durationMs > 0) {
+            (state.positionMs.toFloat() / state.durationMs).coerceIn(0f, 1f)
         } else {
             0f
         }
@@ -143,18 +160,10 @@ fun AudioPlayerWidget(
                     isLoading = true
                     onRequestDecryptedFile?.invoke()
                 } else if (audioFile != null) {
-                    if (isPlaying) {
-                        audioPlayer.pause()
-                        isPlaying = false
-                    } else {
-                        if (completed || currentFileSeconds == 0) {
-                            completed = false
-                            currentFileSeconds = 0
-                            audioPlayer.play(audioFile)
-                        } else {
-                            audioPlayer.resume()
-                        }
-                        isPlaying = true
+                    when {
+                        bubble.isPlaying -> playback.pause()
+                        bubble.canResume -> playback.resume()
+                        else -> coroutineScope.launch { playback.play(playbackKey, audioFile) }
                     }
                 }
             },
@@ -171,8 +180,12 @@ fun AudioPlayerWidget(
                 )
             } else {
                 Icon(
-                    imageVector = if (isPlaying) Icons.Default.Pause else Icons.Default.PlayArrow,
-                    contentDescription = if (isPlaying) stringResource(MR.string.audio_pause) else stringResource(MR.string.audio_play),
+                    imageVector = if (bubble.isPlaying) Icons.Default.Pause else Icons.Default.PlayArrow,
+                    contentDescription = if (bubble.isPlaying) {
+                        stringResource(MR.string.audio_pause)
+                    } else {
+                        stringResource(MR.string.audio_play)
+                    },
                     modifier = Modifier.size(24.dp),
                     tint = MaterialTheme.colorScheme.onPrimary,
                 )
@@ -184,13 +197,8 @@ fun AudioPlayerWidget(
         AudioWaveform(
             amplitudes = amplitudes,
             progress = livePosition,
-            onSeek = if (audioFile != null && totalFileSeconds > 0) {
-                { fraction ->
-                    val target = (fraction * totalFileSeconds).toInt()
-                    completed = false
-                    currentFileSeconds = target
-                    audioPlayer.jump(target)
-                }
+            onSeek = if (bubble.isCurrent) {
+                { fraction -> playback.seekTo(fraction) }
             } else {
                 null
             },
@@ -199,26 +207,66 @@ fun AudioPlayerWidget(
 
         Spacer(modifier = Modifier.width(12.dp))
 
-        Text(
-            text = formatAudioTime(
-                if (currentFileSeconds > 0) currentFileSeconds else totalFileSeconds
-            ),
-            style = MaterialTheme.typography.bodySmall,
-            modifier = Modifier.widthIn(min = 36.dp),
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
-    }
-
-    // Update loading state when file is loaded
-    LaunchedEffect(audioFile) {
-        if (audioFile != null) {
-            if (isLoading) {
-                isLoading = false
-                isPlaying = true
-                audioPlayer.play(audioFile)
+        // The chip sits under the timer rather than beside the waveform: the bubble is capped at
+        // 320dp and a fourth column would cost the waveform a third of its bars.
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
+            modifier = Modifier.widthIn(min = 40.dp),
+        ) {
+            Text(
+                text = formatAudioTime(
+                    if (bubble.elapsedSeconds > 0) bubble.elapsedSeconds else totalSeconds
+                ),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            if (bubble.isCurrent) {
+                Spacer(modifier = Modifier.height(6.dp))
+                SpeedChip(
+                    speed = bubble.speed,
+                    onClick = { playback.setSpeed(nextSpeed(bubble.speed)) },
+                )
             }
         }
     }
+
+    LaunchedEffect(audioFile) {
+        if (audioFile != null && isLoading) {
+            isLoading = false
+            playback.play(playbackKey, audioFile)
+        }
+    }
+}
+
+@Composable
+private fun SpeedChip(speed: Float, onClick: () -> Unit) {
+    val label = when (speed) {
+        2f -> stringResource(MR.string.audio_speed_2x)
+        1.5f -> stringResource(MR.string.audio_speed_1_5x)
+        else -> stringResource(MR.string.audio_speed_1x)
+    }
+    val description = stringResource(MR.string.audio_speed)
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = Modifier
+            .size(width = 40.dp, height = 22.dp)
+            .clip(MaterialTheme.shapes.small)
+            .background(MaterialTheme.colorScheme.secondaryContainer)
+            .clickable(onClick = onClick)
+            .semantics { contentDescription = description },
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSecondaryContainer,
+        )
+    }
+}
+
+private fun nextSpeed(current: Float): Float {
+    val index = PLAYBACK_SPEEDS.indexOfFirst { it == current }
+    return PLAYBACK_SPEEDS[(index + 1) % PLAYBACK_SPEEDS.size]
 }
 
 private fun formatAudioTime(seconds: Int): String {

--- a/homebase-common/src/jvmMain/kotlin/id/homebase/core/audio/JvmAudioPlayer.kt
+++ b/homebase-common/src/jvmMain/kotlin/id/homebase/core/audio/JvmAudioPlayer.kt
@@ -19,12 +19,22 @@ open class JvmAudioPlayer : AudioPlayer {
     private var currentFilePath: String? = null
 
     @Volatile
-    internal var totalDurationSeconds: Int = 0
+    internal var totalDurationMs: Long = 0
         private set
 
     @Volatile
-    internal var seekOffsetSeconds: Int = 0
+    internal var seekOffsetMs: Long = 0
         private set
+
+    @Volatile
+    internal var speed: Float = 1f
+        private set
+
+    @Volatile
+    private var lastReportedMs: Long = 0
+
+    @Volatile
+    private var backwardsCount = 0
 
     @Volatile
     private var isPaused = false
@@ -35,11 +45,11 @@ open class JvmAudioPlayer : AudioPlayer {
     override fun play(filePath: String) {
         stopPlayback()
         currentFilePath = filePath
-        seekOffsetSeconds = 0
+        seekOffsetMs = 0
         isStopped = false
         isPaused = false
-        totalDurationSeconds = probeDurationSeconds(filePath)
-        startPlayback(filePath, seekSeconds = 0)
+        totalDurationMs = probeDurationMs(filePath)
+        startPlayback(filePath, seekMs = 0)
     }
 
     override fun pause() {
@@ -52,20 +62,35 @@ open class JvmAudioPlayer : AudioPlayer {
         isPaused = false
     }
 
-    override fun jump(seconds: Int) {
+    override fun jumpTo(positionMs: Long) {
         val path = currentFilePath ?: return
-        val clamped = seconds.coerceIn(0, totalDurationSeconds)
+        val clamped = positionMs.coerceIn(0, totalDurationMs)
         stopPlayback()
-        seekOffsetSeconds = clamped
+        seekOffsetMs = clamped
         isStopped = false
         isPaused = false
-        startPlayback(path, seekSeconds = clamped)
+        startPlayback(path, seekMs = clamped)
     }
 
     override fun stop() {
         isStopped = true
         stopPlayback()
-        seekOffsetSeconds = 0
+        seekOffsetMs = 0
+    }
+
+    // ffmpeg resamples the whole stream, so a speed change has to restart the decoder from
+    // wherever the line had reached.
+    override fun setSpeed(speed: Float) {
+        val clamped = speed.coerceToPlaybackSpeed()
+        if (clamped == this.speed) return
+        val path = currentFilePath
+        val resumeAt = lastReportedMs
+        this.speed = clamped
+        if (path == null || isStopped) return
+        stopPlayback()
+        seekOffsetMs = resumeAt.coerceIn(0, totalDurationMs)
+        isStopped = false
+        startPlayback(path, seekMs = seekOffsetMs)
     }
 
     override fun release() {
@@ -78,13 +103,22 @@ open class JvmAudioPlayer : AudioPlayer {
         this.observer = observer
     }
 
-    internal fun buildFfmpegCommand(filePath: String, seekSeconds: Int): List<String> = buildList {
-        add(FFmpegBinaryManager.ffmpegPath())
+    internal fun buildFfmpegCommand(
+        filePath: String,
+        seekMs: Long,
+        speed: Float = 1f,
+    ): List<String> = buildList {
+        add(ffmpegExecutable())
         add("-v"); add("error")
-        if (seekSeconds > 0) {
-            add("-ss"); add(seekSeconds.toString())
+        if (seekMs > 0) {
+            add("-ss"); add((seekMs / 1000.0).toString())
         }
         add("-i"); add(filePath)
+        // A single atempo stage covers the clamped 0.5-2.0 range; beyond it ffmpeg needs a chain.
+        val tempo = speed.coerceToPlaybackSpeed()
+        if (tempo != 1f) {
+            add("-filter:a"); add("atempo=$tempo")
+        }
         add("-f"); add("s16le")
         add("-acodec"); add("pcm_s16le")
         add("-ar"); add(SAMPLE_RATE.toString())
@@ -92,12 +126,14 @@ open class JvmAudioPlayer : AudioPlayer {
         add("pipe:1")
     }
 
-    protected open fun startDecoder(filePath: String, seekSeconds: Int): InputStream? {
+    protected open fun ffmpegExecutable(): String = FFmpegBinaryManager.ffmpegPath()
+
+    protected open fun startDecoder(filePath: String, seekMs: Long): InputStream? {
         if (!FFmpegBinaryManager.isAvailable()) {
             Logger.e(tag = TAG) { "FFmpeg binaries not available — cannot decode audio" }
             return null
         }
-        val command = buildFfmpegCommand(filePath, seekSeconds)
+        val command = buildFfmpegCommand(filePath, seekMs, speed)
         process = ProcessBuilder(command)
             .redirectError(ProcessBuilder.Redirect.PIPE)
             .start()
@@ -112,13 +148,15 @@ open class JvmAudioPlayer : AudioPlayer {
         return line
     }
 
-    private fun startPlayback(filePath: String, seekSeconds: Int) {
+    private fun startPlayback(filePath: String, seekMs: Long) {
         val pcmFormat = AudioFormat(
             SAMPLE_RATE.toFloat(), SAMPLE_SIZE_BITS, CHANNELS, true, false
         )
+        lastReportedMs = seekMs
+        backwardsCount = 0
 
         try {
-            val input = startDecoder(filePath, seekSeconds) ?: return
+            val input = startDecoder(filePath, seekMs) ?: return
 
             val line = openAudioLine(pcmFormat)
             sourceLine = line
@@ -152,12 +190,12 @@ open class JvmAudioPlayer : AudioPlayer {
                 try {
                     while (!isStopped && playbackThread?.isAlive == true) {
                         if (!isPaused) {
-                            val linePositionSeconds =
-                                (line.microsecondPosition / 1_000_000).toInt()
-                            val currentSeconds = seekOffsetSeconds + linePositionSeconds
+                            // The line advances in output time, so atempo-stretched media moves
+                            // `speed` times faster than the bytes it has played.
+                            val playedMs = (line.microsecondPosition / 1000.0 * speed).toLong()
                             observer?.onProgressUpdate(
-                                currentSeconds.coerceAtMost(totalDurationSeconds),
-                                totalDurationSeconds
+                                monotonicPositionMs(seekOffsetMs + playedMs),
+                                totalDurationMs
                             )
                         }
                         Thread.sleep(PROGRESS_INTERVAL_MS)
@@ -204,7 +242,25 @@ open class JvmAudioPlayer : AudioPlayer {
         }
     }
 
-    protected open fun probeDurationSeconds(filePath: String): Int {
+    // `line.microsecondPosition` restarts at zero across a pause or a seek, so a single
+    // backwards sample is jitter; only a sustained run of them is a real rewind.
+    internal fun monotonicPositionMs(rawMs: Long): Long {
+        val capped = if (totalDurationMs > 0) rawMs.coerceAtMost(totalDurationMs) else rawMs
+        if (capped >= lastReportedMs) {
+            backwardsCount = 0
+            lastReportedMs = capped
+            return capped
+        }
+        backwardsCount++
+        if (backwardsCount > BACKWARDS_TOLERANCE) {
+            backwardsCount = 0
+            lastReportedMs = capped
+            return capped
+        }
+        return lastReportedMs
+    }
+
+    protected open fun probeDurationMs(filePath: String): Long {
         if (!FFmpegBinaryManager.isAvailable()) {
             Logger.w(tag = TAG) { "FFmpeg not available, falling back to file-size estimate" }
             return estimateDurationFromFileSize(filePath)
@@ -224,7 +280,7 @@ open class JvmAudioPlayer : AudioPlayer {
                 proc.destroy()
                 Logger.w(tag = TAG) { "ffprobe timed out" }
             }
-            output.toDoubleOrNull()?.toInt() ?: 0
+            output.toDoubleOrNull()?.let { (it * 1000).toLong() } ?: 0
         } catch (e: Exception) {
             Logger.e(e, tag = TAG) { "ffprobe failed" }
             0
@@ -237,12 +293,13 @@ open class JvmAudioPlayer : AudioPlayer {
         internal const val SAMPLE_SIZE_BITS = 16
         internal const val CHANNELS = 2
         internal const val BUFFER_SIZE = 8192
-        internal const val PROGRESS_INTERVAL_MS = 500L
+        internal const val PROGRESS_INTERVAL_MS = 80L
+        internal const val BACKWARDS_TOLERANCE = 3
 
-        internal fun estimateDurationFromFileSize(filePath: String): Int {
+        internal fun estimateDurationFromFileSize(filePath: String): Long {
             val sizeBytes = File(filePath).length()
             val bytesPerSecond = SAMPLE_RATE * CHANNELS * (SAMPLE_SIZE_BITS / 8)
-            return (sizeBytes / bytesPerSecond).toInt().coerceAtLeast(1)
+            return (sizeBytes * 1000 / bytesPerSecond).coerceAtLeast(1)
         }
     }
 }

--- a/homebase-common/src/jvmMain/kotlin/id/homebase/core/audio/ProximityAudioRouter.jvm.kt
+++ b/homebase-common/src/jvmMain/kotlin/id/homebase/core/audio/ProximityAudioRouter.jvm.kt
@@ -1,0 +1,12 @@
+package id.homebase.core.audio
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+actual fun getProximityAudioRouter(): ProximityAudioRouter = JvmProximityAudioRouter
+
+private object JvmProximityAudioRouter : ProximityAudioRouter {
+    override val isNearEar: StateFlow<Boolean> = MutableStateFlow(false)
+    override fun start() = Unit
+    override fun stop() = Unit
+}

--- a/homebase-common/src/jvmTest/kotlin/id/homebase/core/audio/JvmAudioPlayerTest.kt
+++ b/homebase-common/src/jvmTest/kotlin/id/homebase/core/audio/JvmAudioPlayerTest.kt
@@ -5,12 +5,12 @@ import java.io.File
 import java.io.InputStream
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.AtomicBoolean
-import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicLong
 import javax.sound.sampled.AudioFormat
 import javax.sound.sampled.SourceDataLine
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -48,17 +48,17 @@ private class FakeSourceDataLine(
  * Test subclass that bypasses FFmpeg and audio hardware.
  */
 private class TestableAudioPlayer(
-    private val fakeDuration: Int = 30,
+    private val fakeDurationMs: Long = 30_000,
     private val fakeAudioBytes: ByteArray = ByteArray(44100 * 2 * 2), // 1 second of stereo 16-bit
 ) : JvmAudioPlayer() {
 
-    var lastSeekSeconds: Int? = null
+    var lastSeekMs: Long? = null
     var decoderStartCount = 0
     var fakeLine: FakeSourceDataLine? = null
     var simulateRealtime = false
 
-    override fun startDecoder(filePath: String, seekSeconds: Int): InputStream {
-        lastSeekSeconds = seekSeconds
+    override fun startDecoder(filePath: String, seekMs: Long): InputStream {
+        lastSeekMs = seekMs
         decoderStartCount++
         return ByteArrayInputStream(fakeAudioBytes)
     }
@@ -69,69 +69,71 @@ private class TestableAudioPlayer(
         return line
     }
 
-    override fun probeDurationSeconds(filePath: String): Int = fakeDuration
+    override fun probeDurationMs(filePath: String): Long = fakeDurationMs
+
+    override fun ffmpegExecutable(): String = "/fake/bin/ffmpeg"
 }
 
 class JvmAudioPlayerTest {
 
     @Test
     fun playSetsDurationAndStartsDecoder() {
-        val player = TestableAudioPlayer(fakeDuration = 45)
+        val player = TestableAudioPlayer(fakeDurationMs = 45_000)
         player.play("/fake/audio.m4a")
         Thread.sleep(100) // let threads start
 
-        assertEquals(45, player.totalDurationSeconds)
-        assertEquals(0, player.seekOffsetSeconds)
+        assertEquals(45_000L, player.totalDurationMs)
+        assertEquals(0L, player.seekOffsetMs)
         assertEquals(1, player.decoderStartCount)
-        assertEquals(0, player.lastSeekSeconds)
+        assertEquals(0L, player.lastSeekMs)
 
         player.release()
     }
 
     @Test
     fun stopResetsSeekOffset() {
-        val player = TestableAudioPlayer(fakeDuration = 60)
+        val player = TestableAudioPlayer(fakeDurationMs = 60_000)
         player.play("/fake/audio.wav")
         Thread.sleep(50)
 
-        player.jump(20)
+        player.jumpTo(20_000)
         Thread.sleep(50)
-        assertEquals(20, player.seekOffsetSeconds)
+        assertEquals(20_000L, player.seekOffsetMs)
 
         player.stop()
-        assertEquals(0, player.seekOffsetSeconds)
+        assertEquals(0L, player.seekOffsetMs)
 
         player.release()
     }
 
     @Test
     fun jumpClampsToTotalDuration() {
-        val player = TestableAudioPlayer(fakeDuration = 30)
+        val player = TestableAudioPlayer(fakeDurationMs = 30_000)
         player.play("/fake/audio.wav")
         Thread.sleep(50)
 
-        player.jump(100)
+        player.jumpTo(100_000)
         Thread.sleep(50)
-        assertEquals(30, player.seekOffsetSeconds)
+        assertEquals(30_000L, player.seekOffsetMs)
 
-        player.jump(-5)
+        player.jumpTo(-5_000)
         Thread.sleep(50)
-        assertEquals(0, player.seekOffsetSeconds)
+        assertEquals(0L, player.seekOffsetMs)
 
         player.release()
     }
 
     @Test
     fun jumpRestartsDecoder() {
-        val player = TestableAudioPlayer(fakeDuration = 60)
+        val player = TestableAudioPlayer(fakeDurationMs = 60_000)
         player.play("/fake/audio.wav")
         Thread.sleep(50)
         assertEquals(1, player.decoderStartCount)
 
-        player.jump(15)
+        player.jumpTo(15_000)
         Thread.sleep(50)
         assertEquals(2, player.decoderStartCount)
-        assertEquals(15, player.lastSeekSeconds)
+        assertEquals(15_000L, player.lastSeekMs)
 
         player.release()
     }
@@ -139,9 +141,9 @@ class JvmAudioPlayerTest {
     @Test
     fun jumpDoesNothingWithoutPriorPlay() {
         val player = TestableAudioPlayer()
-        player.jump(10)
+        player.jumpTo(10_000)
         assertEquals(0, player.decoderStartCount)
-        assertNull(player.lastSeekSeconds)
+        assertNull(player.lastSeekMs)
     }
 
     @Test
@@ -149,25 +151,25 @@ class JvmAudioPlayerTest {
         val player = TestableAudioPlayer()
         val observer = object : AudioPlaybackObserver {
             override fun onComplete() {}
-            override fun onProgressUpdate(progressSeconds: Int, totalSeconds: Int) {}
+            override fun onProgressUpdate(positionMs: Long, durationMs: Long) {}
         }
         player.setPlaybackObserver(observer)
         player.play("/fake/audio.wav")
         Thread.sleep(50)
 
         player.release()
-        assertEquals(0, player.seekOffsetSeconds)
+        assertEquals(0L, player.seekOffsetMs)
     }
 
     @Test
     fun observerReceivesOnComplete() {
         val shortAudio = ByteArray(1764) // ~10ms of stereo 16-bit at 44100
         val completed = CountDownLatch(1)
-        val player = TestableAudioPlayer(fakeDuration = 1, fakeAudioBytes = shortAudio)
+        val player = TestableAudioPlayer(fakeDurationMs = 1_000, fakeAudioBytes = shortAudio)
 
         player.setPlaybackObserver(object : AudioPlaybackObserver {
             override fun onComplete() { completed.countDown() }
-            override fun onProgressUpdate(progressSeconds: Int, totalSeconds: Int) {}
+            override fun onProgressUpdate(positionMs: Long, durationMs: Long) {}
         })
 
         player.play("/fake/short.wav")
@@ -179,35 +181,57 @@ class JvmAudioPlayerTest {
     fun observerReceivesProgressUpdates() {
         val audio = ByteArray(44100 * 2 * 2 * 2) // ~2 seconds
         val progressLatch = CountDownLatch(1)
-        val lastTotal = AtomicInteger(0)
+        val lastTotal = AtomicLong(0)
 
-        val player = TestableAudioPlayer(fakeDuration = 2, fakeAudioBytes = audio)
+        val player = TestableAudioPlayer(fakeDurationMs = 2_000, fakeAudioBytes = audio)
         player.simulateRealtime = true
         player.setPlaybackObserver(object : AudioPlaybackObserver {
             override fun onComplete() {}
-            override fun onProgressUpdate(progressSeconds: Int, totalSeconds: Int) {
-                lastTotal.set(totalSeconds)
+            override fun onProgressUpdate(positionMs: Long, durationMs: Long) {
+                lastTotal.set(durationMs)
                 progressLatch.countDown()
             }
         })
 
         player.play("/fake/audio.wav")
         assertTrue(progressLatch.await(3, TimeUnit.SECONDS), "Observer should receive progress updates")
-        assertEquals(2, lastTotal.get())
+        assertEquals(2_000L, lastTotal.get())
+        player.release()
+    }
+
+    @Test
+    fun progressIsReportedInMilliseconds() {
+        val audio = ByteArray(44100 * 2 * 2 * 2) // ~2 seconds
+        val sawSubSecond = CountDownLatch(1)
+        val player = TestableAudioPlayer(fakeDurationMs = 2_000, fakeAudioBytes = audio)
+        player.simulateRealtime = true
+        player.setPlaybackObserver(object : AudioPlaybackObserver {
+            override fun onComplete() {}
+            override fun onProgressUpdate(positionMs: Long, durationMs: Long) {
+                // A whole-second reporter can only ever emit 0 or a multiple of 1000.
+                if (positionMs > 0 && positionMs % 1000L != 0L) sawSubSecond.countDown()
+            }
+        })
+
+        player.play("/fake/audio.wav")
+        assertTrue(
+            sawSubSecond.await(3, TimeUnit.SECONDS),
+            "Progress should carry millisecond resolution",
+        )
         player.release()
     }
 
     @Test
     fun progressClampsToTotalDuration() {
         val audio = ByteArray(44100 * 2 * 2 * 3) // ~3 seconds
-        val maxProgress = AtomicInteger(0)
+        val maxProgress = AtomicLong(0)
         val progressLatch = CountDownLatch(2)
-        val player = TestableAudioPlayer(fakeDuration = 1, fakeAudioBytes = audio)
+        val player = TestableAudioPlayer(fakeDurationMs = 1_000, fakeAudioBytes = audio)
         player.simulateRealtime = true
         player.setPlaybackObserver(object : AudioPlaybackObserver {
             override fun onComplete() {}
-            override fun onProgressUpdate(progressSeconds: Int, totalSeconds: Int) {
-                if (progressSeconds > maxProgress.get()) maxProgress.set(progressSeconds)
+            override fun onProgressUpdate(positionMs: Long, durationMs: Long) {
+                if (positionMs > maxProgress.get()) maxProgress.set(positionMs)
                 progressLatch.countDown()
             }
         })
@@ -215,13 +239,13 @@ class JvmAudioPlayerTest {
         player.play("/fake/audio.wav")
         progressLatch.await(3, TimeUnit.SECONDS)
 
-        assertTrue(maxProgress.get() <= 1, "Progress should not exceed total duration")
+        assertTrue(maxProgress.get() <= 1_000L, "Progress should not exceed total duration")
         player.release()
     }
 
     @Test
     fun multiplePlayCallsRestartCleanly() {
-        val player = TestableAudioPlayer(fakeDuration = 30)
+        val player = TestableAudioPlayer(fakeDurationMs = 30_000)
 
         player.play("/fake/first.wav")
         Thread.sleep(50)
@@ -230,7 +254,7 @@ class JvmAudioPlayerTest {
         player.play("/fake/second.wav")
         Thread.sleep(50)
         assertEquals(2, player.decoderStartCount)
-        assertEquals(0, player.lastSeekSeconds)
+        assertEquals(0L, player.lastSeekMs)
 
         player.release()
     }
@@ -271,7 +295,7 @@ class JvmAudioPlayerTest {
         try {
             temp.writeBytes(ByteArray(100))
             val duration = JvmAudioPlayer.estimateDurationFromFileSize(temp.absolutePath)
-            assertEquals(1, duration, "Very small files should return at least 1 second")
+            assertEquals(1L, duration, "Very small files should return at least 1 millisecond")
         } finally {
             temp.delete()
         }
@@ -284,10 +308,110 @@ class JvmAudioPlayerTest {
             // 5 seconds of 44100 Hz, stereo, 16-bit = 44100 * 2 * 2 * 5 = 882000 bytes
             temp.writeBytes(ByteArray(882000))
             val duration = JvmAudioPlayer.estimateDurationFromFileSize(temp.absolutePath)
-            assertEquals(5, duration)
+            assertEquals(5_000L, duration)
         } finally {
             temp.delete()
         }
+    }
+
+    @Test
+    fun backwardsProgressIsIgnoredUntilItPersists() {
+        val player = TestableAudioPlayer(fakeDurationMs = 60_000)
+
+        assertEquals(5_000L, player.monotonicPositionMs(5_000))
+
+        // Three isolated dips are jitter from the line restarting its own clock.
+        assertEquals(5_000L, player.monotonicPositionMs(400))
+        assertEquals(5_000L, player.monotonicPositionMs(400))
+        assertEquals(5_000L, player.monotonicPositionMs(400))
+        // The fourth in a row is a real rewind.
+        assertEquals(400L, player.monotonicPositionMs(400))
+    }
+
+    @Test
+    fun forwardProgressResetsTheBackwardsCounter() {
+        val player = TestableAudioPlayer(fakeDurationMs = 60_000)
+
+        player.monotonicPositionMs(5_000)
+        player.monotonicPositionMs(400)
+        player.monotonicPositionMs(400)
+        assertEquals(6_000L, player.monotonicPositionMs(6_000))
+
+        // Counter restarted, so three dips are absorbed again.
+        assertEquals(6_000L, player.monotonicPositionMs(400))
+        assertEquals(6_000L, player.monotonicPositionMs(400))
+        assertEquals(6_000L, player.monotonicPositionMs(400))
+    }
+
+    @Test
+    fun ffmpegCommandOmitsAtempoAtNormalSpeed() {
+        val player = TestableAudioPlayer()
+        val command = player.buildFfmpegCommand("/fake/audio.m4a", seekMs = 0, speed = 1f)
+        assertFalse(command.any { it.startsWith("atempo") }, "1x needs no filter graph")
+        assertFalse(command.contains("-filter:a"))
+    }
+
+    @Test
+    fun ffmpegCommandCarriesAtempoForFasterSpeeds() {
+        val player = TestableAudioPlayer()
+
+        val oneAndAHalf = player.buildFfmpegCommand("/fake/audio.m4a", seekMs = 0, speed = 1.5f)
+        assertEquals("atempo=1.5", oneAndAHalf[oneAndAHalf.indexOf("-filter:a") + 1])
+
+        val double = player.buildFfmpegCommand("/fake/audio.m4a", seekMs = 0, speed = 2f)
+        assertEquals("atempo=2.0", double[double.indexOf("-filter:a") + 1])
+    }
+
+    @Test
+    fun ffmpegCommandClampsSpeedToTheAtempoRange() {
+        val player = TestableAudioPlayer()
+
+        val tooFast = player.buildFfmpegCommand("/fake/audio.m4a", seekMs = 0, speed = 8f)
+        assertEquals("atempo=2.0", tooFast[tooFast.indexOf("-filter:a") + 1])
+
+        val tooSlow = player.buildFfmpegCommand("/fake/audio.m4a", seekMs = 0, speed = 0.1f)
+        assertEquals("atempo=0.5", tooSlow[tooSlow.indexOf("-filter:a") + 1])
+    }
+
+    @Test
+    fun ffmpegCommandSeeksWithSubSecondPrecision() {
+        val player = TestableAudioPlayer()
+        val command = player.buildFfmpegCommand("/fake/audio.m4a", seekMs = 1_500)
+        assertEquals("1.5", command[command.indexOf("-ss") + 1])
+    }
+
+    @Test
+    fun setSpeedRestartsTheDecoderAtTheCurrentPosition() {
+        val player = TestableAudioPlayer(fakeDurationMs = 60_000)
+        player.play("/fake/audio.wav")
+        Thread.sleep(50)
+        assertEquals(1, player.decoderStartCount)
+
+        player.monotonicPositionMs(12_000)
+        player.setSpeed(1.5f)
+        Thread.sleep(50)
+
+        assertEquals(2, player.decoderStartCount)
+        assertEquals(12_000L, player.lastSeekMs)
+        assertEquals(1.5f, player.speed)
+
+        player.release()
+    }
+
+    @Test
+    fun setSpeedBeforePlayIsRememberedForTheFirstDecoder() {
+        val player = TestableAudioPlayer(fakeDurationMs = 60_000)
+        player.setSpeed(2f)
+        assertEquals(0, player.decoderStartCount)
+        assertEquals(2f, player.speed)
+
+        player.play("/fake/audio.wav")
+        Thread.sleep(50)
+
+        val command = player.buildFfmpegCommand("/fake/audio.wav", seekMs = 0, speed = player.speed)
+        assertEquals("atempo=2.0", command[command.indexOf("-filter:a") + 1])
+
+        player.release()
     }
 }
 

--- a/homebase-common/src/jvmTest/kotlin/id/homebase/core/audio/ProximityAudioRouterTest.kt
+++ b/homebase-common/src/jvmTest/kotlin/id/homebase/core/audio/ProximityAudioRouterTest.kt
@@ -1,0 +1,21 @@
+package id.homebase.core.audio
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+
+class ProximityAudioRouterTest {
+
+    @Test
+    fun `desktop router is inert and start_stop are idempotent`() {
+        val router = getProximityAudioRouter()
+        assertFalse(router.isNearEar.value)
+
+        router.start()
+        router.start()
+        assertFalse(router.isNearEar.value)
+
+        router.stop()
+        router.stop()
+        assertFalse(router.isNearEar.value)
+    }
+}

--- a/homebase-common/src/jvmTest/kotlin/id/homebase/core/audio/VoiceNotePlaybackTest.kt
+++ b/homebase-common/src/jvmTest/kotlin/id/homebase/core/audio/VoiceNotePlaybackTest.kt
@@ -1,0 +1,170 @@
+package id.homebase.core.audio
+
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+private class RecordingAudioPlayer : AudioPlayer {
+    val calls = mutableListOf<String>()
+    var observer: AudioPlaybackObserver? = null
+    var appliedSpeed = 1f
+
+    override fun play(filePath: String) { calls += "play:$filePath" }
+    override fun jumpTo(positionMs: Long) { calls += "jumpTo:$positionMs" }
+    override fun resume() { calls += "resume" }
+    override fun pause() { calls += "pause" }
+    override fun stop() { calls += "stop" }
+    override fun release() { calls += "release" }
+    override fun setSpeed(speed: Float) {
+        appliedSpeed = speed
+        calls += "setSpeed:$speed"
+    }
+
+    override fun setPlaybackObserver(observer: AudioPlaybackObserver) {
+        this.observer = observer
+    }
+}
+
+private class RecordingProximityRouter : ProximityAudioRouter {
+    override val isNearEar = kotlinx.coroutines.flow.MutableStateFlow(false)
+    var startCount = 0
+    var stopCount = 0
+    override fun start() { startCount++ }
+    override fun stop() { stopCount++ }
+}
+
+class VoiceNotePlaybackTest {
+
+    private fun playback(
+        player: AudioPlayer,
+        router: ProximityAudioRouter = RecordingProximityRouter(),
+        scope: TestScope,
+    ) = DefaultVoiceNotePlayback(player, router, scope)
+
+    @Test
+    fun playingASecondKeyStopsTheFirst() = runTest(StandardTestDispatcher()) {
+        val player = RecordingAudioPlayer()
+        val service = playback(player, scope = this)
+
+        service.play("bubble-a", "/tmp/a.m4a")
+        assertEquals("bubble-a", service.state.value.playingKey)
+        assertTrue(service.state.value.isPlaying)
+
+        player.observer?.onProgressUpdate(4_000, 9_000)
+        assertEquals(4_000L, service.state.value.positionMs)
+
+        service.play("bubble-b", "/tmp/b.m4a")
+
+        assertEquals("bubble-b", service.state.value.playingKey)
+        // The first note's position must not bleed into the second bubble.
+        assertEquals(0L, service.state.value.positionMs)
+        assertEquals(
+            listOf("stop", "play:/tmp/a.m4a", "setSpeed:1.0", "stop", "play:/tmp/b.m4a", "setSpeed:1.0"),
+            player.calls,
+        )
+    }
+
+    @Test
+    fun speedPersistsAcrossKeys() = runTest(StandardTestDispatcher()) {
+        val player = RecordingAudioPlayer()
+        val service = playback(player, scope = this)
+
+        service.play("bubble-a", "/tmp/a.m4a")
+        service.setSpeed(1.5f)
+        testScheduler.advanceUntilIdle()
+        assertEquals(1.5f, player.appliedSpeed)
+
+        service.play("bubble-b", "/tmp/b.m4a")
+        assertEquals(1.5f, service.state.value.speed)
+        assertEquals(1.5f, player.appliedSpeed)
+    }
+
+    @Test
+    fun speedIsClampedToTheSupportedRange() = runTest(StandardTestDispatcher()) {
+        val player = RecordingAudioPlayer()
+        val service = playback(player, scope = this)
+
+        service.setSpeed(9f)
+        assertEquals(MAX_PLAYBACK_SPEED, service.state.value.speed)
+
+        service.setSpeed(0.01f)
+        assertEquals(MIN_PLAYBACK_SPEED, service.state.value.speed)
+    }
+
+    @Test
+    fun completionRewindsWithoutClearingTheOwningBubble() = runTest(StandardTestDispatcher()) {
+        val player = RecordingAudioPlayer()
+        val service = playback(player, scope = this)
+
+        service.play("bubble-a", "/tmp/a.m4a")
+        player.observer?.onProgressUpdate(8_500, 9_000)
+        player.observer?.onComplete()
+
+        assertEquals("bubble-a", service.state.value.playingKey)
+        assertEquals(0L, service.state.value.positionMs)
+        assertFalse(service.state.value.isPlaying)
+    }
+
+    @Test
+    fun stopClearsTheOwningBubble() = runTest(StandardTestDispatcher()) {
+        val player = RecordingAudioPlayer()
+        val service = playback(player, scope = this)
+
+        service.play("bubble-a", "/tmp/a.m4a")
+        service.stop()
+
+        assertNull(service.state.value.playingKey)
+        assertFalse(service.state.value.isPlaying)
+    }
+
+    @Test
+    fun seekingConvertsTheFractionAgainstTheReportedDuration() = runTest(StandardTestDispatcher()) {
+        val player = RecordingAudioPlayer()
+        val service = playback(player, scope = this)
+
+        service.play("bubble-a", "/tmp/a.m4a")
+        player.observer?.onProgressUpdate(0, 10_000)
+        service.seekTo(0.25f)
+        testScheduler.advanceUntilIdle()
+
+        assertEquals(2_500L, service.state.value.positionMs)
+        assertTrue(player.calls.contains("jumpTo:2500"))
+    }
+
+    @Test
+    fun proximityMonitoringFollowsPlayback() = runTest(StandardTestDispatcher()) {
+        val player = RecordingAudioPlayer()
+        val router = RecordingProximityRouter()
+        val service = playback(player, router, this)
+
+        service.play("bubble-a", "/tmp/a.m4a")
+        assertEquals(1, router.startCount)
+
+        service.pause()
+        assertEquals(1, router.stopCount)
+
+        service.resume()
+        assertEquals(2, router.startCount)
+
+        player.observer?.onComplete()
+        assertEquals(2, router.stopCount)
+    }
+
+    @Test
+    fun progressForAStoppedServiceIsDropped() = runTest(StandardTestDispatcher()) {
+        val player = RecordingAudioPlayer()
+        val service = playback(player, scope = this)
+
+        service.play("bubble-a", "/tmp/a.m4a")
+        service.stop()
+        player.observer?.onProgressUpdate(3_000, 9_000)
+
+        assertEquals(0L, service.state.value.positionMs)
+        assertEquals(0L, service.state.value.durationMs)
+    }
+}

--- a/homebase-common/src/nativeMain/kotlin/id/homebase/core/audio/AudioSession.kt
+++ b/homebase-common/src/nativeMain/kotlin/id/homebase/core/audio/AudioSession.kt
@@ -10,8 +10,11 @@ import kotlinx.cinterop.memScoped
 import kotlinx.cinterop.ptr
 import kotlinx.cinterop.value
 import platform.AVFAudio.AVAudioSession
+import platform.AVFAudio.AVAudioSessionCategoryPlayAndRecord
 import platform.AVFAudio.AVAudioSessionCategoryPlayback
 import platform.AVFAudio.AVAudioSessionCategoryRecord
+import platform.AVFAudio.AVAudioSessionPortOverrideNone
+import platform.AVFAudio.AVAudioSessionPortOverrideSpeaker
 import platform.AVFAudio.AVAudioSessionSetActiveOptionNotifyOthersOnDeactivation
 import platform.AVFAudio.setActive
 import platform.Foundation.NSError
@@ -26,9 +29,74 @@ import platform.Foundation.NSError
  */
 object AudioSession {
 
-    fun configureForPlayback(): Boolean = activate(AVAudioSessionCategoryPlayback)
+    private var proximityRouting = false
+    private var savedCategory: String? = null
+    private var savedMode: String? = null
+
+    fun configureForPlayback(): Boolean = activate(
+        // Proximity routing owns the category while it is on — Playback has no receiver route.
+        if (proximityRouting) AVAudioSessionCategoryPlayAndRecord else AVAudioSessionCategoryPlayback
+    )
 
     fun configureForRecording(): Boolean = activate(AVAudioSessionCategoryRecord)
+
+    // PlayAndRecord is recording-capable, so this is called only once the phone is at the ear —
+    // entering it up front would prompt for the microphone just to play a voice note.
+    fun beginProximityRouting(): Boolean = memScoped {
+        if (proximityRouting) return@memScoped true
+
+        val session = AVAudioSession.sharedInstance()
+        val err = alloc<ObjCObjectVar<NSError?>>()
+        savedCategory = session.category
+        savedMode = session.mode
+
+        session.setCategory(AVAudioSessionCategoryPlayAndRecord, err.ptr)
+        err.value?.let {
+            Logger.e(tag = TAG) { "setCategory(PlayAndRecord) failed: ${it.localizedDescription}" }
+            savedCategory = null
+            savedMode = null
+            return@memScoped false
+        }
+
+        proximityRouting = true
+        true
+    }
+
+    fun routeOutput(toEarpiece: Boolean) = memScoped {
+        if (!proximityRouting) return@memScoped
+        val err = alloc<ObjCObjectVar<NSError?>>()
+        val port =
+            if (toEarpiece) AVAudioSessionPortOverrideNone else AVAudioSessionPortOverrideSpeaker
+        AVAudioSession.sharedInstance().overrideOutputAudioPort(port, err.ptr)
+        err.value?.let {
+            Logger.w(tag = TAG) { "overrideOutputAudioPort failed: ${it.localizedDescription}" }
+        }
+    }
+
+    fun endProximityRouting() = memScoped {
+        if (!proximityRouting) return@memScoped
+        proximityRouting = false
+
+        val session = AVAudioSession.sharedInstance()
+        val err = alloc<ObjCObjectVar<NSError?>>()
+        session.overrideOutputAudioPort(AVAudioSessionPortOverrideNone, err.ptr)
+        err.value = null
+
+        session.setCategory(savedCategory ?: AVAudioSessionCategoryPlayback, err.ptr)
+        err.value?.let {
+            Logger.e(tag = TAG) { "category restore failed: ${it.localizedDescription}" }
+        }
+        err.value = null
+
+        savedMode?.let { mode ->
+            session.setMode(mode, err.ptr)
+            err.value?.let {
+                Logger.w(tag = TAG) { "mode restore failed: ${it.localizedDescription}" }
+            }
+        }
+        savedCategory = null
+        savedMode = null
+    }
 
     /**
      * For callers that only need the route to be output-capable. Deliberately does

--- a/homebase-common/src/nativeMain/kotlin/id/homebase/core/audio/IOSAudioPlayer.kt
+++ b/homebase-common/src/nativeMain/kotlin/id/homebase/core/audio/IOSAudioPlayer.kt
@@ -28,6 +28,7 @@ class IOSAudioPlayer : AudioPlayer {
 
     private var positionJob: Job? = null
     private val scope = CoroutineScope(Dispatchers.IO)
+    private var speed = 1f
 
     @OptIn(ExperimentalForeignApi::class, BetaInteropApi::class)
     override fun play(filePath: String) {
@@ -64,18 +65,28 @@ class IOSAudioPlayer : AudioPlayer {
         }
 
         newPlayer.delegate = delegate
+        newPlayer.enableRate = true
         newPlayer.prepareToPlay()
         newPlayer.play()
+        newPlayer.rate = speed
         player = newPlayer
         startPositionPolling()
     }
 
-    override fun jump(seconds: Int) {
-        player?.currentTime = seconds.toDouble()
+    override fun jumpTo(positionMs: Long) {
+        player?.currentTime = positionMs / 1000.0
     }
 
     override fun resume() {
         player?.play()
+        player?.rate = speed
+    }
+
+    // AVAudioPlayer resets rate to 1 on every play(), so it is reapplied there too.
+    override fun setSpeed(speed: Float) {
+        this.speed = speed.coerceToPlaybackSpeed()
+        val current = player ?: return
+        if (current.playing) current.rate = this.speed
     }
 
     override fun pause() {
@@ -100,12 +111,16 @@ class IOSAudioPlayer : AudioPlayer {
     private fun startPositionPolling() {
         positionJob = scope.launch {
             while (isActive) {
-                val position = player?.currentTime?.toInt() ?: 0
-                val duration = player?.duration?.toInt() ?: 0
+                val position = ((player?.currentTime ?: 0.0) * 1000).toLong()
+                val duration = ((player?.duration ?: 0.0) * 1000).toLong()
                 delegate.observer?.onProgressUpdate(position, duration)
-                delay(500)
+                delay(PROGRESS_INTERVAL_MS)
             }
         }
+    }
+
+    private companion object {
+        const val PROGRESS_INTERVAL_MS = 80L
     }
 
     private class AudioPlayerDelegate : NSObject(), AVAudioPlayerDelegateProtocol {

--- a/homebase-common/src/nativeMain/kotlin/id/homebase/core/audio/ProximityAudioRouter.native.kt
+++ b/homebase-common/src/nativeMain/kotlin/id/homebase/core/audio/ProximityAudioRouter.native.kt
@@ -1,0 +1,61 @@
+package id.homebase.core.audio
+
+import co.touchlab.kermit.Logger
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import platform.Foundation.NSNotificationCenter
+import platform.Foundation.NSOperationQueue
+import platform.UIKit.UIDevice
+import platform.UIKit.UIDeviceProximityStateDidChangeNotification
+import platform.darwin.NSObjectProtocol
+
+actual fun getProximityAudioRouter(): ProximityAudioRouter = IOSProximityAudioRouter
+
+private object IOSProximityAudioRouter : ProximityAudioRouter {
+    private val logger = Logger.withTag("ProximityAudioRouter")
+
+    private val _isNearEar = MutableStateFlow(false)
+    override val isNearEar: StateFlow<Boolean> = _isNearEar.asStateFlow()
+
+    private var observer: NSObjectProtocol? = null
+
+    override fun start() {
+        if (observer != null) return
+
+        val device = UIDevice.currentDevice
+        device.proximityMonitoringEnabled = true
+        // UIKit refuses the flag on hardware without the sensor, so read it back.
+        if (!device.proximityMonitoringEnabled) {
+            logger.d { "No proximity sensor — raise-to-ear disabled" }
+            return
+        }
+
+        observer = NSNotificationCenter.defaultCenter.addObserverForName(
+            name = UIDeviceProximityStateDidChangeNotification,
+            `object` = device,
+            queue = NSOperationQueue.mainQueue,
+            usingBlock = { onProximityChanged() },
+        )
+        onProximityChanged()
+    }
+
+    override fun stop() {
+        val current = observer ?: return
+        observer = null
+        NSNotificationCenter.defaultCenter.removeObserver(current)
+        UIDevice.currentDevice.proximityMonitoringEnabled = false
+        AudioSession.endProximityRouting()
+        _isNearEar.value = false
+    }
+
+    // iOS blanks the screen itself while proximity monitoring is on; only the route is ours.
+    private fun onProximityChanged() {
+        val near = UIDevice.currentDevice.proximityState
+        _isNearEar.value = near
+        // PlayAndRecord is the only category with an earpiece route, and entering it can prompt
+        // for the microphone — so it waits until the phone is actually at the ear.
+        if (near && !AudioSession.beginProximityRouting()) return
+        AudioSession.routeOutput(toEarpiece = near)
+    }
+}

--- a/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/audio/AudioPlayer.web.kt
+++ b/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/audio/AudioPlayer.web.kt
@@ -19,6 +19,7 @@ private class WebAudioPlayer : AudioPlayer {
     private var element: JsAny? = null
     private var objectUrl: String? = null
     private var observer: AudioPlaybackObserver? = null
+    private var speed = 1f
 
     override fun play(filePath: String) {
         teardown()
@@ -33,9 +34,10 @@ private class WebAudioPlayer : AudioPlayer {
         objectUrl = url
 
         val el = createAudioElement(url)
+        setAudioPlaybackRate(el, speed.toDouble())
         addAudioProgressListener(el) { currentSec, durationSec ->
             guardJsCallback("audio.progress") {
-                observer?.onProgressUpdate(currentSec.toWholeSeconds(), durationSec.toWholeSeconds())
+                observer?.onProgressUpdate(currentSec.toMillis(), durationSec.toMillis())
             }
         }
         addAudioEndedListener(el) { guardJsCallback("audio.ended") { observer?.onComplete() } }
@@ -49,9 +51,14 @@ private class WebAudioPlayer : AudioPlayer {
         }
     }
 
-    override fun jump(seconds: Int) {
+    override fun jumpTo(positionMs: Long) {
         val el = element ?: return
-        setAudioCurrentTime(el, seconds.coerceAtLeast(0).toDouble())
+        setAudioCurrentTime(el, positionMs.coerceAtLeast(0) / 1000.0)
+    }
+
+    override fun setSpeed(speed: Float) {
+        this.speed = speed.coerceToPlaybackSpeed()
+        element?.let { setAudioPlaybackRate(it, this.speed.toDouble()) }
     }
 
     override fun resume() {
@@ -94,8 +101,8 @@ private class WebAudioPlayer : AudioPlayer {
 
 // A stream muxed without a duration box reports NaN/Infinity; 0 tells the widget to keep the
 // length it already read off the payload descriptor.
-private fun Double.toWholeSeconds(): Int =
-    if (isFinite() && this > 0.0) toInt() else 0
+private fun Double.toMillis(): Long =
+    if (isFinite() && this > 0.0) (this * 1000).toLong() else 0
 
 private fun audioMimeForPath(path: String): String =
     detectContentTypeFromExtensionOrHint(path).takeIf { it.startsWith("audio/") } ?: "audio/mp4"
@@ -123,6 +130,10 @@ private fun pauseAudioElement(el: JsAny): Unit = js("{ try { el.pause(); } catch
 
 private fun setAudioCurrentTime(el: JsAny, seconds: Double): Unit = js(
     "{ try { el.currentTime = seconds; } catch (e) {} }"
+)
+
+private fun setAudioPlaybackRate(el: JsAny, rate: Double): Unit = js(
+    "{ try { el.playbackRate = rate; } catch (e) {} }"
 )
 
 private fun addAudioProgressListener(el: JsAny, cb: (Double, Double) -> Unit): Unit = js(

--- a/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/audio/ProximityAudioRouter.web.kt
+++ b/homebase-common/src/wasmJsMain/kotlin/id/homebase/core/audio/ProximityAudioRouter.web.kt
@@ -1,0 +1,12 @@
+package id.homebase.core.audio
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+actual fun getProximityAudioRouter(): ProximityAudioRouter = WebProximityAudioRouter
+
+private object WebProximityAudioRouter : ProximityAudioRouter {
+    override val isNearEar: StateFlow<Boolean> = MutableStateFlow(false)
+    override fun start() = Unit
+    override fun stop() = Unit
+}

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/di/AppModule.kt
@@ -93,6 +93,10 @@ import id.homebase.chat.services.convo.contact.ContactService
 import id.homebase.chat.services.outbox.OptimisticWriter
 import id.homebase.chat.services.requests.ConnectionRequestService
 import id.homebase.core.NotificationActionBridge
+import id.homebase.core.audio.DefaultVoiceNotePlayback
+import id.homebase.core.audio.ProximityAudioRouter
+import id.homebase.core.audio.VoiceNotePlayback
+import id.homebase.core.audio.getProximityAudioRouter
 import id.homebase.core.auth.AuthConnectionCoordinator
 import id.homebase.core.util.PlatformInfo
 import id.homebase.core.vault.VaultPreferences
@@ -242,6 +246,11 @@ val LocationPermissionQualifier = named("locationPermission")
 
 val appModule = module {
     single { UserPreferences(get()) }
+
+    single<ProximityAudioRouter> { getProximityAudioRouter() }
+    single<VoiceNotePlayback> {
+        DefaultVoiceNotePlayback(player = get(), proximityRouter = get(), scope = get())
+    }
     single { MomentsPreferences(get()) }
     singleOf(::MomentsPostSenderService)
     // User-state store mirrors DriveRegistry's wiring — narrow lambda deps for


### PR DESCRIPTION
Follow-on to #1520.

## Cause

`AudioPlayerWidget` called `remember { getAudioPlayer() }`, so **every audio bubble constructed its own player** and released it on dispose. Two notes could play simultaneously, playback died when a bubble scrolled out of view, speed had nowhere to live that survived a bubble, and nothing could coordinate the audio session for proximity routing.

## Changes

**`VoiceNotePlayback`** — an app-scoped Koin single owning one `AudioPlayer` and exposing `StateFlow<VoiceNotePlaybackState>`. A bubble renders as playing only when `playingKey` matches its own; starting a note stops whatever else was playing. The `DisposableEffect { stop(); release() }` is gone, so scrolling a playing bubble out of view no longer kills audio. `AudioPlayer` was already registered as a per-platform single in all four `AppModule.<platform>.kt` files but nothing consumed it — the widget bypassed DI entirely.

**`play()` off the main thread.** On Desktop it ran `probeDurationSeconds()` — an `ffprobe` subprocess with `waitFor(10, SECONDS)` — then spawned ffmpeg, synchronously from `onClick`.

**Millisecond progress.** `AudioPlaybackObserver.onProgressUpdate` carried whole seconds, which made the head step once a second — the known limitation documented in #1520. Now milliseconds, sampled every 80ms on JVM/Android/iOS. Interpolating on top of whole seconds was tried in #1520 and reverted: it cannot be made both smooth and monotonic, because `line.microsecondPosition` genuinely reports backwards across a pause or seek. The service emits a monotonic position using Signal's rule — a backwards sample is held at the last value unless four consecutive backwards samples arrive, and a seek re-baselines the counter so a legitimate jump is never swallowed.

`jump(seconds: Int)` became `jumpTo(positionMs: Long)`. Second-granularity seek beside millisecond progress means a four-second voice note can only be scrubbed to four positions.

**Speed 1x/1.5x/2x**, session-scoped, reapplied on every `play()`. `MediaPlayer.playbackParams` on Android (guarded — setting it on a paused player silently resumes), `AVAudioPlayer.rate` with `enableRate` on iOS (reapplied after play/resume, which reset it), `playbackRate` on web, ffmpeg `atempo` on Desktop. Clamped 0.5–2.0 in common so all four actuals agree.

**Proximity routing** (Android `SensorManager` + `PROXIMITY_SCREEN_OFF_WAKE_LOCK` + `AudioManager`; iOS `UIDevice.proximityMonitoringEnabled` + `AVAudioSession`; JVM/web no-ops). Monitoring starts with playback, but the iOS audio category only switches on the near-ear edge: `PlayAndRecord` is recording-capable, so entering it eagerly would prompt for the microphone merely to *play* a voice note. `WAKE_LOCK` added to the manifest; the wake lock is released in a `finally` and a failed `registerListener` calls `stop()`, since a leaked proximity lock keeps the user's screen off.

## Recomposition

`AudioWaveform`'s `progress: () -> Float` is preserved and invoked inside the Canvas draw block, so an 80ms position tick invalidates **draw only**. A separate coarse `map{}.distinctUntilChanged()` projection drives composition, so non-playing bubbles are suppressed entirely and the playing one recomposes once per second, unchanged from before. With a shared service at 80ms, passing a plain `Float` would recompose every visible bubble's row 12x/sec.

## Verification

`JvmAudioPlayerTest` 13 → 23 cases covering millisecond progress, the backwards guard, and `atempo` emission per speed. `VoiceNotePlaybackTest` proves a second `play()` on a different key stops the first. `homebase-common` 651 tests, `homebase-chat` 1412 tests, 0 failures. All four targets compile, plus `:homebase-core:compileKotlinIosSimulatorArm64` — `AppModule.kt` is commonMain and a K/N link break there wouldn't surface in a JVM check.

## Known limitations

- **Changing speed on Desktop has an audible gap.** Tempo is an ffmpeg `atempo` argument fixed at process start, so a change restarts the decoder at the current position. Android and iOS apply speed to the live player with no interruption. Fixable by overlapping the new spawn with continued playback of the old stream; deliberately deferred.
- **Web progress stays chunky** — event-driven off `timeupdate`, which browsers fire ~4Hz. Would need an rAF loop.
- **Speed chip tap target is 40x22dp**, under the 48dp guideline. Enlarging it would either shrink the waveform or make a playing bubble taller than idle ones.
- **Unverified without hardware:** earpiece routing and screen blanking, the iOS mic-prompt deferral, `MediaPlayer.playbackParams` on a real device, and whether `atempo` at 2x sounds acceptable.