### PR TITLE
Show who recorded a voice note in group chats

### DIFF
--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MediaItem.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MediaItem.kt
@@ -64,6 +64,7 @@ import id.homebase.core.image.rememberFullScreenImagePrefetch
 import id.homebase.core.image.thumbSizesFrom
 import id.homebase.core.ui.theme.Dimens
 import id.homebase.core.widget.AudioPlayerWidget
+import id.homebase.core.widget.VoiceNoteSender
 import id.homebase.resources.MR
 import id.homebase.resources.cd_play_video
 import id.homebase.resources.chat_message_image_attachment
@@ -124,6 +125,7 @@ fun MediaItem(
     isDownloading: Boolean = false,
     messageId: Uuid? = null,
     isUploading: Boolean = false,
+    audioSender: VoiceNoteSender? = null,
 ) {
     val contentType = payload.contentType ?: ""
     val imageContentScale = if (preserveAspectRatio) ContentScale.Fit else ContentScale.Crop
@@ -552,6 +554,7 @@ fun MediaItem(
                 audioFile = decryptedFiles[DecryptedFileKey(fileId, payload.key)],
                 payload = payload,
                 onRequestDecryptedFile = onRequestDecryptedFile,
+                sender = audioSender,
             )
         }
 

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MediaMessage.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MediaMessage.kt
@@ -40,6 +40,7 @@ import id.homebase.chat.services.ChatProtocol
 import id.homebase.chat.services.builder.LocationPreviewDescriptor
 import id.homebase.core.image.ImageSize
 import id.homebase.core.ui.theme.Dimens
+import id.homebase.core.widget.VoiceNoteSender
 import id.homebase.resources.MR
 import id.homebase.resources.cd_upload_complete
 import id.homebase.resources.upload_compressing
@@ -123,6 +124,7 @@ fun MediaMessage(
      *  to Signal's 240dp width — the caption can't collapse to char-per-line and the image can't
      *  leave a gap. No effect on stickers, link-preview cards, or galleries. */
     hasCaption: Boolean = false,
+    audioSender: VoiceNoteSender? = null,
 ) {
     if (payloads.isEmpty()) return
 
@@ -238,6 +240,7 @@ fun MediaMessage(
                     isUploading = uploadStatus != null,
                     liveControls = liveControls,
                     locationHeaderDescriptor = locationHeaderDescriptor,
+                    audioSender = audioSender,
                 )
             }
 

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubble.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubble.kt
@@ -360,6 +360,7 @@ fun SentMessageBubble(
                         decryptedFiles = decryptedFiles,
                         liveControls = liveControls,
                         sentByYou = true,
+                        showVoiceNoteSender = true,
                         currentOdinId = currentOdinId,
                         clusterPosition = clusterPosition,
                         onLongClick = {

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubble.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubble.kt
@@ -541,6 +541,8 @@ fun ReceivedMessageBubble(
     val mediaOnly = !message.content.hasContent() && hasMedia
     val emojiOnly = message.content.isEmojiContentOnly() && !hasMedia
     val hasVisibleBackground = !mediaOnly && !emojiOnly
+    val isVoiceNote = mediaOnly &&
+        filteredPayloads.singleOrNull()?.contentType?.startsWith("audio/") == true
     val clipboardManager = LocalClipboard.current
     val scope = rememberCoroutineScope()
     val haptics = rememberHaptics()
@@ -556,8 +558,11 @@ fun ReceivedMessageBubble(
             .padding(top = clusterPosition.topSpacing(), bottom = clusterPosition.bottomSpacing()),
     ) {
         if (isGroupConversation) {
-            val showAvatar = clusterPosition == MessageClusterPosition.ALONE ||
-                clusterPosition == MessageClusterPosition.END
+            // A voice note draws the sender inside its own bubble, so the gutter yields to it
+            // rather than showing the same face twice.
+            val showAvatar = !isVoiceNote &&
+                (clusterPosition == MessageClusterPosition.ALONE ||
+                    clusterPosition == MessageClusterPosition.END)
             Box(
                 modifier = Modifier
                     .align(Alignment.Bottom)
@@ -628,6 +633,7 @@ fun ReceivedMessageBubble(
                             decryptedFiles = decryptedFiles,
                         liveControls = liveControls,
                             sentByYou = false,
+                            showVoiceNoteSender = isGroupConversation,
                             currentOdinId = currentOdinId,
                             clusterPosition = clusterPosition,
                             authorName = if (renderAuthorName && hasVisibleBackground) authorNameTxt

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubble.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubble.kt
@@ -633,7 +633,7 @@ fun ReceivedMessageBubble(
                             decryptedFiles = decryptedFiles,
                         liveControls = liveControls,
                             sentByYou = false,
-                            showVoiceNoteSender = isGroupConversation,
+                            showVoiceNoteSender = true,
                             currentOdinId = currentOdinId,
                             clusterPosition = clusterPosition,
                             authorName = if (renderAuthorName && hasVisibleBackground) authorNameTxt

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubbleRaw.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubbleRaw.kt
@@ -88,6 +88,7 @@ import id.homebase.core.util.ifTrue
 import id.homebase.core.util.isEmojiContentOnly
 import id.homebase.core.util.isMobile
 import id.homebase.core.util.stripComposerLineBreakArtifacts
+import id.homebase.core.widget.VoiceNoteSender
 import id.homebase.resources.MR
 import id.homebase.resources.chat_message_deleted
 import id.homebase.resources.chat_message_edited
@@ -175,7 +176,15 @@ fun MessageBubbleRaw(
     // Rendered as a preview of a message (action-menu header, message info, reply quote) rather
     // than as the message itself: typed bubbles must not open their full-screen detail from here.
     displayOnly: Boolean = false,
+    showVoiceNoteSender: Boolean = false,
 ) {
+    val voiceNoteSender = remember(
+        showVoiceNoteSender, sentByYou, message.originalAuthor, message.displayName,
+    ) {
+        message.originalAuthor
+            ?.takeIf { showVoiceNoteSender && !sentByYou }
+            ?.let { VoiceNoteSender(it, message.displayName) }
+    }
 
     // #814: render the timestamp + delivery footer only on the last bubble of a
     // same-sender cluster (END/ALONE), or whenever a sent message failed to deliver.
@@ -602,6 +611,7 @@ fun MessageBubbleRaw(
                         messageId = message.id,
                         downloadingFiles = downloadingFiles,
                         uploadStatus = uploadStatus,
+                        audioSender = voiceNoteSender,
                     )
                     MediaTimestampOverlay(
                         showTimestamp = showMessageFooter,
@@ -643,6 +653,7 @@ fun MessageBubbleRaw(
                                 messageId = message.id,
                                 downloadingFiles = downloadingFiles,
                                 uploadStatus = uploadStatus,
+                                audioSender = voiceNoteSender,
                             )
                             MediaTimestampOverlay(
                                 showTimestamp = showMessageFooter,
@@ -735,6 +746,7 @@ fun MessageBubbleRaw(
                                 uploadStatus = uploadStatus,
                                 fillWidth = true,
                                 hasCaption = true,
+                                audioSender = voiceNoteSender,
                             )
                         }
                     }
@@ -851,6 +863,7 @@ fun MessageBubbleRaw(
                                         // Floors a narrow single image to 240dp so the caption
                                         // clamp below can't collapse it to one char per line.
                                         hasCaption = true,
+                                        audioSender = voiceNoteSender,
                                     )
                                 }
                             }

--- a/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubbleRaw.kt
+++ b/homebase-chat/src/commonMain/kotlin/id/homebase/chat/widget/MessageBubbleRaw.kt
@@ -62,6 +62,7 @@ import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import id.homebase.api.client.KeyHeader
+import id.homebase.api.common.OdinId
 import id.homebase.api.client.drives.files.DescriptorContent
 import id.homebase.api.client.drives.files.PayloadDescriptor
 import id.homebase.api.util.markdownHasBlockElements
@@ -179,11 +180,15 @@ fun MessageBubbleRaw(
     showVoiceNoteSender: Boolean = false,
 ) {
     val voiceNoteSender = remember(
-        showVoiceNoteSender, sentByYou, message.originalAuthor, message.displayName,
+        showVoiceNoteSender, sentByYou, message.originalAuthor, message.displayName, currentOdinId,
     ) {
-        message.originalAuthor
-            ?.takeIf { showVoiceNoteSender && !sentByYou }
-            ?.let { VoiceNoteSender(it, message.displayName) }
+        // An outgoing message carries no originalAuthor, so fall back to the signed-in identity.
+        // OdinId(String) validates the domain and throws, and currentOdinId defaults to blank.
+        val odinId = message.originalAuthor
+            ?: currentOdinId.takeIf { sentByYou && it.isNotBlank() }?.let { OdinId(it) }
+        odinId
+            ?.takeIf { showVoiceNoteSender }
+            ?.let { VoiceNoteSender(it, message.displayName, isYou = sentByYou) }
     }
 
     // #814: render the timestamp + delivery footer only on the last bubble of a

--- a/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/widget/BubbleLayoutInvariantTest.kt
+++ b/homebase-chat/src/jvmTest/kotlin/id/homebase/chat/widget/BubbleLayoutInvariantTest.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.ComposeUiTest
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.getUnclippedBoundsInRoot
+import androidx.compose.ui.test.onAllNodesWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.runComposeUiTest
@@ -229,6 +230,7 @@ class BubbleLayoutInvariantTest {
         cluster: MessageClusterPosition = MessageClusterPosition.ALONE,
         quoted: MessageUiModel? = null,
         width: Dp = columnWidth,
+        showVoiceNoteSender: Boolean = false,
     ) = setContent {
         Host(width) {
             MessageBubbleRaw(
@@ -244,6 +246,7 @@ class BubbleLayoutInvariantTest {
                 downloadingFiles = emptySet(),
                 authorName = authorName,
                 clusterPosition = cluster,
+                showVoiceNoteSender = showVoiceNoteSender,
             )
         }
     }
@@ -255,6 +258,11 @@ class BubbleLayoutInvariantTest {
     private fun ComposeUiTest.quoteTextBounds(): DpRect =
         onNodeWithTag(ChatBubbleTestTags.REPLY_QUOTE_TEXT, useUnmergedTree = true)
             .getUnclippedBoundsInRoot()
+
+    // The label AudioPlayerWidget stamps on the sender avatar, so the geometry assertions
+    // below can't pass vacuously on a bubble that never drew one.
+    private fun ComposeUiTest.avatarExists(): Boolean =
+        onAllNodesWithContentDescription("Voice note from Alice").fetchSemanticsNodes().size == 1
 
     private fun ComposeUiTest.exists(tag: String): Boolean =
         onNodeWithTag(tag).let { runCatching { it.getUnclippedBoundsInRoot() }.isSuccess }
@@ -717,6 +725,65 @@ class BubbleLayoutInvariantTest {
                     "bubble.right=${bubble.right.value} > ${phoneWidth.value}"
         }
         assertTrue(failures.isEmpty(), "voice-note phone-width failures:\n" + failures.joinToString("\n"))
+    }
+
+    /**
+     * The group sender avatar rides inside the voice-note bubble ahead of the play button. It
+     * must buy its width out of the waveform, never out of the bubble: the desktop cap still
+     * binds and the row is no taller than without it (the 28dp avatar fits inside the 40dp
+     * waveform band the duration column already sits in).
+     */
+    @Test
+    fun voiceNote_senderAvatarKeepsCapAndHeight() = runComposeUiTest {
+        val cap = Dimens.MediaBubble.audioMaxWidth.value
+        val failures = mutableListOf<String>()
+        val case = Case("audio/recv", sent = false, images = 0, caption = Caption.NONE, audio = true)
+
+        for (width in listOf(desktopWidth, phoneWidth)) {
+            render(case, width = width)
+            val plain = boundsOf(ChatBubbleTestTags.MEDIA)
+            val plainWidth = plain.right.value - plain.left.value
+            val plainHeight = plain.bottom.value - plain.top.value
+            if (avatarExists()) failures += "[at ${width.value}dp] an avatar was drawn without the flag"
+
+            render(case, width = width, showVoiceNoteSender = true)
+            if (!avatarExists()) failures += "[at ${width.value}dp] the sender avatar was not drawn"
+            val withAvatar = boundsOf(ChatBubbleTestTags.MEDIA)
+            val bubble = boundsOf(ChatBubbleTestTags.BUBBLE)
+            val avatarWidth = withAvatar.right.value - withAvatar.left.value
+            val avatarHeight = withAvatar.bottom.value - withAvatar.top.value
+
+            val at = "at ${width.value}dp"
+            if (avatarWidth > cap + tol)
+                failures += "[$at] voice note with a sender avatar is ${avatarWidth}dp, cap is ${cap}dp"
+            if (bubble.right.value - bubble.left.value > cap + tol)
+                failures += "[$at] bubble behind the avatared voice note is " +
+                    "${bubble.right.value - bubble.left.value}dp, cap is ${cap}dp"
+            if (!approx(avatarWidth, plainWidth))
+                failures += "[$at] the avatar changed the bubble width: " +
+                    "${plainWidth}dp -> ${avatarWidth}dp"
+            if (!approx(avatarHeight, plainHeight))
+                failures += "[$at] the avatar changed the bubble height: " +
+                    "${plainHeight}dp -> ${avatarHeight}dp"
+        }
+
+        // A note you sent has no originalAuthor, so the flag alone must not draw anything.
+        val sentCase = Case("audio/sent", sent = true, images = 0, caption = Caption.NONE, audio = true)
+        render(sentCase, width = desktopWidth)
+        val sentPlain = boundsOf(ChatBubbleTestTags.MEDIA)
+        render(sentCase, width = desktopWidth, showVoiceNoteSender = true)
+        val sentFlagged = boundsOf(ChatBubbleTestTags.MEDIA)
+        if (!approx(
+                sentFlagged.bottom.value - sentFlagged.top.value,
+                sentPlain.bottom.value - sentPlain.top.value,
+            )
+        )
+            failures += "[sent] the flag altered an outgoing voice note"
+
+        assertTrue(
+            failures.isEmpty(),
+            "voice-note sender-avatar failures:\n" + failures.joinToString("\n"),
+        )
     }
 
     /**

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -1525,6 +1525,7 @@
     <string name="audio_speed_2x">2x</string>
     <string name="audio_play">Play</string>
     <string name="audio_sender_avatar">Voice note from %1$s</string>
+    <string name="audio_sender_avatar_you">Voice note from you</string>
 
     <!-- Bottom navigation -->
     <string name="nav_chats">Chats</string>

--- a/homebase-common/src/commonMain/composeResources/values/strings.xml
+++ b/homebase-common/src/commonMain/composeResources/values/strings.xml
@@ -1524,6 +1524,7 @@
     <string name="audio_speed_1_5x">1.5x</string>
     <string name="audio_speed_2x">2x</string>
     <string name="audio_play">Play</string>
+    <string name="audio_sender_avatar">Voice note from %1$s</string>
 
     <!-- Bottom navigation -->
     <string name="nav_chats">Chats</string>

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/audio/WaveformRaster.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/audio/WaveformRaster.kt
@@ -16,9 +16,9 @@ import id.homebase.core.image.HomebaseImageData
 import id.homebase.core.image.HomebaseImageLoader
 import id.homebase.core.image.ImageSize
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
+import kotlinx.atomicfu.locks.SynchronizedObject
+import kotlinx.atomicfu.locks.synchronized
 import org.jetbrains.compose.resources.decodeToImageBitmap
 import org.koin.compose.koinInject
 import kotlin.io.encoding.Base64
@@ -69,13 +69,16 @@ fun ImageBitmap.toWaveformAmplitudes(
 }
 
 private val waveformCache = LinkedHashMap<String, FloatArray>()
-private val waveformCacheLock = Mutex()
 
-private suspend fun cachedWaveform(key: String): FloatArray? =
-    waveformCacheLock.withLock { waveformCache[key] }
+// Read during composition so a bubble scrolling back into view has its bars on the first
+// frame; a suspending read costs a frame of placeholder and restarts the grow-in animation.
+private val waveformCacheLock = SynchronizedObject()
 
-private suspend fun storeWaveform(key: String, value: FloatArray) {
-    waveformCacheLock.withLock {
+private fun cachedWaveform(key: String): FloatArray? =
+    synchronized(waveformCacheLock) { waveformCache[key] }
+
+private fun storeWaveform(key: String, value: FloatArray) {
+    synchronized(waveformCacheLock) {
         waveformCache.remove(key)
         waveformCache[key] = value
         while (waveformCache.size > MAX_CACHED_WAVEFORMS) {
@@ -95,15 +98,11 @@ fun rememberWaveformAmplitudes(
     keyHeader: KeyHeader,
 ): FloatArray? {
     val imageLoader: HomebaseImageLoader = koinInject()
-    var amplitudes by remember(fileId, payload.key) { mutableStateOf<FloatArray?>(null) }
+    val cacheKey = remember(fileId, payload.key) { "$fileId-${payload.key}" }
+    var amplitudes by remember(cacheKey) { mutableStateOf(cachedWaveform(cacheKey)) }
 
-    LaunchedEffect(fileId, payload.key, thumbnail.pixelWidth, thumbnail.pixelHeight) {
-        val cacheKey = "$fileId-${payload.key}"
-        val hit = cachedWaveform(cacheKey)
-        if (hit != null) {
-            amplitudes = hit
-            return@LaunchedEffect
-        }
+    LaunchedEffect(cacheKey, thumbnail.pixelWidth, thumbnail.pixelHeight) {
+        if (amplitudes != null) return@LaunchedEffect
 
         val decoded = withContext(Dispatchers.Default) {
             runCatching {

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/widget/AudioPlayerWidget.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/widget/AudioPlayerWidget.kt
@@ -51,6 +51,7 @@ import id.homebase.resources.MR
 import id.homebase.resources.audio_pause
 import id.homebase.resources.audio_play
 import id.homebase.resources.audio_sender_avatar
+import id.homebase.resources.audio_sender_avatar_you
 import id.homebase.resources.audio_speed
 import id.homebase.resources.audio_speed_1_5x
 import id.homebase.resources.audio_speed_1x
@@ -73,7 +74,11 @@ private val SenderAvatarOptions = AvatarOptions(size = Dimens.Message.senderAvat
 private val SENDER_AVATAR_GAP = 8.dp
 
 @Immutable
-data class VoiceNoteSender(val odinId: OdinId, val displayName: String)
+data class VoiceNoteSender(
+    val odinId: OdinId,
+    val displayName: String,
+    val isYou: Boolean = false,
+)
 
 @Immutable
 private data class VoiceNoteBubbleState(
@@ -169,7 +174,11 @@ fun AudioPlayerWidget(
     ) {
         if (sender != null) {
             val senderInitials = remember(sender.displayName) { sender.displayName.initials() }
-            val senderLabel = stringResource(MR.string.audio_sender_avatar, sender.displayName)
+            val senderLabel = if (sender.isYou) {
+                stringResource(MR.string.audio_sender_avatar_you)
+            } else {
+                stringResource(MR.string.audio_sender_avatar, sender.displayName)
+            }
             // PublicAvatar hard-codes a generic description; clearAndSetSemantics replaces the
             // whole subtree's so a screen reader names the person instead.
             Box(modifier = Modifier.clearAndSetSemantics { contentDescription = senderLabel }) {

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/widget/AudioPlayerWidget.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/widget/AudioPlayerWidget.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Pause
 import androidx.compose.material.icons.filled.PlayArrow
@@ -69,7 +68,10 @@ private const val MIN_WAVEFORM_RASTER_WIDTH = 320
 
 private val PLAYBACK_SPEEDS = floatArrayOf(1f, 1.5f, 2f)
 
-private val SenderAvatarOptions = AvatarOptions(size = Dimens.Message.senderAvatarSize)
+// The avatar is the row's only filled circle: a solid primary play disc beside it made the
+// face read as subordinate, so the play control is a flat glyph and the avatar carries the mass.
+private val SENDER_AVATAR_SIZE = 36.dp
+private val SenderAvatarOptions = AvatarOptions(size = SENDER_AVATAR_SIZE)
 
 private val SENDER_AVATAR_GAP = 8.dp
 
@@ -206,15 +208,13 @@ fun AudioPlayerWidget(
                 }
             },
             enabled = (audioFile != null || !fileRequested) && onRequestDecryptedFile != null,
-            modifier = Modifier
-                .size(36.dp)
-                .background(MaterialTheme.colorScheme.primary, CircleShape),
+            modifier = Modifier.size(32.dp),
         ) {
             if (isLoading && audioFile == null) {
                 CircularProgressIndicator(
                     modifier = Modifier.size(20.dp),
                     strokeWidth = 2.dp,
-                    color = MaterialTheme.colorScheme.onPrimary,
+                    color = MaterialTheme.colorScheme.primary,
                 )
             } else {
                 Icon(
@@ -224,13 +224,13 @@ fun AudioPlayerWidget(
                     } else {
                         stringResource(MR.string.audio_play)
                     },
-                    modifier = Modifier.size(24.dp),
-                    tint = MaterialTheme.colorScheme.onPrimary,
+                    modifier = Modifier.size(26.dp),
+                    tint = MaterialTheme.colorScheme.primary,
                 )
             }
         }
 
-        Spacer(modifier = Modifier.width(12.dp))
+        Spacer(modifier = Modifier.width(8.dp))
 
         AudioWaveform(
             amplitudes = amplitudes,
@@ -253,8 +253,14 @@ fun AudioPlayerWidget(
             modifier = Modifier.widthIn(min = 40.dp),
         ) {
             Text(
+                // Counts down while playing, like Signal: what is left to listen to is the
+                // useful number mid-note, and it lands back on the full length when it ends.
                 text = formatAudioTime(
-                    if (bubble.elapsedSeconds > 0) bubble.elapsedSeconds else totalSeconds
+                    if (bubble.isCurrent && bubble.elapsedSeconds > 0) {
+                        (totalSeconds - bubble.elapsedSeconds).coerceAtLeast(0)
+                    } else {
+                        totalSeconds
+                    }
                 ),
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/widget/AudioPlayerWidget.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/widget/AudioPlayerWidget.kt
@@ -32,6 +32,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
@@ -39,12 +40,17 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import id.homebase.api.client.KeyHeader
 import id.homebase.api.client.drives.files.DescriptorContent
 import id.homebase.api.client.drives.files.PayloadDescriptor
+import id.homebase.api.common.OdinId
 import id.homebase.core.audio.VoiceNotePlayback
 import id.homebase.core.audio.rememberWaveformAmplitudes
+import id.homebase.core.avatars.AvatarOptions
+import id.homebase.core.avatars.PublicAvatar
 import id.homebase.core.ui.theme.Dimens
+import id.homebase.core.util.initials
 import id.homebase.resources.MR
 import id.homebase.resources.audio_pause
 import id.homebase.resources.audio_play
+import id.homebase.resources.audio_sender_avatar
 import id.homebase.resources.audio_speed
 import id.homebase.resources.audio_speed_1_5x
 import id.homebase.resources.audio_speed_1x
@@ -61,6 +67,13 @@ import kotlin.uuid.Uuid
 private const val MIN_WAVEFORM_RASTER_WIDTH = 320
 
 private val PLAYBACK_SPEEDS = floatArrayOf(1f, 1.5f, 2f)
+
+private val SenderAvatarOptions = AvatarOptions(size = Dimens.Message.senderAvatarSize)
+
+private val SENDER_AVATAR_GAP = 8.dp
+
+@Immutable
+data class VoiceNoteSender(val odinId: OdinId, val displayName: String)
 
 @Immutable
 private data class VoiceNoteBubbleState(
@@ -81,6 +94,7 @@ fun AudioPlayerWidget(
     audioFile: String?,
     payload: PayloadDescriptor,
     onRequestDecryptedFile: (() -> Unit)? = null,
+    sender: VoiceNoteSender? = null,
 ) {
     val playback: VoiceNotePlayback = koinInject()
     val coroutineScope = rememberCoroutineScope()
@@ -153,6 +167,21 @@ fun AudioPlayerWidget(
             .background(MaterialTheme.colorScheme.surfaceContainerHigh)
             .padding(horizontal = 12.dp, vertical = 12.dp)
     ) {
+        if (sender != null) {
+            val senderInitials = remember(sender.displayName) { sender.displayName.initials() }
+            val senderLabel = stringResource(MR.string.audio_sender_avatar, sender.displayName)
+            // PublicAvatar hard-codes a generic description; clearAndSetSemantics replaces the
+            // whole subtree's so a screen reader names the person instead.
+            Box(modifier = Modifier.clearAndSetSemantics { contentDescription = senderLabel }) {
+                PublicAvatar(
+                    odinId = sender.odinId,
+                    initials = senderInitials,
+                    options = SenderAvatarOptions,
+                )
+            }
+            Spacer(modifier = Modifier.width(SENDER_AVATAR_GAP))
+        }
+
         IconButton(
             onClick = {
                 if (audioFile == null && !fileRequested) {

--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/widget/AudioWaveform.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/widget/AudioWaveform.kt
@@ -74,10 +74,15 @@ fun AudioWaveform(
     val grow = remember { Animatable(0f) }
     var dragProgress by remember { mutableStateOf<Float?>(null) }
 
+    // The bars grow in when the waveform first arrives, never when a bubble is recycled back
+    // into view: a LazyColumn disposes it on scroll, so without this the animation replays.
+    val hadBarsOnFirstFrame = remember { amplitudes != null }
+
     LaunchedEffect(amplitudes) {
-        grow.snapTo(0f)
-        if (amplitudes != null) {
-            grow.animateTo(
+        when {
+            amplitudes == null -> grow.snapTo(0f)
+            hadBarsOnFirstFrame -> grow.snapTo(1f)
+            else -> grow.animateTo(
                 targetValue = 1f,
                 animationSpec = tween(WaveformGeometry.totalGrowMs, easing = LinearEasing),
             )


### PR DESCRIPTION
Stacked on #1521 — review that first; this PR's diff is only the avatar.

## Cause

Received voice notes now always show who recorded them. In a group, a cluster of voice notes from the same person identified them only at the ends. `ReceivedMessageBubble` renders the 28dp gutter avatar at `MessageClusterPosition.ALONE`/`END`, and `ConversationContent.kt` sets `renderAuthorName` at `ALONE`/`START`. So three consecutive voice notes from Alice read: **name** / *nothing* / **avatar** — the middle one carried no attribution at all.

## Changes

The avatar moves into the bubble for received voice notes in groups, and the gutter stops drawing one for those rows, so no message ever shows two 28dp circles of the same face diagonally adjacent. Identity becomes per-note instead of per-cluster.

1:1 conversations show it too, so a voice note looks the same wherever it appears. The gutter avatar only renders for groups, so there is nothing to collide with in a 1:1 and it is purely additive there. Outgoing notes get nothing either; `MessageBubbleRaw` gates on `!sentByYou` *and* a non-null `originalAuthor`, so your own bubble is byte-identical with the flag on. That matches `SentMessageBubble`, which draws no avatar anywhere.

Reuses the existing `PublicAvatar` + `AvatarOptions(size = Dimens.Message.senderAvatarSize)` — no new component or image path. `contentDescription` needed a new `audio_sender_avatar` ("Voice note from %1$s") applied via `clearAndSetSemantics`, because `PublicAvatar` hard-codes a generic "Public avatar" and a plain wrapper would not name the person.

## Cost to the waveform — measured, not estimated

| bubble | waveform before | after | bars (46 max) |
|---|---|---|---|
| 320dp (cap) | 196dp | 160dp | 46 → **46, none lost** |
| 240dp (`audioMinWidth`) | 116dp | 80dp | 33 → 23 |

160dp is exactly `46 x 2.5 + 45 x 1` — the narrowest width that still fits all 46 bars. **8dp is therefore the largest gap that costs nothing at the cap**; 9dp would start dropping bars, which is why the gap is tighter than the 12dp used elsewhere in the row. A 360dp phone in a group lands at ~296dp bubble → 136dp waveform → 39 of 46 bars.

Rejected placements: overlapping the avatar under the play circle (halves the cost but shows half a face at 28dp and muddies the primary touch target); replacing the play circle's fill with the avatar (free, but destroys the play affordance); a mic-badge micro-avatar (illegible as a face).

## Call sites

Only the chat bubble supplies a sender. `ConversationMediaScreen`'s audio tab already prints `senderName · date` above every widget, and `MomentMediaItem` has the author in the post header — a third copy in either would be noise. The parameter is optional and defaulted, so both stay valid unchanged.

## Verification

`voiceNote_senderAvatarKeepsCapAndHeight` asserts the 320dp cap still binds at desktop and phone widths, that bubble width *and* height are unchanged versus the no-avatar render, and that an outgoing note is unaffected by the flag. It carries a vacuity guard — `avatarExists()` must be false without the flag and true with it — since otherwise the equality assertions would pass trivially on a bubble that never drew an avatar. `BubbleLayoutInvariantTest` 15 cases, 0 failures. All four targets compile; `homebase-common` and `homebase-chat` jvmTest green, including the Konsist string check.

Rendered at 240/320dp in light and dark across photo, initials-fallback and no-avatar states, with Coil stubbed so the fallback and photo states are deterministic rather than a stuck spinner.

## Known limitations

- **The initials fallback is weak in light theme.** `secondaryContainer` sits almost on top of the bubble's `surfaceContainerHigh`, so the disc nearly dissolves into the bubble. Dark theme is fine. Not a regression — the gutter avatar has the same problem against `surface` — and matching the gutter is why it was left alone, but `AvatarOptions` exposes `containerColor`/`contentColor` if the fallback matters.
- **240dp is the case that pays.** 23 bars still reads as a waveform but is noticeably stubby. It only bites when the bubble is squeezed to `audioMinWidth`.
- **The new information is narrower than it looks.** At cluster head and tail the group already identified the sender, so what is genuinely added is mid-cluster attribution; the rest is a relocation.
