### PR TITLE
Hide the Email icon on a host that does not run mail

### DIFF
--- a/homebase-common/src/commonMain/kotlin/id/homebase/core/email/EmailPreferences.kt
+++ b/homebase-common/src/commonMain/kotlin/id/homebase/core/email/EmailPreferences.kt
@@ -31,6 +31,17 @@ class EmailPreferences(
     private val _biometricsEnabled = MutableStateFlow(readBoolean(BIOMETRICS_KEY, default = true))
     val biometricsEnabled: StateFlow<Boolean> = _biometricsEnabled.asStateFlow()
 
+    /**
+     * The last answer this host gave to "do you run mail at all" — null until one has been heard.
+     *
+     * Cached so the toolbar can decide on the first frame. The status call itself runs on every
+     * launch regardless (EmailViewModel asks as soon as credentials exist), so this saves no
+     * request; what it saves is an icon that pops in a second late, or worse, pops in and then
+     * vanishes on a host without mail.
+     */
+    private val _serverSupportsMail = MutableStateFlow(readBooleanOrNull(SERVER_SUPPORTS_MAIL_KEY))
+    val serverSupportsMail: StateFlow<Boolean?> = _serverSupportsMail.asStateFlow()
+
     // In-memory biometric session tracking — not persisted, resets on app restart.
     private var lastAuthTimeMs: Long = 0L
     private var lastBackgroundTimeMs: Long = 0L
@@ -46,6 +57,7 @@ class EmailPreferences(
     fun reset() {
         _iconVisible.value = readBoolean(ICON_VISIBLE_KEY, default = true)
         _biometricsEnabled.value = readBoolean(BIOMETRICS_KEY, default = true)
+        _serverSupportsMail.value = readBooleanOrNull(SERVER_SUPPORTS_MAIL_KEY)
         lastAuthTimeMs = 0L
         lastBackgroundTimeMs = 0L
         lastActionTimeMs = 0L
@@ -92,6 +104,20 @@ class EmailPreferences(
         _biometricsEnabled.value = value
     }
 
+    suspend fun setServerSupportsMail(value: Boolean) {
+        if (_serverSupportsMail.value == value) return
+        keyValue.upsertValue(SERVER_SUPPORTS_MAIL_KEY, encode(value))
+        _serverSupportsMail.value = value
+    }
+
+    /** Null means "never asked", which is not the same answer as "no". */
+    private fun readBooleanOrNull(key: Uuid): Boolean? {
+        val bytes: ByteArray = runCatching {
+            keyValue.selectByKeyBootstrapSync(key) { _, data -> data }
+        }.getOrNull() ?: return null
+        return if (bytes.isEmpty()) null else bytes[0].toInt() != 0
+    }
+
     private fun readBoolean(key: Uuid, default: Boolean): Boolean {
         // Bootstrap-only sync read — seeds the StateFlow at construction. See
         // KeyValueWrapper.selectByKeyBootstrapSync (commonMain has no runBlocking on wasmJs).
@@ -110,6 +136,7 @@ class EmailPreferences(
         // Thunderbird is the only client we support — so both stay unused.
         val ICON_VISIBLE_KEY: Uuid = Uuid.parse("00000000-0000-0000-0000-0000000a0702")
         val BIOMETRICS_KEY: Uuid = Uuid.parse("00000000-0000-0000-0000-0000000a0703")
+        val SERVER_SUPPORTS_MAIL_KEY: Uuid = Uuid.parse("00000000-0000-0000-0000-0000000a0705")
 
         private const val AUTH_SESSION_DURATION_MS = 5 * 60 * 1000L  // 5 minutes
         private const val BACKGROUND_THRESHOLD_MS = 30 * 1000L       // 30 seconds

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/navigation/AppNavHost.kt
@@ -303,6 +303,9 @@ fun AppNavHost(
     val contactBookViewModel: ContactBookViewModel = koinViewModel()
     val emailPreferences = koinInject<EmailPreferences>()
     val emailIconVisible by emailPreferences.iconVisible.collectAsStateWithLifecycle()
+    // Null until this host has answered once: no icon rather than one that leads to "no email
+    // here". Hosts that do run mail cache a yes and get the icon on the first frame after that.
+    val serverSupportsMail by emailPreferences.serverSupportsMail.collectAsStateWithLifecycle()
     val emailViewModel: EmailViewModel = koinViewModel()
     val emailUiState by emailViewModel.uiState.collectAsStateWithLifecycle()
     val emailUnreadCount = emailUiState.mailboxStatus
@@ -314,6 +317,7 @@ fun AppNavHost(
         locationIconVisible,
         contactBookIconVisible,
         emailIconVisible,
+        serverSupportsMail,
     ) {
         buildList {
             add(TopLevelRoute.Chat)
@@ -322,7 +326,7 @@ fun AppNavHost(
             if (vaultIconVisible) add(TopLevelRoute.Vault)
             if (locationIconVisible) add(TopLevelRoute.Location)
             if (contactBookIconVisible) add(TopLevelRoute.ContactBook)
-            if (emailIconVisible) add(TopLevelRoute.Email)
+            if (emailIconVisible && serverSupportsMail == true) add(TopLevelRoute.Email)
             add(TopLevelRoute.Home)
         }
     }

--- a/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/email/EmailViewModel.kt
+++ b/homebase-core/src/commonMain/kotlin/id/homebase/core/ui/screens/email/EmailViewModel.kt
@@ -196,6 +196,8 @@ class EmailViewModel(
             try {
                 val status = mailProvider.getStatus()
                 _uiState.update { it.copy(serverStatus = status, isCheckingServer = false) }
+                // Remembered for the toolbar, which has to decide before this call can finish.
+                emailPreferences.setServerSupportsMail(status.tenantMailEnabled)
 
                 // Only once email is actually on: before that there is no mailbox to ask about,
                 // and a failure here must not make the whole screen look broken.


### PR DESCRIPTION
Stacked on #1524 (which removes the developer-menu gate) — until that merges, the comparison here also shows its commits.

## Why

Ungating Email put its icon in front of every user, `iconVisible` defaulting to true. On a host that answers `tenantMailEnabled=false`, the only thing behind that icon is a screen saying "no email here".

## What

The icon waits for the host's answer, and the answer is cached in `EmailPreferences` (slot `0a0705`, tri-state).

**This adds no network cost.** `EmailViewModel` is constructed at composition and calls `refreshStatus()` as soon as credentials exist, so `GET /api/v2/mail/status` already runs on every app open — uncached. This commit reads a result that was previously discarded.

What the cache buys is timing: the toolbar can decide on the first frame instead of a second in, and a mail-less host never flashes an icon that then vanishes.

`null` is deliberately not `false` — a host that has never answered (fresh install, or a launch with no network) shows no icon rather than being written off as mail-less forever. The next successful status call settles it.

Settings keeps its Email row unconditionally: that is where the icon gets turned off again once a host does have mail, so it must not depend on the same answer.

## Verification

- `:homebase-common` and `:homebase-core` compile on JVM, Android and wasmJs; `:homebase-core:jvmTest` and `:homebase-common:jvmTest` pass.
- Not device-verified: the paths that matter are a host with mail (icon from the first frame after the first launch) and one without (never), and I cannot reach a mail-less host from here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KdbXXKj2hZDne6UD36gf9A